### PR TITLE
refactor: rename strided-rs -> strided, stridedview-rs -> stridedview (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ For local development, add a path dependency:
 
 ```toml
 [dependencies]
-strided-rs = { path = "../strided-rs" }
+strided = { path = "../strided-rs/strided" }
 ```
 
 ## Quick Start
 
 ```rust
-use strided_rs::{StridedArray, StridedView, map_into};
+use strided::{StridedArray, StridedView, map_into};
 
 // Create a row-major 2D array
 let src = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| {
@@ -55,7 +55,7 @@ Owned strided multidimensional array with `view()` and `view_mut()` methods.
 ## View Operations
 
 ```rust
-use strided_rs::StridedArray;
+use strided::StridedArray;
 
 let a = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| {
     (idx[0] * 10 + idx[1]) as f64
@@ -72,14 +72,14 @@ assert_eq!(vp.get(&[2, 1]), v.get(&[1, 2]));
 
 // Broadcast (stride-0 for size-1 dims)
 let row_data = vec![1.0, 2.0, 3.0];
-let row = strided_rs::StridedView::<f64>::new(&row_data, &[1, 3], &[3, 1], 0).unwrap();
+let row = strided::StridedView::<f64>::new(&row_data, &[1, 3], &[3, 1], 0).unwrap();
 let broad = row.broadcast(&[4, 3]).unwrap();
 ```
 
 ## Map and Reduce Operations
 
 ```rust
-use strided_rs::{StridedArray, map_into, zip_map2_into, zip_map4_into, reduce};
+use strided::{StridedArray, map_into, zip_map2_into, zip_map4_into, reduce};
 
 let a = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| idx[0] as f64);
 let b = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| idx[1] as f64);
@@ -98,7 +98,7 @@ let total = reduce(&a.view(), |x| x, |a, b| a + b, 0.0).unwrap();
 ## High-Level Operations
 
 ```rust
-use strided_rs::{StridedArray, copy_into, add, dot, symmetrize_into};
+use strided::{StridedArray, copy_into, add, dot, symmetrize_into};
 
 let a = StridedArray::<f64>::from_fn_row_major(&[4, 4], |idx| (idx[0] * 10 + idx[1]) as f64);
 let mut out = StridedArray::<f64>::row_major(&[4, 4]);
@@ -131,7 +131,7 @@ Enable Rayon-based multi-threading with the `parallel` feature:
 
 ```toml
 [dependencies]
-strided-rs = { path = "../strided-rs", features = ["parallel"] }
+strided = { path = "../strided-rs/strided", features = ["parallel"] }
 ```
 
 When enabled, `map_into`, `zip_map*_into`, `reduce`, and all high-level ops

--- a/deprecated/benches/julia_benchtests.rs
+++ b/deprecated/benches/julia_benchtests.rs
@@ -4,7 +4,7 @@ use mdarray::Tensor;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::time::Duration;
-use strided_rs::{
+use strided::{
     copy_into, mapreducedim_capture_views_into, sum, Arg, CaptureArgs, Identity, StridedArrayView,
     StridedArrayViewMut,
 };

--- a/deprecated/benches/mdarray_compare.rs
+++ b/deprecated/benches/mdarray_compare.rs
@@ -4,7 +4,7 @@ use mdarray::Tensor;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::time::Duration;
-use strided_rs::copy_into;
+use strided::copy_into;
 
 // Compare mdarray's assign (iterator-based) with strided-rs's copy_into (blocked)
 // for a 4D permutation: (32, 32, 32, 32) -> [3, 2, 1, 0]

--- a/deprecated/benches/readme_examples.rs
+++ b/deprecated/benches/readme_examples.rs
@@ -4,7 +4,7 @@ use mdarray::Tensor;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::time::Duration;
-use strided_rs::{copy_into, copy_transpose_scale_into_fast, zip_map2_into, zip_map4_into};
+use strided::{copy_into, copy_transpose_scale_into_fast, zip_map2_into, zip_map4_into};
 
 // Benchmark 1: B = (A + A') / 2 for 4000x4000 matrix
 fn bench_symmetrize_4000(c: &mut Criterion) {
@@ -99,7 +99,7 @@ fn bench_complex_elementwise_1000(c: &mut Criterion) {
 
     group.bench_function("strided", |bencher| {
         bencher.iter(|| {
-            strided_rs::map_into(&mut b, a.as_ref(), |&x| {
+            strided::map_into(&mut b, a.as_ref(), |&x| {
                 x * (-2.0 * x).exp() + (x * x).sin()
             })
             .unwrap();

--- a/deprecated/benches/strided_bench.rs
+++ b/deprecated/benches/strided_bench.rs
@@ -4,7 +4,7 @@ use mdarray::Tensor;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::time::Duration;
-use strided_rs::{
+use strided::{
     copy_into, copy_transpose_scale_into_fast, map_into, sum, symmetrize_into, zip_map2_into,
     zip_map4_into,
 };

--- a/strided/Cargo.toml
+++ b/strided/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "strided-rs"
+name = "strided"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ description = "Cache-optimized kernels for strided multidimensional array operat
 publish = false
 
 [dependencies]
-stridedview = { path = "../stridedview", package = "stridedview-rs" }
+stridedview = { path = "../stridedview" }
 num-traits = "0.2"
 num-complex = "0.4"
 rayon = { version = "1.10", optional = true }

--- a/strided/benches/rust_compare.rs
+++ b/strided/benches/rust_compare.rs
@@ -2,7 +2,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::hint::black_box;
 use std::time::{Duration, Instant};
-use strided_rs::{
+use strided::{
     copy_into, copy_transpose_scale_into, map_into, zip_map2_into, zip_map4_into, StridedArray,
 };
 

--- a/strided/benches/scaling_compare.rs
+++ b/strided/benches/scaling_compare.rs
@@ -10,7 +10,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::hint::black_box;
 use std::time::{Duration, Instant};
-use strided_rs::{copy_into, sum, StridedArray};
+use strided::{copy_into, sum, StridedArray};
 
 fn median(durations: &mut [Duration]) -> Duration {
     durations.sort();

--- a/strided/benches/threaded_compare.rs
+++ b/strided/benches/threaded_compare.rs
@@ -2,7 +2,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use std::hint::black_box;
 use std::time::{Duration, Instant};
-use strided_rs::{
+use strided::{
     copy_into, copy_transpose_scale_into, map_into, sum, zip_map2_into, zip_map4_into, StridedArray,
 };
 

--- a/strided/src/lib.rs
+++ b/strided/src/lib.rs
@@ -34,7 +34,7 @@
 //! # Example
 //!
 //! ```rust
-//! use strided_rs::{StridedView, StridedViewMut, StridedArray, Identity, map_into};
+//! use strided::{StridedView, StridedViewMut, StridedArray, Identity, map_into};
 //!
 //! // Create a column-major array (Julia default)
 //! let src = StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| {

--- a/strided/tests/correctness_view.rs
+++ b/strided/tests/correctness_view.rs
@@ -1,5 +1,5 @@
 use approx::assert_relative_eq;
-use strided_rs::{
+use strided::{
     add, axpy, copy_into, copy_transpose_scale_into, dot, fma, map_into, mul, reduce, reduce_axis,
     sum, symmetrize_into, zip_map2_into, zip_map4_into, StridedArray,
 };
@@ -210,7 +210,7 @@ fn test_col_major_tensor() {
 #[test]
 fn test_strided_view_broadcast_and_copy() {
     let data = vec![1.0, 2.0, 3.0];
-    let row = strided_rs::StridedView::<f64>::new(&data, &[1, 3], &[3, 1], 0).unwrap();
+    let row = strided::StridedView::<f64>::new(&data, &[1, 3], &[3, 1], 0).unwrap();
     let broad = row.broadcast(&[4, 3]).unwrap();
 
     let mut dest = StridedArray::<f64>::row_major(&[4, 3]);

--- a/stridedview/Cargo.toml
+++ b/stridedview/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stridedview-rs"
+name = "stridedview"
 version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -7,9 +7,6 @@ authors = ["Satoshi Terasaki", "Hiroshi Shinaoka"]
 repository = "https://github.com/tensor4all/strided-rs"
 description = "Device-agnostic strided view types and metadata operations (ported from Julia StridedViews.jl)."
 publish = false
-
-[lib]
-name = "stridedview"
 
 [dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
## Summary
- Rename package `strided-rs` to `strided` and `stridedview-rs` to `stridedview`
- Aligns naming with the planned `strided*` crate family: `stridedview`, `strided`, `strided-einsum2`
- Update all `use strided_rs::` imports to `use strided::` across tests, benches, and doctests
- Update README dependency examples

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 103 tests pass (34 stridedview + 44+24+1 strided)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)