### PR TITLE
improve: opteinsum robustness, differential tests, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,13 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+  doc:
+    name: cargo doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build docs
+        run: cargo doc --workspace --no-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build docs
+        run: cargo doc --workspace --no-deps
+      - name: Prepare Pages artifact
+        run: |
+          touch target/doc/.nojekyll
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # strided-rs
 
-Cache-optimized kernels for strided multidimensional array operations in Rust.
+`strided-rs` is a Rust workspace for strided tensor views, kernels, and einsum.
+It is inspired by Julia's [Strided.jl](https://github.com/Jutho/Strided.jl),
+[StridedViews.jl](https://github.com/Jutho/StridedViews.jl), and
+[OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl).
 
-This crate is a port of Julia's [Strided.jl](https://github.com/Jutho/Strided.jl) and [StridedViews.jl](https://github.com/Jutho/StridedViews.jl) libraries.
+## Workspace Layout
+
+- [`strided-view`](strided-view/README.md): core dynamic-rank strided view/array types and metadata ops
+- [`strided-kernel`](strided-kernel/README.md): cache-optimized elementwise/reduction kernels over strided views
+- [`strided-einsum2`](strided-einsum2/README.md): binary einsum (`einsum2_into`) on strided tensors
+- [`strided-opteinsum`](strided-opteinsum/README.md): N-ary einsum frontend with nested notation and contraction-order optimization
 
 ## Features
 
@@ -15,14 +23,32 @@ This crate is a port of Julia's [Strided.jl](https://github.com/Jutho/Strided.jl
 
 ## Installation
 
-This crate is currently **not published to crates.io** (`publish = false` in `Cargo.toml`).
-
-For local development, add a path dependency:
+These crates are currently **not published to crates.io** (`publish = false`).
+Use workspace path dependencies:
 
 ```toml
 [dependencies]
+strided-view = { path = "../strided-rs/strided-view" }
 strided-kernel = { path = "../strided-rs/strided-kernel" }
+strided-einsum2 = { path = "../strided-rs/strided-einsum2" }
+strided-opteinsum = { path = "../strided-rs/strided-opteinsum" }
 ```
+
+## Documentation
+
+Generate API docs locally:
+
+```bash
+cargo doc --workspace --no-deps
+```
+
+Open docs locally:
+
+```bash
+open target/doc/index.html
+```
+
+CI also builds rustdoc on PRs and deploys workspace docs to GitHub Pages on `main`.
 
 ## Quick Start
 
@@ -343,6 +369,8 @@ Both compute a combined importance score over all 5 arrays (output + 4 inputs) a
 This crate is inspired by and ports functionality from:
 - [Strided.jl](https://github.com/Jutho/Strided.jl) by Jutho
 - [StridedViews.jl](https://github.com/Jutho/StridedViews.jl) by Jutho
+- [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl) for
+  `strided-opteinsum` design ideas and reference test-case patterns
 
 ## License
 

--- a/strided-einsum2/src/plan.rs
+++ b/strided-einsum2/src/plan.rs
@@ -163,7 +163,7 @@ impl<ID: AxisId> Einsum2Plan<ID> {
             .collect()
     }
 
-    /// Get the inverse of c_to_internal_perm (maps [batch,lo,ro] back to IC order).
+    /// Get the inverse of c_to_internal_perm (maps `\[batch, lo, ro\]` back to IC order).
     pub fn internal_to_c_perm(&self) -> Vec<usize> {
         invert_perm(&self.c_to_internal_perm)
     }

--- a/strided-einsum2/src/util.rs
+++ b/strided-einsum2/src/util.rs
@@ -1,6 +1,6 @@
 //! Shared helpers for strided-einsum2.
 
-/// Invert a permutation: if perm[i] = j, then result[j] = i.
+/// Invert a permutation: if `perm[i] = j`, then `result[j] = i`.
 pub fn invert_perm(perm: &[usize]) -> Vec<usize> {
     let mut inv = vec![0usize; perm.len()];
     for (i, &p) in perm.iter().enumerate() {

--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -1,0 +1,28 @@
+# strided-kernel
+
+Cache-optimized compute kernels over `strided-view` tensors.
+
+## Scope
+
+- Unary/Binary/N-ary map kernels (`map_into`, `zip_map*_into`)
+- Reductions (`reduce`, `reduce_axis`)
+- Utility ops (`copy_into`, `add`, `dot`, `sum`, `symmetrize_into`)
+- Optional parallel execution via `parallel` feature (Rayon)
+
+## Quick Example
+
+```rust
+use strided_kernel::{map_into, StridedArray};
+
+let src = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 3 + idx[1]) as f64);
+let mut dst = StridedArray::<f64>::row_major(&[2, 3]);
+map_into(&mut dst.view_mut(), &src.view(), |x| 2.0 * x).unwrap();
+assert_eq!(dst.get(&[1, 2]), 10.0);
+```
+
+## Parallel Feature
+
+```toml
+[dependencies]
+strided-kernel = { path = "../strided-kernel", features = ["parallel"] }
+```

--- a/strided-opteinsum/Cargo.toml
+++ b/strided-opteinsum/Cargo.toml
@@ -15,4 +15,5 @@ thiserror = "1.0"
 [dev-dependencies]
 approx = "0.5"
 num-complex = "0.4"
+rand = "0.8"
 strided-view = { path = "../strided-view" }

--- a/strided-opteinsum/README.md
+++ b/strided-opteinsum/README.md
@@ -1,0 +1,27 @@
+# strided-opteinsum
+
+N-ary einsum frontend built on `strided-view`, `strided-kernel`, and `strided-einsum2`.
+
+## Scope
+
+- String parser for einsum with nested notation (example: `"(ij,jk),kl->il"`)
+- Mixed `f64` / `Complex64` operands with promotion to complex when needed
+- Single-tensor ops (permute/trace/partial-trace/diagonal extraction)
+- 3+ tensor contraction-order optimization via `omeco`
+
+## Quick Example
+
+```rust
+use strided_opteinsum::{einsum, EinsumOperand};
+use strided_view::StridedArray;
+
+let a = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| (idx[0] * 2 + idx[1] + 1) as f64);
+let b = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| (idx[0] * 2 + idx[1] + 5) as f64);
+let out = einsum("ij,jk->ik", vec![EinsumOperand::from(a), EinsumOperand::from(b)]).unwrap();
+assert!(out.is_f64());
+```
+
+## Notes
+
+- Current parser accepts ASCII lowercase index labels.
+- Generative output notation such as `->ii` is tracked in GitHub issues.

--- a/strided-opteinsum/src/error.rs
+++ b/strided-opteinsum/src/error.rs
@@ -18,6 +18,12 @@ pub enum EinsumError {
 
     #[error("output axis '{0}' not found in any input")]
     OrphanOutputAxis(String),
+
+    #[error("operand count mismatch: expected {expected}, found {found}")]
+    OperandCountMismatch { expected: usize, found: usize },
+
+    #[error("internal error: {0}")]
+    Internal(String),
 }
 
 pub type Result<T> = std::result::Result<T, EinsumError>;

--- a/strided-opteinsum/src/single_tensor.rs
+++ b/strided-opteinsum/src/single_tensor.rs
@@ -120,15 +120,13 @@ where
     }
 
     // Compute permutation: for each output axis, find its position in current_ids.
-    let perm: Vec<usize> = output_ids
-        .iter()
-        .map(|oc| {
-            current_ids
-                .iter()
-                .position(|c| c == oc)
-                .expect("output axis not found in current axes")
-        })
-        .collect();
+    let mut perm: Vec<usize> = Vec::with_capacity(output_ids.len());
+    for oc in output_ids {
+        match current_ids.iter().position(|c| c == oc) {
+            Some(pos) => perm.push(pos),
+            None => return Err(crate::EinsumError::OrphanOutputAxis(oc.to_string())),
+        }
+    }
 
     let permuted_view = result_arr.view().permute(&perm)?;
     let out_dims = permuted_view.dims().to_vec();

--- a/strided-opteinsum/tests/support/loop_einsum.rs
+++ b/strided-opteinsum/tests/support/loop_einsum.rs
@@ -1,0 +1,185 @@
+use std::collections::HashMap;
+
+use num_complex::Complex64;
+use strided_opteinsum::{parse_einsum, EinsumNode};
+use strided_view::{row_major_strides, StridedArray};
+
+#[derive(Clone)]
+pub enum LoopTensor {
+    F64(StridedArray<f64>),
+    C64(StridedArray<Complex64>),
+}
+
+impl LoopTensor {
+    pub fn dims(&self) -> &[usize] {
+        match self {
+            LoopTensor::F64(a) => a.dims(),
+            LoopTensor::C64(a) => a.dims(),
+        }
+    }
+}
+
+pub fn row_major_f64(dims: &[usize], data: Vec<f64>) -> LoopTensor {
+    let strides = row_major_strides(dims);
+    let arr = StridedArray::from_parts(data, dims, &strides, 0).expect("valid row-major f64 array");
+    LoopTensor::F64(arr)
+}
+
+pub fn row_major_c64(dims: &[usize], data: Vec<Complex64>) -> LoopTensor {
+    let strides = row_major_strides(dims);
+    let arr = StridedArray::from_parts(data, dims, &strides, 0).expect("valid row-major c64 array");
+    LoopTensor::C64(arr)
+}
+
+fn collect_leaf_ids(node: &EinsumNode, out: &mut Vec<Option<Vec<char>>>) -> Result<(), String> {
+    match node {
+        EinsumNode::Leaf { ids, tensor_index } => {
+            if *tensor_index >= out.len() {
+                out.resize_with(*tensor_index + 1, || None);
+            }
+            if out[*tensor_index].is_some() {
+                return Err(format!("duplicate tensor index {tensor_index}"));
+            }
+            out[*tensor_index] = Some(ids.clone());
+            Ok(())
+        }
+        EinsumNode::Contract { args } => {
+            for arg in args {
+                collect_leaf_ids(arg, out)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn operand_value(operand: &LoopTensor, positions: &[usize], assignment: &[usize]) -> Complex64 {
+    let mut idx = Vec::with_capacity(positions.len());
+    for &pos in positions {
+        idx.push(assignment[pos]);
+    }
+    match operand {
+        LoopTensor::F64(arr) => Complex64::new(arr.get(&idx), 0.0),
+        LoopTensor::C64(arr) => arr.get(&idx),
+    }
+}
+
+fn accumulate_recursive(
+    depth: usize,
+    label_dims: &[usize],
+    assignment: &mut [usize],
+    operands: &[LoopTensor],
+    op_positions: &[Vec<usize>],
+    out: &mut StridedArray<Complex64>,
+    out_positions: &[usize],
+) {
+    if depth == label_dims.len() {
+        let mut term = Complex64::new(1.0, 0.0);
+        for (operand, positions) in operands.iter().zip(op_positions.iter()) {
+            term *= operand_value(operand, positions, assignment);
+        }
+
+        let mut out_idx = Vec::with_capacity(out_positions.len());
+        for &pos in out_positions {
+            out_idx.push(assignment[pos]);
+        }
+        let prev = out.get(&out_idx);
+        out.set(&out_idx, prev + term);
+        return;
+    }
+
+    for i in 0..label_dims[depth] {
+        assignment[depth] = i;
+        accumulate_recursive(
+            depth + 1,
+            label_dims,
+            assignment,
+            operands,
+            op_positions,
+            out,
+            out_positions,
+        );
+    }
+}
+
+pub fn loop_einsum_complex(
+    notation: &str,
+    operands: &[LoopTensor],
+) -> Result<StridedArray<Complex64>, String> {
+    let code = parse_einsum(notation).map_err(|e| e.to_string())?;
+
+    let mut leaf_ids_opt: Vec<Option<Vec<char>>> = vec![None; operands.len()];
+    collect_leaf_ids(&code.root, &mut leaf_ids_opt)?;
+    if leaf_ids_opt.len() != operands.len() || leaf_ids_opt.iter().any(|x| x.is_none()) {
+        return Err(format!(
+            "operand count mismatch in reference evaluator: expected {}, found {}",
+            leaf_ids_opt.len(),
+            operands.len()
+        ));
+    }
+    let leaf_ids: Vec<Vec<char>> = leaf_ids_opt
+        .into_iter()
+        .map(|ids| ids.expect("checked above"))
+        .collect();
+
+    let mut dim_map: HashMap<char, usize> = HashMap::new();
+    let mut label_order: Vec<char> = Vec::new();
+
+    for (i, ids) in leaf_ids.iter().enumerate() {
+        let dims = operands[i].dims();
+        if ids.len() != dims.len() {
+            return Err(format!(
+                "rank mismatch for operand {i}: ids={}, dims={}",
+                ids.len(),
+                dims.len()
+            ));
+        }
+        for (&id, &dim) in ids.iter().zip(dims.iter()) {
+            match dim_map.get(&id) {
+                Some(&existing) if existing != dim => {
+                    return Err(format!(
+                        "dimension mismatch for label '{id}': {existing} vs {dim}"
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    dim_map.insert(id, dim);
+                    label_order.push(id);
+                }
+            }
+        }
+    }
+
+    for &id in &code.output_ids {
+        if !dim_map.contains_key(&id) {
+            return Err(format!(
+                "orphan output label '{id}' is not supported in loop_einsum"
+            ));
+        }
+    }
+
+    let mut label_pos: HashMap<char, usize> = HashMap::new();
+    for (i, &label) in label_order.iter().enumerate() {
+        label_pos.insert(label, i);
+    }
+
+    let label_dims: Vec<usize> = label_order.iter().map(|label| dim_map[label]).collect();
+    let op_positions: Vec<Vec<usize>> = leaf_ids
+        .iter()
+        .map(|ids| ids.iter().map(|id| label_pos[id]).collect())
+        .collect();
+    let out_positions: Vec<usize> = code.output_ids.iter().map(|id| label_pos[id]).collect();
+    let out_dims: Vec<usize> = code.output_ids.iter().map(|id| dim_map[id]).collect();
+
+    let mut out = StridedArray::<Complex64>::col_major(&out_dims);
+    let mut assignment = vec![0usize; label_order.len()];
+    accumulate_recursive(
+        0,
+        &label_dims,
+        &mut assignment,
+        operands,
+        &op_positions,
+        &mut out,
+        &out_positions,
+    );
+    Ok(out)
+}

--- a/strided-view/README.md
+++ b/strided-view/README.md
@@ -1,0 +1,25 @@
+# strided-view
+
+Core dynamic-rank strided tensor view types and metadata-only transformations.
+
+## Scope
+
+- `StridedView` / `StridedViewMut`
+- `StridedArray`
+- Stride/layout helpers (`row_major_strides`, `col_major_strides`)
+- Zero-copy metadata ops (`permute`, `transpose_2d`, `broadcast`, `diagonal_view`)
+
+`strided-view` does not implement heavy compute kernels by itself.
+Use `strided-kernel` for map/reduce operations.
+
+## Quick Example
+
+```rust
+use strided_view::StridedArray;
+
+let a = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 10 + idx[1]) as f64);
+let v = a.view();
+let vt = v.permute(&[1, 0]).unwrap();
+assert_eq!(vt.dims(), &[3, 2]);
+assert_eq!(vt.get(&[2, 1]), 12.0);
+```


### PR DESCRIPTION
## Summary

- Replace `panic!`/`.expect()` with proper `EinsumError` returns (`OperandCountMismatch`, `OrphanOutputAxis`, `Internal`) in expr.rs, single_tensor.rs, parse.rs
- Add operand count validation in `EinsumCode::evaluate()` via `leaf_count()` helper
- Add empty operand detection in parser (double comma `ij,,jk->ik`, trailing comma `ij,->i`)
- Add differential tests: loop-based reference evaluator (`loop_einsum_complex`) compared against `einsum` with 30 f64 + 20 c64 random cases
- Add per-crate README files and update workspace README with layout overview
- Add `cargo doc` CI step
- Fix rustdoc bracket escaping in einsum2 doc comments

## Test plan

- [x] 5 new error-path unit tests (operand count mismatch, orphan output axis, empty operand parsing)
- [x] 2 new differential integration tests (f64 + c64, 50 random cases total)
- [x] All 230 tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo doc --workspace --no-deps` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)