### PR TITLE
feat: Rayon-based parallelization with double-fusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ publish = false
 num-traits = "0.2"
 num-complex = "0.4"
 thiserror = "1.0"
+rayon = { version = "1.10", optional = true }
+
+[features]
+default = []
+parallel = ["rayon"]
 
 [dev-dependencies]
 criterion = "0.5"
@@ -25,3 +30,8 @@ bench = false
 [[bench]]
 name = "rust_compare"
 harness = false
+
+[[bench]]
+name = "threaded_compare"
+harness = false
+required-features = ["parallel"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This crate is a port of Julia's [Strided.jl](https://github.com/Jutho/Strided.jl
 - **Lazy element operations** (conjugate, transpose, adjoint) with type-level composition
 - **Zero-copy transformations**: permuting, transposing, broadcasting
 - **Cache-optimized iteration** with automatic blocking and loop reordering
+- **Optional multi-threading** via Rayon (`parallel` feature) with recursive dimension splitting
 
 ## Installation
 
@@ -124,23 +125,51 @@ The library automatically optimizes iteration order for cache efficiency:
 3. **Tiled Iteration**: Operations are blocked to fit in L1 cache (32KB)
 4. **Contiguous Fast Paths**: Contiguous arrays bypass blocking for direct iteration
 
+## Parallel Feature
+
+Enable Rayon-based multi-threading with the `parallel` feature:
+
+```toml
+[dependencies]
+strided-rs = { path = "../strided-rs", features = ["parallel"] }
+```
+
+When enabled, `map_into`, `zip_map*_into`, `reduce`, and all high-level ops
+(`copy_into`, `add`, `sum`, `dot`, etc.) automatically parallelize when the
+total element count exceeds 32768. The implementation faithfully ports Julia
+Strided.jl's `_mapreduce_threaded!` recursive dimension-splitting strategy via
+`rayon::join`, with an additional **double-fusion pass** (fuse → order →
+fuse-again → block) that enables threading for any memory layout, not just
+column-major.
+
 ## Benchmarks
 
-Run the Rust benchmark runner:
+Run all benchmarks (single-threaded + multi-threaded, Rust + Julia):
 
 ```bash
+bash benches/run_all.sh        # default thread counts: 1 2 4
+bash benches/run_all.sh 1 2 4 8  # custom thread counts
+```
+
+Or individually:
+
+```bash
+# Single-threaded Rust
 cargo bench --bench rust_compare
-```
 
-Run the Julia comparison script:
-
-```bash
+# Single-threaded Julia
 JULIA_NUM_THREADS=1 julia --project=. benches/julia_compare.jl
+
+# Multi-threaded Rust (N threads)
+RAYON_NUM_THREADS=N cargo bench --features parallel --bench threaded_compare
+
+# Multi-threaded comparison script
+bash benches/run_threaded.sh 1 2 4
 ```
 
-### Benchmark Results (2026-01-29)
+### Single-Threaded Results
 
-Environment: Apple Silicon M2, single-threaded (`JULIA_NUM_THREADS=1`).
+Environment: Apple Silicon M2, single-threaded.
 
 | Case | Julia Strided (ms) | Rust strided (ms) | Rust naive (ms) |
 |---|---:|---:|---:|
@@ -154,6 +183,20 @@ Environment: Apple Silicon M2, single-threaded (`JULIA_NUM_THREADS=1`).
 Notes:
 - Julia results from `benches/julia_compare.jl` using BenchmarkTools (mean time). Rust results from `benches/rust_compare.rs`.
 - The Rust naive baseline uses `StridedView::get`/`StridedArray::set` per-element indexing with bounds checks.
+
+### Multi-Threaded Scaling (Rust, `parallel` feature)
+
+Environment: Apple Silicon M2 (4 performance + 4 efficiency cores).
+
+| Case | 1T (ms) | 2T (ms) | 4T (ms) | Speedup (4T) |
+|---|---:|---:|---:|---:|
+| symmetrize_4000 | 42.2 | 23.3 | 16.4 | 2.6x |
+| scale_transpose_1000 | 1.8 | 1.8 | 0.5 | 3.9x |
+| mwe_scale_transpose_1000 | 1.4 | 2.4 | 0.5 | 2.6x |
+| complex_elementwise_1000 | 13.6 | 6.8 | 3.7 | 3.7x |
+| permute_32_4d | 1.9 | 0.9 | 0.6 | 2.9x |
+| multiple_permute_sum_32_4d | 9.5 | 4.6 | 3.4 | 2.8x |
+| sum_1m | 1.0 | 0.5 | 0.4 | 2.4x |
 
 ### Algorithm Comparison: Julia Strided.jl vs Rust strided-rs
 
@@ -169,7 +212,16 @@ The key architectural differences are:
 |---------|-------|------|
 | **Kernel generation** | `@generated` unrolls loops per (rank, num\_arrays) at compile time | Handwritten 1D/2D/3D/4D specializations + generic N-D fallback |
 | **Inner-loop SIMD** | Explicit `@simd` pragma on innermost loop | Stride-specialized inner loops: slice-based when stride=1, raw pointer otherwise; relies on LLVM auto-vectorization |
-| **Threading** | Recursive work-stealing via `Threads.@spawn` (disabled in benchmarks) | Single-threaded only |
+| **Threading** | Recursive dimension-splitting via `Threads.@spawn` | Recursive dimension-splitting via `rayon::join` with double-fusion for layout-agnostic parallelization |
+
+> **Note: Strided.jl threading bug for non-column-major views.**
+> Julia's `_mapreduce_fuse!` only detects column-major contiguity, so permuted
+> views (e.g. `PermutedDimsArray(A, (2,1))`) with row-major strides are never
+> fused. This causes `_mapreduce_threaded!` to fall through to the single-threaded
+> kernel because all individual dimensions are ≤1024. strided-rs fixes this with
+> a **double-fusion pass** after ordering. See
+> [docs/strided\_jl\_threading\_bug.md](docs/strided_jl_threading_bug.md) for a
+> minimal reproduction and root cause analysis.
 
 #### Per-case analysis
 

--- a/benches/julia_threaded_compare.jl
+++ b/benches/julia_threaded_compare.jl
@@ -1,0 +1,67 @@
+using Strided
+using BenchmarkTools
+using Statistics
+
+println("Julia Threads: ", Threads.nthreads())
+println("Strided threads: ", Strided.get_num_threads())
+println()
+
+function bench_symmetrize_4000()
+    A = rand(4000, 4000)
+    B = similar(A)
+    t = @benchmark @strided $B .= ($A .+ $A') ./ 2
+    println("symmetrize_4000 (Strided): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_scale_transpose_1000()
+    A = rand(1000, 1000)
+    B = similar(A)
+    t = @benchmark @strided $B .= 3 .* $A'
+    println("scale_transpose_1000 (Strided): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_mwe_stridedview_scale_transpose_1000()
+    n = 1000
+    A = rand(n, n)
+    B = similar(A)
+    svA = StridedView(A)
+    svB = StridedView(B)
+    t = @benchmark $svB .= 3 .* $svA'
+    println("mwe_stridedview_scale_transpose_1000 (StridedView): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_complex_elementwise_1000()
+    A = rand(1000, 1000)
+    B = similar(A)
+    t = @benchmark @strided $B .= $A .* exp.( -2 .* $A) .+ sin.( $A .* $A)
+    println("complex_elementwise_1000 (Strided): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_permute_32_4d()
+    A = randn(32, 32, 32, 32)
+    B = similar(A)
+    t = @benchmark @strided permutedims!($B, $A, (4,3,2,1))
+    println("permute_32_4d (Strided): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_multiple_permute_sum_32_4d()
+    A = randn(32, 32, 32, 32)
+    B = similar(A)
+    t = @benchmark @strided $B .= permutedims($A, (1,2,3,4)) .+ permutedims($A, (2,3,4,1)) .+ permutedims($A, (3,4,1,2)) .+ permutedims($A, (4,1,2,3))
+    println("multiple_permute_sum_32_4d (Strided): ", mean(t.times) / 1e6, " ms")
+end
+
+function bench_sum_1m()
+    A = randn(1_000_000)
+    svA = StridedView(A)
+    t = @benchmark sum($svA)
+    println("sum_1m (StridedView): ", mean(t.times) / 1e6, " ms")
+end
+
+bench_symmetrize_4000()
+bench_mwe_stridedview_scale_transpose_1000()
+bench_scale_transpose_1000()
+bench_complex_elementwise_1000()
+bench_permute_32_4d()
+bench_multiple_permute_sum_32_4d()
+bench_sum_1m()

--- a/benches/run_all.sh
+++ b/benches/run_all.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "============================================================"
+echo " Single-threaded benchmarks"
+echo "============================================================"
+echo ""
+
+echo "--- Rust (strided-rs, single-threaded) ---"
+RAYON_NUM_THREADS=1 cargo bench --bench rust_compare \
+    --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1 \
+    | grep -v "^$\|Compiling\|Finished\|Running\|Benchmarking"
+echo ""
+
+echo "--- Julia (Strided.jl, single-threaded) ---"
+JULIA_NUM_THREADS=1 julia "$SCRIPT_DIR/julia_compare.jl"
+echo ""
+
+echo "============================================================"
+echo " Multi-threaded benchmarks (Rust parallel feature)"
+echo "============================================================"
+echo ""
+
+THREADS="${@:-1 2 4}"
+
+cargo build --release --features parallel --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1 \
+    | grep -v "^$"
+echo ""
+
+for T in $THREADS; do
+    echo "------------------------------------------------------------"
+    echo " Threads: $T"
+    echo "------------------------------------------------------------"
+
+    echo "--- Rust (strided-rs, parallel feature) ---"
+    RAYON_NUM_THREADS=$T cargo bench --features parallel --bench threaded_compare \
+        --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1 \
+        | grep -v "^$\|Compiling\|Finished\|Running\|Benchmarking"
+    echo ""
+
+    echo "--- Julia (Strided.jl) ---"
+    JULIA_NUM_THREADS=$T julia "$SCRIPT_DIR/julia_threaded_compare.jl"
+    echo ""
+done

--- a/benches/run_threaded.sh
+++ b/benches/run_threaded.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+THREADS="${@:-1 2 4}"
+
+echo "Building Rust (release + parallel)..."
+cargo build --release --features parallel --manifest-path "$PROJECT_DIR/Cargo.toml"
+echo ""
+
+for T in $THREADS; do
+    echo "============================================================"
+    echo " Threads: $T"
+    echo "============================================================"
+
+    echo "--- Rust (strided-rs, parallel feature) ---"
+    RAYON_NUM_THREADS=$T cargo bench --features parallel --bench threaded_compare \
+        --manifest-path "$PROJECT_DIR/Cargo.toml" 2>&1 \
+        | grep -v "^$\|Compiling\|Finished\|Running\|Benchmarking"
+    echo ""
+
+    echo "--- Julia (Strided.jl) ---"
+    JULIA_NUM_THREADS=$T julia "$SCRIPT_DIR/julia_threaded_compare.jl"
+    echo ""
+done

--- a/benches/threaded_compare.rs
+++ b/benches/threaded_compare.rs
@@ -1,0 +1,166 @@
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand_distr::StandardNormal;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+use strided_rs::{
+    copy_into, copy_transpose_scale_into, map_into, sum, zip_map2_into, zip_map4_into, StridedArray,
+};
+
+fn mean(durations: &[Duration]) -> Duration {
+    let total_nanos: u128 = durations.iter().map(|d| d.as_nanos()).sum();
+    Duration::from_nanos((total_nanos / durations.len() as u128) as u64)
+}
+
+fn bench_n(label: &str, warmup_iters: usize, iters: usize, mut f: impl FnMut()) -> Duration {
+    for _ in 0..warmup_iters {
+        f();
+    }
+
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed());
+    }
+
+    let avg = mean(&samples);
+    println!("{label}: {:.3} ms", avg.as_secs_f64() * 1e3);
+    avg
+}
+
+fn make_random_2d(n: usize, seed: u64) -> StridedArray<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    StridedArray::<f64>::from_fn_col_major(&[n, n], |_| rng.sample(StandardNormal))
+}
+
+fn make_random_4d(n: usize, seed: u64) -> StridedArray<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    StridedArray::<f64>::from_fn_col_major(&[n, n, n, n], |_| rng.sample(StandardNormal))
+}
+
+fn main() {
+    let nthreads = rayon::current_num_threads();
+    println!("Rust threaded runner: benches/threaded_compare.rs");
+    println!("Rayon threads: {nthreads}");
+    println!();
+
+    // 1) symmetrize_4000
+    {
+        println!("=== Benchmark 1: symmetrize_4000 ===");
+        let n = 4000usize;
+        let a = make_random_2d(n, 0);
+        let a_view = a.view();
+        let a_t = a_view.permute(&[1, 0]).unwrap();
+        let mut b = StridedArray::<f64>::col_major(&[n, n]);
+
+        bench_n("rust_strided", 1, 3, || {
+            zip_map2_into(&mut b.view_mut(), &a_view, &a_t, |x, y| (x + y) * 0.5).unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 2) scale_transpose_1000
+    {
+        println!("=== Benchmark 2: scale_transpose_1000 ===");
+        let n = 1000usize;
+        let a = make_random_2d(n, 1);
+        let a_view = a.view();
+        let mut b = StridedArray::<f64>::col_major(&[n, n]);
+
+        bench_n("rust_strided", 5, 10, || {
+            copy_transpose_scale_into(&mut b.view_mut(), &a_view, 3.0).unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 2a) mwe_stridedview_scale_transpose_1000 (map_into)
+    {
+        println!("=== Benchmark 2a: mwe_stridedview_scale_transpose_1000 ===");
+        let n = 1000usize;
+        let mut rng = StdRng::seed_from_u64(11);
+        let a = StridedArray::<f64>::from_fn_col_major(&[n, n], |_| rng.gen::<f64>());
+        let a_view = a.view();
+        let a_t = a_view.permute(&[1, 0]).unwrap();
+        let mut b = StridedArray::<f64>::col_major(&[n, n]);
+
+        bench_n("rust_strided_map", 5, 10, || {
+            map_into(&mut b.view_mut(), &a_t, |x| 3.0 * x).unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 3) complex_elementwise_1000
+    {
+        println!("=== Benchmark 3: complex_elementwise_1000 (Float64) ===");
+        let n = 1000usize;
+        let a = make_random_2d(n, 2);
+        let a_view = a.view();
+        let mut b = StridedArray::<f64>::col_major(&[n, n]);
+
+        bench_n("rust_strided", 3, 6, || {
+            map_into(&mut b.view_mut(), &a_view, |x| {
+                x * (-2.0 * x).exp() + (x * x).sin()
+            })
+            .unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 4) permute_32_4d
+    {
+        println!("=== Benchmark 4: permute_32_4d ===");
+        let n = 32usize;
+        let a = make_random_4d(n, 3);
+        let a_view = a.view();
+        let a_perm = a_view.permute(&[3, 2, 1, 0]).unwrap();
+        let mut b = StridedArray::<f64>::col_major(&[n, n, n, n]);
+
+        bench_n("rust_strided", 20, 50, || {
+            copy_into(&mut b.view_mut(), &a_perm).unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 5) multiple_permute_sum_32_4d
+    {
+        println!("=== Benchmark 5: multiple_permute_sum_32_4d ===");
+        let n = 32usize;
+        let a = make_random_4d(n, 4);
+        let a_view = a.view();
+
+        let p1 = a_view.permute(&[0, 1, 2, 3]).unwrap();
+        let p2 = a_view.permute(&[1, 2, 3, 0]).unwrap();
+        let p3 = a_view.permute(&[2, 3, 0, 1]).unwrap();
+        let p4 = a_view.permute(&[3, 0, 1, 2]).unwrap();
+        let mut b = StridedArray::<f64>::col_major(&[n, n, n, n]);
+
+        bench_n("rust_strided_fused", 10, 30, || {
+            zip_map4_into(&mut b.view_mut(), &p1, &p2, &p3, &p4, |a, b, c, d| {
+                a + b + c + d
+            })
+            .unwrap();
+            black_box(&b);
+        });
+        println!();
+    }
+
+    // 6) large contiguous sum (reduction)
+    {
+        println!("=== Benchmark 6: sum_1m ===");
+        let n = 1_000_000usize;
+        let mut rng = StdRng::seed_from_u64(42);
+        let a = StridedArray::<f64>::from_fn_col_major(&[n], |_| rng.sample(StandardNormal));
+        let a_view = a.view();
+
+        bench_n("rust_strided_sum", 5, 10, || {
+            let s = sum(&a_view).unwrap();
+            black_box(s);
+        });
+        println!();
+    }
+}

--- a/docs/strided_jl_threading_bug.md
+++ b/docs/strided_jl_threading_bug.md
@@ -1,0 +1,106 @@
+# Strided.jl: Threading not activated for permuted (non-column-major) views
+
+## Summary
+
+`_mapreduce_threaded!` fails to split dimensions for arrays whose strides are
+not in column-major order. Contiguous row-major views (e.g. `permutedims(A, (2,1))`)
+cannot be parallelized even when the total element count far exceeds
+`MINTHREADLENGTH`.
+
+## Minimal reproduction
+
+```julia
+using Strided
+
+function bench_threaded(n, niter)
+    A = rand(n, n)                    # col-major  (strides = (1, n))
+    B = similar(A)
+    At = StridedView(PermutedDimsArray(A, (2,1)))  # row-major-ish (strides = (n, 1))
+    Bt = StridedView(PermutedDimsArray(B, (2,1)))  # row-major-ish (strides = (n, 1))
+
+    f(x) = x * exp(-2x) + sin(x*x)
+
+    # Warm up
+    @strided B  .= f.(A)
+    @strided Bt .= f.(At)
+
+    # Benchmark column-major
+    t_col = @elapsed for _ in 1:niter
+        @strided B .= f.(A)
+    end
+
+    # Benchmark row-major (permuted) – same data, same total elements
+    t_row = @elapsed for _ in 1:niter
+        @strided Bt .= f.(At)
+    end
+
+    println("Threads : ", Threads.nthreads())
+    println("Elements: ", n*n)
+    println("Col-major: $(1e3 * t_col / niter) ms")
+    println("Row-major: $(1e3 * t_row / niter) ms")
+end
+
+bench_threaded(1000, 20)
+```
+
+### Expected (4 threads)
+
+Both cases should scale roughly equally because the data is contiguous in
+memory; only the stride order differs.
+
+```
+Col-major: ~3 ms
+Row-major: ~3 ms
+```
+
+### Actual (4 threads)
+
+```
+Col-major: ~3 ms     ← parallelized ✓
+Row-major: ~12 ms    ← sequential   ✗
+```
+
+## Root cause
+
+The pipeline is: `_mapreduce_fuse!` → `_mapreduce_order!` → `_computeblocks` → `_mapreduce_threaded!`.
+
+1. **`_mapreduce_fuse!`** checks `s[i] == dims[i-1] * s[i-1]` for consecutive
+   dimensions. This only detects column-major contiguity.
+
+   - Col-major `(1, 1000)`: `s[2] = 1000 == 1000 * 1 = dims[1] * s[1]` → **fuses** to `(1_000_000,)`
+   - Row-major `(1000, 1)`: `s[2] = 1 ≠ 1000 * 1000` → **no fusion**, stays `(1000, 1000)`
+
+2. **`_computeblocks`** preserves dimensions whose stride-order position is minimal
+   (the "first dim has smallest stride" path). For row-major after ordering,
+   both dimensions are preserved: `blocks = (1000, 1000) = dims`.
+
+3. **`_mapreduce_threaded!`** guard: `dims[i] ≤ min(blocks[i], 1024)` →
+   `1000 ≤ min(1000, 1024) = 1000` → **true** for all dimensions → falls
+   through to single-threaded `_mapreduce_kernel!`.
+
+For column-major, fusion produces a single `1_000_000`-element dimension that
+exceeds the 1024 guard and is split normally.
+
+## Suggested fix
+
+Apply a **second fusion pass after ordering**. Once `_mapreduce_order!` has
+sorted dimensions by stride importance (smallest stride first), consecutive
+dimensions may now be contiguous regardless of the original memory layout:
+
+```julia
+# After ordering (pseudocode)
+ordered_dims   = permute(dims, p)
+ordered_strides = map(s -> permute(s, p), strides)
+
+# Second fuse on ordered representation
+ordered_dims = _mapreduce_fuse_ordered!(ordered_dims, ordered_strides)
+
+# Then compute blocks and proceed to threading
+blocks = _computeblocks(ordered_dims, ...)
+```
+
+For the row-major example after ordering:
+- `ordered_strides = (1, 1000)` → `s[2] = 1000 == 1000 * 1` → fuses to `(1_000_000, 1)`
+- Now `dims[1] = 1_000_000 > 1024` → threading guard passes → parallelized
+
+This fix is layout-agnostic and preserves the existing algorithm structure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ mod fuse;
 mod kernel;
 mod order;
 pub mod strided_view;
+#[cfg(feature = "parallel")]
+mod threading;
 
 // View-based operation modules
 mod map_view;


### PR DESCRIPTION
## Summary

- Add optional Rayon-based multi-threading via `parallel` Cargo feature
- Port Julia Strided.jl's `_mapreduce_threaded!` recursive dimension-splitting strategy using `rayon::join`
- Introduce **double-fusion pass** (fuse -> order -> fuse-again -> block) that enables threading for any memory layout, not just column-major -- this also fixes a latent bug in upstream Strided.jl

### Changes

**Core threading** (`src/threading.rs` -- new):
- `SendPtr<T>` wrapper for raw pointer Send+Sync safety
- `mapreduce_threaded`: recursive dimension splitting via `rayon::join`
- `for_each_inner_block_with_offsets`: kernel wrapper for sub-region execution
- `MINTHREADLENGTH = 1 << 15` threshold

**Double-fusion** (`src/kernel.rs`):
- `double_fuse_for_parallel`: reorders by plan, runs a second `fuse_dims`, recomputes blocks
- Fixes the case where row-major or permuted views have individual dims <=1024 but large total element count, which prevents Strided.jl from parallelizing

**Parallel branches** (`src/map_view.rs`, `src/reduce_view.rs`, `src/ops_view.rs`):
- `map_into`, `zip_map{2,3,4}_into`, `reduce`, and all high-level ops
- `use_sequential_fast_path` guard to skip contiguous fast paths when parallel is enabled
- `Send + Sync` bounds on all public function type parameters

**Benchmarks & docs**:
- `benches/threaded_compare.rs` -- Rust multi-threaded benchmark
- `benches/julia_threaded_compare.jl` -- Julia equivalent
- `benches/run_threaded.sh` -- comparison script across thread counts
- `benches/run_all.sh` -- single + multi-threaded, Rust + Julia
- `docs/strided_jl_threading_bug.md` -- minimal reproduction and root cause analysis of the Strided.jl threading bug
- Updated README with parallel feature docs, scaling results, and bug note

### Scaling (Apple M2, 4 threads)

| Case | 1T (ms) | 4T (ms) | Speedup |
|---|---:|---:|---:|
| symmetrize_4000 | 42.2 | 16.4 | 2.6x |
| complex_elementwise_1000 | 13.6 | 3.7 | 3.7x |
| permute_32_4d | 1.9 | 0.6 | 2.9x |
| multiple_permute_sum_32 | 9.5 | 3.4 | 2.8x |
| sum_1m | 1.0 | 0.4 | 2.4x |

## Test plan

- [x] `cargo test` (without parallel feature)
- [x] `cargo test --features parallel`
- [x] `cargo fmt --check`
- [x] Verified scaling at 1/2/4/8 threads
- [x] Verified both col-major and row-major arrays parallelize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
