### PR TITLE
Reduce allocations across strided* and improve einsum2 planning

### DIFF
--- a/strided-einsum2/src/bgemm_naive.rs
+++ b/strided-einsum2/src/bgemm_naive.rs
@@ -76,24 +76,27 @@ where
     let is_alpha_one = alpha == T::one();
 
     let mut batch_iter = MultiIndex::new(batch_dims);
+    let mut lo_iter = MultiIndex::new(lo_dims);
+    let mut ro_iter = MultiIndex::new(ro_dims);
+    let mut sum_iter = MultiIndex::new(sum_dims);
     while batch_iter.next().is_some() {
         let a_batch_off = batch_iter.offset(a_batch_strides);
         let b_batch_off = batch_iter.offset(b_batch_strides);
         let c_batch_off = batch_iter.offset(c_batch_strides);
 
-        let mut lo_iter = MultiIndex::new(lo_dims);
+        lo_iter.reset();
         while lo_iter.next().is_some() {
             let a_lo_off = lo_iter.offset(a_lo_strides);
             let c_lo_off = lo_iter.offset(c_lo_strides);
 
-            let mut ro_iter = MultiIndex::new(ro_dims);
+            ro_iter.reset();
             while ro_iter.next().is_some() {
                 let b_ro_off = ro_iter.offset(b_ro_strides);
                 let c_ro_off = ro_iter.offset(c_ro_strides);
 
                 // Accumulate sum over contraction indices
                 let mut acc = T::zero();
-                let mut sum_iter = MultiIndex::new(sum_dims);
+                sum_iter.reset();
                 while sum_iter.next().is_some() {
                     let a_sum_off = sum_iter.offset(a_sum_strides);
                     let b_sum_off = sum_iter.offset(b_sum_strides);

--- a/strided/src/threading.rs
+++ b/strided/src/threading.rs
@@ -48,7 +48,7 @@ pub(crate) const MINTHREADLENGTH: usize = 1 << 15;
 ///
 /// Takes the per-dimension minimum stride magnitude across all arrays,
 /// then maps: 0 → 1, nonzero → 2*|min_stride|.
-pub(crate) fn compute_costs(strides_list: &[&[isize]], ndim: usize) -> Vec<isize> {
+pub(crate) fn compute_costs(strides_list: &[Vec<isize>], ndim: usize) -> Vec<isize> {
     (0..ndim)
         .map(|d| {
             let min_stride = strides_list
@@ -230,9 +230,7 @@ mod tests {
     #[test]
     fn test_compute_costs() {
         // stride 0 → cost 1, stride 1 → cost 2, stride 3 → cost 6
-        let s1: Vec<isize> = vec![1, 0, 3];
-        let s2: Vec<isize> = vec![2, 0, 4];
-        let strides_list: Vec<&[isize]> = vec![&s1, &s2];
+        let strides_list: Vec<Vec<isize>> = vec![vec![1, 0, 3], vec![2, 0, 4]];
         let costs = compute_costs(&strides_list, 3);
         assert_eq!(costs, vec![2, 1, 6]);
     }

--- a/stridedview/src/strided_view.rs
+++ b/stridedview/src/strided_view.rs
@@ -9,6 +9,7 @@
 
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
+use std::sync::Arc;
 
 use crate::element_op::{ElementOp, ElementOpApply, Identity};
 use crate::{Result, StridedError};
@@ -98,8 +99,8 @@ pub fn row_major_strides(dims: &[usize]) -> Vec<isize> {
 pub struct StridedView<'a, T, Op: ElementOp = Identity> {
     ptr: *const T,
     data: &'a [T],
-    dims: Box<[usize]>,
-    strides: Box<[isize]>,
+    dims: Arc<[usize]>,
+    strides: Arc<[isize]>,
     offset: isize,
     _op: PhantomData<Op>,
 }
@@ -138,8 +139,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Ok(Self {
             ptr,
             data,
-            dims: dims.into(),
-            strides: strides.into(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset,
             _op: PhantomData,
         })
@@ -159,8 +160,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Self {
             ptr,
             data,
-            dims: dims.into(),
-            strides: strides.into(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset,
             _op: PhantomData,
         }
@@ -228,8 +229,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Ok(StridedView {
             ptr: self.ptr,
             data: self.data,
-            dims: new_dims.into_boxed_slice(),
-            strides: new_strides.into_boxed_slice(),
+            dims: Arc::from(new_dims),
+            strides: Arc::from(new_strides),
             offset: self.offset,
             _op: PhantomData,
         })
@@ -248,8 +249,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Ok(StridedView {
             ptr: self.ptr,
             data: self.data,
-            dims: Box::new([self.dims[1], self.dims[0]]),
-            strides: Box::new([self.strides[1], self.strides[0]]),
+            dims: Arc::new([self.dims[1], self.dims[0]]),
+            strides: Arc::new([self.strides[1], self.strides[0]]),
             offset: self.offset,
             _op: PhantomData,
         })
@@ -268,8 +269,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Ok(StridedView {
             ptr: self.ptr,
             data: self.data,
-            dims: Box::new([self.dims[1], self.dims[0]]),
-            strides: Box::new([self.strides[1], self.strides[0]]),
+            dims: Arc::new([self.dims[1], self.dims[0]]),
+            strides: Arc::new([self.strides[1], self.strides[0]]),
             offset: self.offset,
             _op: PhantomData,
         })
@@ -318,8 +319,8 @@ impl<'a, T, Op: ElementOp> StridedView<'a, T, Op> {
         Ok(StridedView {
             ptr: self.ptr,
             data: self.data,
-            dims: target_dims.into(),
-            strides: new_strides.into_boxed_slice(),
+            dims: Arc::from(target_dims),
+            strides: Arc::from(new_strides),
             offset: self.offset,
             _op: PhantomData,
         })
@@ -368,8 +369,8 @@ impl<'a, T: Copy + ElementOpApply, Op: ElementOp> StridedView<'a, T, Op> {
 pub struct StridedViewMut<'a, T> {
     ptr: *mut T,
     data: &'a mut [T],
-    dims: Box<[usize]>,
-    strides: Box<[isize]>,
+    dims: Arc<[usize]>,
+    strides: Arc<[isize]>,
     offset: isize,
 }
 
@@ -398,8 +399,8 @@ impl<'a, T> StridedViewMut<'a, T> {
         Ok(Self {
             ptr,
             data,
-            dims: dims.into(),
-            strides: strides.into(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset,
         })
     }
@@ -418,8 +419,8 @@ impl<'a, T> StridedViewMut<'a, T> {
         Self {
             ptr,
             data,
-            dims: dims.into(),
-            strides: strides.into(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset,
         }
     }
@@ -490,8 +491,8 @@ impl<'a, T> StridedViewMut<'a, T> {
         Ok(StridedViewMut {
             ptr: self.ptr,
             data: self.data,
-            dims: new_dims.into_boxed_slice(),
-            strides: new_strides.into_boxed_slice(),
+            dims: Arc::from(new_dims),
+            strides: Arc::from(new_strides),
             offset: self.offset,
         })
     }
@@ -544,8 +545,8 @@ impl<'a, T: Copy> StridedViewMut<'a, T> {
 /// Supports both column-major (Julia default) and row-major (C default) layouts.
 pub struct StridedArray<T> {
     data: Vec<T>,
-    dims: Box<[usize]>,
-    strides: Box<[isize]>,
+    dims: Arc<[usize]>,
+    strides: Arc<[isize]>,
     offset: isize,
 }
 
@@ -578,8 +579,8 @@ impl<T: Clone + Default> StridedArray<T> {
         let strides = col_major_strides(dims);
         Self {
             data,
-            dims: dims.into(),
-            strides: strides.into_boxed_slice(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset: 0,
         }
     }
@@ -591,8 +592,8 @@ impl<T: Clone + Default> StridedArray<T> {
         let strides = row_major_strides(dims);
         Self {
             data,
-            dims: dims.into(),
-            strides: strides.into_boxed_slice(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset: 0,
         }
     }
@@ -618,8 +619,8 @@ impl<T: Clone + Default> StridedArray<T> {
         }
         Self {
             data,
-            dims: dims.into(),
-            strides: strides.into_boxed_slice(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset: 0,
         }
     }
@@ -645,8 +646,8 @@ impl<T: Clone + Default> StridedArray<T> {
         }
         Self {
             data,
-            dims: dims.into(),
-            strides: strides.into_boxed_slice(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset: 0,
         }
     }
@@ -663,8 +664,8 @@ impl<T> StridedArray<T> {
         validate_bounds(data.len(), dims, strides, offset)?;
         Ok(Self {
             data,
-            dims: dims.into(),
-            strides: strides.into(),
+            dims: Arc::from(dims),
+            strides: Arc::from(strides),
             offset,
         })
     }


### PR DESCRIPTION
Implements non-DRY improvement items discussed during issue #15 roadmap review (excluding the big DRY/common-runner refactor).

Changes:
- stridedview: make dims/strides Arc-backed to avoid heap allocs when creating views.
- strided: remove redundant dims/strides Vec cloning in map/ops/reduce hot paths; kernel-based reduce_axis.
- strided-einsum2: O(n) plan permutations; single-pass trace reduction; more general contiguous fuse detection.

Validation:
- cargo fmt
- cargo test (workspace)