### PR TITLE
refactor: deduplicate compute_costs (fuse vs threading)

### DIFF
--- a/strided-kernel/src/fuse.rs
+++ b/strided-kernel/src/fuse.rs
@@ -173,15 +173,16 @@ pub fn sort_by_importance(importance: &[u64]) -> Vec<usize> {
 /// Compute the minimum stride cost for each dimension.
 ///
 /// Julia: `costs = map(a -> ifelse(iszero(a), 1, a << 1), map(min, strides...))`
-pub fn compute_costs(all_strides: &[&[isize]]) -> Vec<isize> {
+pub fn compute_costs<S: AsRef<[isize]>>(all_strides: &[S]) -> Vec<isize> {
     if all_strides.is_empty() {
         return vec![];
     }
 
-    let n = all_strides[0].len();
+    let n = all_strides[0].as_ref().len();
     let mut costs = vec![isize::MAX; n];
 
     for strides in all_strides {
+        let strides = strides.as_ref();
         for i in 0..n {
             costs[i] = costs[i].min(strides[i].abs());
         }
@@ -342,6 +343,14 @@ mod tests {
 
         // Output has 2x weight, so dimension 0 (smaller stride in output) wins
         assert!(importance[0] > importance[1]);
+    }
+
+    #[test]
+    fn test_compute_costs_owned_vecs() {
+        // Ported from threading.rs: verify compute_costs works with Vec<Vec<isize>>
+        let strides_list: Vec<Vec<isize>> = vec![vec![1, 0, 3], vec![2, 0, 4]];
+        let costs = compute_costs(&strides_list);
+        assert_eq!(costs, vec![2, 1, 6]);
     }
 
     #[test]

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -13,9 +13,9 @@ use crate::Result;
 use strided_view::{ElementOp, ElementOpApply};
 
 #[cfg(feature = "parallel")]
-use crate::threading::{
-    compute_costs, for_each_inner_block_with_offsets, mapreduce_threaded, MINTHREADLENGTH,
-};
+use crate::fuse::compute_costs;
+#[cfg(feature = "parallel")]
+use crate::threading::{for_each_inner_block_with_offsets, mapreduce_threaded, MINTHREADLENGTH};
 
 // ============================================================================
 // Stride-specialized inner loop helpers
@@ -237,7 +237,7 @@ pub fn map_into<T: Copy + ElementOpApply + MaybeSendSync, Op: ElementOp>(
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -331,7 +331,7 @@ pub fn zip_map2_into<T: Copy + ElementOpApply + MaybeSendSync, OpA: ElementOp, O
             let a_send = SendPtr(a_ptr as *mut T);
             let b_send = SendPtr(b_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -446,7 +446,7 @@ pub fn zip_map3_into<
             let b_send = SendPtr(b_ptr as *mut T);
             let c_send = SendPtr(c_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -587,7 +587,7 @@ pub fn zip_map4_into<
             let c_send = SendPtr(c_ptr as *mut T);
             let e_send = SendPtr(e_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 

--- a/strided-kernel/src/ops_view.rs
+++ b/strided-kernel/src/ops_view.rs
@@ -16,8 +16,10 @@ use std::ops::{Add, Mul};
 use strided_view::{ElementOp, ElementOpApply};
 
 #[cfg(feature = "parallel")]
+use crate::fuse::compute_costs;
+#[cfg(feature = "parallel")]
 use crate::threading::{
-    compute_costs, for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
+    for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
 };
 
 // ============================================================================
@@ -265,7 +267,7 @@ pub fn add<T: Copy + ElementOpApply + Add<Output = T> + MaybeSendSync, Op: Eleme
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -360,7 +362,7 @@ pub fn mul<T: Copy + ElementOpApply + Mul<Output = T> + MaybeSendSync, Op: Eleme
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -459,7 +461,7 @@ pub fn axpy<
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 
@@ -562,7 +564,7 @@ pub fn fma<T: Copy + ElementOpApply + Mul<Output = T> + Add<Output = T> + MaybeS
             let a_send = SendPtr(a_ptr as *mut T);
             let b_send = SendPtr(b_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
             let nthreads = rayon::current_num_threads();
 

--- a/strided-kernel/src/reduce_view.rs
+++ b/strided-kernel/src/reduce_view.rs
@@ -10,8 +10,10 @@ use crate::{Result, StridedError};
 use strided_view::{ElementOp, ElementOpApply};
 
 #[cfg(feature = "parallel")]
+use crate::fuse::compute_costs;
+#[cfg(feature = "parallel")]
 use crate::threading::{
-    compute_costs, for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
+    for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
 };
 
 /// Full reduction with map function: `reduce(init, op, map.(src))`.
@@ -58,7 +60,7 @@ where
             let threadedout_ptr = SendPtr(threadedout.as_mut_ptr());
             let src_send = SendPtr(src_ptr as *mut T);
 
-            let costs = compute_costs(&ordered_strides, fused_dims.len());
+            let costs = compute_costs(&ordered_strides);
 
             // For complete reduction, strides_list has 2 entries:
             // [0] = threadedout (stride 0 everywhere — broadcasting), [1] = src


### PR DESCRIPTION
## Summary

Closes #28

- Generalize `compute_costs` in `fuse.rs` to accept `&[S]` where `S: AsRef<[isize]>`, so both `&[&[isize]]` (from `block.rs`) and `&[Vec<isize>]` (from parallel call sites) work without adapter code
- Remove the duplicate `compute_costs` from `threading.rs`
- Update imports and call sites in `map_view.rs` (4), `ops_view.rs` (4), `reduce_view.rs` (1)
- Port the threading test to `fuse.rs` as `test_compute_costs_owned_vecs`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (without `parallel` feature)
- [x] `cargo test --features parallel` passes
- [x] `bash strided-kernel/benches/run_all.sh` — no performance regression (single-threaded and multi-threaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)