### PR TITLE
feat: reduce Vec allocations in parallel splitting (#26)

### DIFF
--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -13,11 +13,12 @@ strided-view = { path = "../strided-view" }
 num-traits = "0.2"
 num-complex = "0.4"
 rayon = { version = "1.10", optional = true }
+smallvec = { version = "1", optional = true }
 pulp = { version = "0.22", optional = true }
 
 [features]
 default = ["simd"]
-parallel = ["rayon"]
+parallel = ["rayon", "smallvec"]
 simd = ["dep:pulp"]
 
 [dev-dependencies]

--- a/strided-kernel/src/threading.rs
+++ b/strided-kernel/src/threading.rs
@@ -3,8 +3,14 @@
 //! Faithfully ports Julia Strided.jl's `_mapreduce_threaded!` recursive
 //! dimension-splitting strategy using `rayon::join`.
 
+use smallvec::SmallVec;
+
 use crate::kernel::for_each_inner_block_preordered;
 use crate::Result;
+
+/// Stack-allocated Vec for dims/offsets in recursive threading.
+/// 8 elements covers up to 8-dimensional arrays (after fusion, typically 2-4).
+type SVec<T> = SmallVec<[T; 8]>;
 
 /// A raw pointer wrapper that is `Send` + `Sync`.
 ///
@@ -65,22 +71,6 @@ pub(crate) fn compute_costs(strides_list: &[Vec<isize>], ndim: usize) -> Vec<isi
         .collect()
 }
 
-/// Julia's `_lastargmax`: argmax that breaks ties by choosing the last index.
-fn lastargmax(values: &[isize]) -> Option<usize> {
-    if values.is_empty() {
-        return None;
-    }
-    let mut best_idx = 0;
-    let mut best_val = values[0];
-    for (i, &v) in values.iter().enumerate().skip(1) {
-        if v >= best_val {
-            best_val = v;
-            best_idx = i;
-        }
-    }
-    Some(best_idx)
-}
-
 /// Recursive dimension-splitting parallel execution.
 ///
 /// Faithfully ports Julia's `_mapreduce_threaded!` (mapreduce.jl L195-227).
@@ -117,7 +107,7 @@ where
     // Base case: single thread or below threshold
     if nthreads <= 1 || total <= MINTHREADLENGTH {
         if spacing != 0 {
-            let mut spaced = offsets.to_vec();
+            let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
             spaced[0] += spacing * (taskindex as isize - 1);
             return f(dims, blocks, strides_list, &spaced);
         }
@@ -125,17 +115,24 @@ where
     }
 
     // Select split dimension: _lastargmax((dims .- 1) .* costs)
-    let scores: Vec<isize> = dims
-        .iter()
-        .zip(costs.iter())
-        .map(|(&d, &c)| (d as isize - 1) * c)
-        .collect();
-    let i = lastargmax(&scores).unwrap();
+    // Streaming argmax avoids allocating a scores Vec.
+    // Uses >= to match Julia's `_lastargmax` (ties broken by last index).
+    let (i, _) = dims.iter().zip(costs.iter()).enumerate().fold(
+        (0, isize::MIN),
+        |(best_i, best_v), (idx, (&d, &c))| {
+            let score = (d as isize - 1) * c;
+            if score >= best_v {
+                (idx, score)
+            } else {
+                (best_i, best_v)
+            }
+        },
+    );
 
     // Guard: costs[i] == 0 || dims[i] <= min(blocks[i], 1024)
     if costs[i] == 0 || dims[i] <= blocks[i].min(1024) {
         if spacing != 0 {
-            let mut spaced = offsets.to_vec();
+            let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
             spaced[0] += spacing * (taskindex as isize - 1);
             return f(dims, blocks, strides_list, &spaced);
         }
@@ -149,18 +146,18 @@ where
     let nt_right = nthreads - nt_left;
 
     // Left half: dims[i] = ndi, same offsets
-    let mut left_dims = dims.to_vec();
+    let mut left_dims: SVec<usize> = SmallVec::from_slice(dims);
     left_dims[i] = ndi;
 
     // Right half: dims[i] = di - ndi, offsets advanced by ndi * stride[i]
-    let mut right_dims = dims.to_vec();
+    let mut right_dims: SVec<usize> = SmallVec::from_slice(dims);
     right_dims[i] = di - ndi;
-    let mut right_offsets = offsets.to_vec();
+    let mut right_offsets: SVec<isize> = SmallVec::from_slice(offsets);
     for (k, strides) in strides_list.iter().enumerate() {
         right_offsets[k] += ndi as isize * strides[i];
     }
 
-    let left_offsets = offsets.to_vec();
+    let left_offsets: SVec<isize> = SmallVec::from_slice(offsets);
 
     // rayon::join for parallel left/right execution
     let (r1, r2) = rayon::join(
@@ -218,13 +215,36 @@ where
 mod tests {
     use super::*;
 
+    /// Helper: compute lastargmax via streaming fold (same logic as in mapreduce_threaded).
+    fn streaming_lastargmax(dims: &[usize], costs: &[isize]) -> usize {
+        let (i, _) = dims.iter().zip(costs.iter()).enumerate().fold(
+            (0, isize::MIN),
+            |(best_i, best_v), (idx, (&d, &c))| {
+                let score = (d as isize - 1) * c;
+                if score >= best_v {
+                    (idx, score)
+                } else {
+                    (best_i, best_v)
+                }
+            },
+        );
+        i
+    }
+
     #[test]
-    fn test_lastargmax() {
-        assert_eq!(lastargmax(&[1, 3, 2]), Some(1));
-        // Ties: last index wins
-        assert_eq!(lastargmax(&[3, 1, 3]), Some(2));
-        assert_eq!(lastargmax(&[]), None);
-        assert_eq!(lastargmax(&[5]), Some(0));
+    fn test_streaming_lastargmax() {
+        // Basic: scores = (9*2, 19*1, 4*3) = (18, 19, 12) → max at index 1
+        assert_eq!(streaming_lastargmax(&[10, 20, 5], &[2, 1, 3]), 1);
+
+        // Ties: last index wins (>= semantics)
+        // scores: (10-1)*1=9, (10-1)*1=9, (10-1)*1=9 → all equal → last wins
+        assert_eq!(streaming_lastargmax(&[10, 10, 10], &[1, 1, 1]), 2);
+
+        // All dims=1: scores are all 0 → last wins
+        assert_eq!(streaming_lastargmax(&[1, 1, 1], &[1, 1, 1]), 2);
+
+        // Single dimension
+        assert_eq!(streaming_lastargmax(&[100], &[2]), 0);
     }
 
     #[test]
@@ -261,5 +281,65 @@ mod tests {
         )
         .unwrap();
         assert!(called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_mapreduce_threaded_splits_cover_all_elements() {
+        // Verify that parallel splitting covers all elements
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let dims = vec![100, 100];
+        let blocks = vec![100, 100];
+        let strides = vec![vec![1isize, 100], vec![1, 100]];
+        let offsets = vec![0isize, 0];
+        let costs = vec![2, 200];
+
+        let total_elements = AtomicUsize::new(0);
+        mapreduce_threaded(
+            &dims,
+            &blocks,
+            &strides,
+            &offsets,
+            &costs,
+            4,
+            0,
+            1,
+            &|dims, _blocks, _strides, _offsets| {
+                let n: usize = dims.iter().product();
+                total_elements.fetch_add(n, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(total_elements.load(Ordering::SeqCst), 10000);
+    }
+
+    #[test]
+    fn test_mapreduce_threaded_with_spacing() {
+        // Verify spacing/taskindex base case applies offsets correctly
+        use std::sync::atomic::{AtomicI64, Ordering};
+        let dims = vec![10];
+        let blocks = vec![10];
+        let strides = vec![vec![0isize], vec![1]];
+        let offsets = vec![0isize, 0];
+        let costs = vec![2];
+
+        let received_offset = AtomicI64::new(0);
+        mapreduce_threaded(
+            &dims,
+            &blocks,
+            &strides,
+            &offsets,
+            &costs,
+            1,
+            8,
+            3, // spacing=8, taskindex=3
+            &|_dims, _blocks, _strides, offsets| {
+                received_offset.store(offsets[0] as i64, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .unwrap();
+        // offset[0] should be 8 * (3 - 1) = 16
+        assert_eq!(received_offset.load(Ordering::SeqCst), 16);
     }
 }


### PR DESCRIPTION
## Summary
- Eliminate `scores: Vec<isize>` allocation by replacing `lastargmax()` with an inline streaming fold (zero allocation)
- Replace 6 `.to_vec()` heap allocations with `SmallVec<[T; 8]>::from_slice()` for `dims` and `offsets` — stack-resident for typical rank 2–4
- Add `smallvec` as optional dependency gated on the `parallel` feature
- Remove unused `lastargmax` function
- Add tests for streaming argmax semantics, parallel split element coverage, and spacing/taskindex

Closes #26

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (all features)
- [x] `cargo test --features parallel` passes
- [x] `bash strided-kernel/benches/run_all.sh` shows no performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)