### PR TITLE
perf: propagate borrowed views through eval_node (fixes #50)

### DIFF
--- a/docs/plans/2026-02-07-eval-node-lifetime-design.md
+++ b/docs/plans/2026-02-07-eval-node-lifetime-design.md
@@ -1,0 +1,128 @@
+# eval_node Lifetime Refactor: Propagate Borrowed Views
+
+GitHub Issue: #50
+
+## Problem
+
+`eval_node` returns `EinsumOperand<'static>`, forcing `to_owned_static()` on every Leaf operand. This copies the entire input tensor even when only a small subset is needed (trace, diagonal, ptrace). The `eval_single_ref`/`eval_pair_ref` workarounds only help when children are immediate Leaves of a Contract node.
+
+Remaining copy sites:
+- Binary contraction with one Leaf, one Contract child — the Leaf gets copied
+- N-ary (3+) contractions — all Leaf children get copied
+- Any deeper tree nesting where a Leaf isn't a direct child of its consuming Contract
+
+## Solution
+
+### 1. Core Signature Change
+
+Thread lifetime `'a` through `eval_node` so borrowed views propagate from Leaf to consumer:
+
+```rust
+// Before:
+fn eval_node(
+    node: &EinsumNode,
+    operands: &mut Vec<Option<EinsumOperand<'_>>>,
+    needed_ids: &HashSet<char>,
+) -> Result<(EinsumOperand<'static>, Vec<char>)>
+
+// After:
+fn eval_node<'a>(
+    node: &EinsumNode,
+    operands: &mut Vec<Option<EinsumOperand<'a>>>,
+    needed_ids: &HashSet<char>,
+) -> Result<(EinsumOperand<'a>, Vec<char>)>
+```
+
+Leaf branch returns the operand directly via `.take()` — no `to_owned_static()`.
+
+Contract results are `EinsumOperand<'static>` (freshly allocated), which coerces to `EinsumOperand<'a>` since `'static: 'a`.
+
+Entry point changes accordingly:
+
+```rust
+pub fn evaluate<'a>(&self, operands: Vec<EinsumOperand<'a>>) -> Result<EinsumOperand<'a>>
+```
+
+### 2. Simplified Contract Branches
+
+All Contract branches become uniform — no Leaf-detection special cases:
+
+**Single-tensor (1 arg):**
+```rust
+let (child_op, child_ids) = eval_node(&args[0], operands, &needed_ids)?;
+// identity/permutation passthrough (see section 3) or:
+let result = eval_single_ref(&child_op, &child_ids, &output_ids)?;
+```
+
+**Binary (2 args):**
+```rust
+let (left_op, left_ids) = eval_node(&args[0], operands, &needed_ids)?;
+let (right_op, right_ids) = eval_node(&args[1], operands, &needed_ids)?;
+let result = eval_pair_ref(&left_op, &left_ids, &right_op, &right_ids, &output_ids)?;
+```
+
+**N-ary (3+ args):**
+```rust
+let mut children: Vec<(EinsumOperand<'a>, Vec<char>)> = args.iter()
+    .map(|arg| eval_node(arg, operands, &needed_ids))
+    .collect::<Result<_>>()?;
+execute_nested(&mut children, &tree, &output_ids)  // signature updated to 'a
+```
+
+`execute_nested` updated to accept `EinsumOperand<'a>` and use `eval_pair_ref` internally.
+
+### 3. Additional Zero-Copy Optimizations
+
+**Identity passthrough:** When `input_ids == output_ids`, return the operand directly with no allocation:
+
+```rust
+if child_ids == output_ids {
+    return Ok((child_op, output_ids));
+}
+```
+
+**Permutation-only passthrough:** When input and output ids are the same set (same length, no repeats, just reordered), permute dims/strides metadata without touching the data buffer:
+
+```rust
+if is_permutation_only(&child_ids, &output_ids) {
+    let perm = compute_permutation(&child_ids, &output_ids);
+    let permuted = child_op.permuted(perm);
+    return Ok((permuted, output_ids));
+}
+```
+
+Requires new `permuted()` method on `StridedData`/`EinsumOperand` and a new `StridedArray::permuted()` method that reorders dims/strides Arcs (metadata only, no data copy). `StridedView::permute()` already exists and is zero-copy.
+
+Detection: `is_permutation_only` checks that input_ids and output_ids have the same length, same set of chars, and no char appears more than once in either (rules out trace).
+
+### 4. Code Removal
+
+Remove dead code after the refactor:
+- `to_owned_static()` method on `EinsumOperand`
+- `eval_pair` (consuming version) — replaced by `eval_pair_ref` everywhere
+- `eval_single` (consuming version) — replaced by `eval_single_ref` everywhere
+- Leaf-detection branches in single-arg and binary-arg Contract cases
+
+### 5. Impact Summary
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Leaf in non-trivial tree | full tensor copy | zero-copy |
+| Identity single-tensor | allocate + copy | zero-cost passthrough |
+| Permutation-only single-tensor | allocate + copy | metadata reorder only |
+| Trace/reduction | allocate + compute | same (unavoidable) |
+| Binary contraction output | allocate + compute | same (unavoidable) |
+
+## Files Changed
+
+- `strided-opteinsum/src/expr.rs` — `eval_node`, `evaluate`, remove `eval_pair`/`eval_single`/`to_owned_static`, simplify Contract branches
+- `strided-opteinsum/src/operand.rs` — add `permuted()` to `StridedData` and `EinsumOperand`
+- `strided-view/src/view.rs` — add `StridedArray::permuted()` (metadata-only dim/stride reorder)
+
+## Testing
+
+1. All existing einsum tests pass (baseline correctness)
+2. View operands in 3+ operand expressions with non-trivial tree structure
+3. Permutation-only passthrough correctness
+4. Mixed owned/view operands in the same expression
+5. Benchmark validation with `RAYON_NUM_THREADS=1` — no regression, improvement for View inputs in n-ary cases

--- a/strided-opteinsum/README.md
+++ b/strided-opteinsum/README.md
@@ -42,54 +42,54 @@ Environment: Apple Silicon M2, single-threaded. Mean time (ms).
 
 | Case | Julia OMEinsum (ms) | Rust strided-opteinsum (ms) |
 |---|---:|---:|
-| matmul (1) square 1000×1000 Float64 | 40.121 | 42.859 |
-| matmul (1) square 1000×1000 ComplexF64 | 201.803 | 230.800 |
-| matmul (2) (2000,50)×(50,2000) Float64 | 9.613 | 9.966 |
-| matmul (2) (2000,50)×(50,2000) ComplexF64 | 44.214 | 46.754 |
-| matmul (3) (50,2000)×(2000,50) Float64 | 0.262 | 0.351 |
-| matmul (3) (50,2000)×(2000,50) ComplexF64 | 1.098 | 1.476 |
-| batchmul (1) square b=3 1000³ Float64 | 120.510 | 165.476 |
-| batchmul (1) square b=3 1000³ ComplexF64 | 606.124 | 713.732 |
-| batchmul (2) b=3 (2000,50)×(50,2000) Float64 | 28.576 | 35.187 |
-| batchmul (2) b=3 (2000,50)×(50,2000) ComplexF64 | 130.857 | 153.312 |
-| batchmul (3) b=3 (50,2000)×(2000,50) Float64 | 0.778 | 0.886 |
-| batchmul (3) b=3 (50,2000)×(2000,50) ComplexF64 | 3.344 | 4.167 |
-| dot (1) square 100³ Float64 | 5.459 | 0.226 |
-| dot (1) square 100³ ComplexF64 | 4.872 | 0.775 |
-| dot (2) (2000,50,2000) Float64 | 1096.416 | 58.041 |
-| dot (2) (2000,50,2000) ComplexF64 | 978.969 | 150.506 |
-| dot (3) (50,2000,50) Float64 | 27.319 | 2.153 |
-| dot (3) (50,2000,50) ComplexF64 | 24.567 | 3.464 |
-| trace 1000×1000 Float64 | 0.003 | 0.001 |
+| matmul (1) square 1000×1000 Float64 | 40.121 | 45.426 |
+| matmul (1) square 1000×1000 ComplexF64 | 201.803 | 240.058 |
+| matmul (2) (2000,50)×(50,2000) Float64 | 9.613 | 9.716 |
+| matmul (2) (2000,50)×(50,2000) ComplexF64 | 44.214 | 48.040 |
+| matmul (3) (50,2000)×(2000,50) Float64 | 0.262 | 0.306 |
+| matmul (3) (50,2000)×(2000,50) ComplexF64 | 1.098 | 1.399 |
+| batchmul (1) square b=3 1000³ Float64 | 120.510 | 134.531 |
+| batchmul (1) square b=3 1000³ ComplexF64 | 606.124 | 720.396 |
+| batchmul (2) b=3 (2000,50)×(50,2000) Float64 | 28.576 | 30.488 |
+| batchmul (2) b=3 (2000,50)×(50,2000) ComplexF64 | 130.857 | 142.431 |
+| batchmul (3) b=3 (50,2000)×(2000,50) Float64 | 0.778 | 0.972 |
+| batchmul (3) b=3 (50,2000)×(2000,50) ComplexF64 | 3.344 | 4.720 |
+| dot (1) square 100³ Float64 | 5.459 | 0.252 |
+| dot (1) square 100³ ComplexF64 | 4.872 | 0.663 |
+| dot (2) (2000,50,2000) Float64 | 1096.416 | 60.504 |
+| dot (2) (2000,50,2000) ComplexF64 | 978.969 | 137.299 |
+| dot (3) (50,2000,50) Float64 | 27.319 | 1.552 |
+| dot (3) (50,2000,50) ComplexF64 | 24.567 | 3.525 |
+| trace 1000×1000 Float64 | 0.003 | 0.002 |
 | trace 1000×1000 ComplexF64 | 0.004 | 0.001 |
-| ptrace (100,100,100)→(100) Float64 | 0.020 | 0.009 |
-| ptrace (100,100,100)→(100) ComplexF64 | 0.029 | 0.012 |
-| diag (100,100,100)→(100,100) Float64 | 0.016 | 0.006 |
-| diag (100,100,100)→(100,100) ComplexF64 | 0.023 | 0.010 |
-| perm (30,30,30,30) Float64 | 0.567 | 1.556 |
-| perm (30,30,30,30) ComplexF64 | 0.835 | 1.973 |
-| tcontract (1) square 30³ Float64 | 0.073 | 0.287 |
-| tcontract (1) square 30³ ComplexF64 | 0.225 | 0.703 |
-| tcontract (2) (2000,50,50)×(50,2000,50) Float64 | 405.114 | 484.457 |
-| tcontract (2) (2000,50,50)×(50,2000,50) ComplexF64 | 1985.169 | 2462.706 |
-| tcontract (3) (50,2000,2000)×(2000,50,2000) Float64 | 719.871 | 779.809 |
-| tcontract (3) (50,2000,2000)×(2000,50,2000) ComplexF64 | 4017.383 | 3548.229 |
-| star (50,50) Float64 | 2.540 | 2.117 |
-| star (50,50) ComplexF64 | 6.403 | 4.481 |
-| starandcontract (50,50) Float64 | 0.111 | 0.071 |
-| starandcontract (50,50) ComplexF64 | 0.126 | 0.095 |
-| indexsum (100,100,100)→(100,100) Float64 | 0.163 | 1.787 |
-| indexsum (100,100,100)→(100,100) ComplexF64 | 1.270 | 1.119 |
-| hadamard (100,100,100) Float64 | 0.196 | 0.439 |
-| hadamard (100,100,100) ComplexF64 | 0.755 | 1.397 |
-| outer (1) square 40⁴ Float64 | 1.455 | 1.592 |
-| outer (1) square 40⁴ ComplexF64 | 2.269 | 2.808 |
-| outer (2) (80,20)×(20,80) Float64 | 1.309 | 1.026 |
-| outer (2) (80,20)×(20,80) ComplexF64 | 2.272 | 2.545 |
-| outer (3) (20,80)×(80,20) Float64 | 1.217 | 0.939 |
-| outer (3) (20,80)×(80,20) ComplexF64 | 2.281 | 2.377 |
-| manyinds (12+12→13 indices, dim 2) Float64 | 0.067 | 0.374 |
-| manyinds (12+12→13 indices, dim 2) ComplexF64 | 0.130 | 0.404 |
+| ptrace (100,100,100)→(100) Float64 | 0.020 | 0.008 |
+| ptrace (100,100,100)→(100) ComplexF64 | 0.029 | 0.013 |
+| diag (100,100,100)→(100,100) Float64 | 0.016 | 0.010 |
+| diag (100,100,100)→(100,100) ComplexF64 | 0.023 | 0.015 |
+| perm (30,30,30,30) Float64 | 0.567 | 0.002 |
+| perm (30,30,30,30) ComplexF64 | 0.835 | 0.001 |
+| tcontract (1) square 30³ Float64 | 0.073 | 0.070 |
+| tcontract (1) square 30³ ComplexF64 | 0.225 | 0.220 |
+| tcontract (2) (2000,50,50)×(50,2000,50) Float64 | 405.114 | 457.123 |
+| tcontract (2) (2000,50,50)×(50,2000,50) ComplexF64 | 1985.169 | 2416.238 |
+| tcontract (3) (50,2000,2000)×(2000,50,2000) Float64 | 719.871 | 786.455 |
+| tcontract (3) (50,2000,2000)×(2000,50,2000) ComplexF64 | 4017.383 | 3056.063 |
+| star (50,50) Float64 | 2.540 | 0.551 |
+| star (50,50) ComplexF64 | 6.403 | 1.847 |
+| starandcontract (50,50) Float64 | 0.111 | 0.037 |
+| starandcontract (50,50) ComplexF64 | 0.126 | 0.026 |
+| indexsum (100,100,100)→(100,100) Float64 | 0.163 | 0.718 |
+| indexsum (100,100,100)→(100,100) ComplexF64 | 1.270 | 1.226 |
+| hadamard (100,100,100) Float64 | 0.196 | 0.537 |
+| hadamard (100,100,100) ComplexF64 | 0.755 | 1.510 |
+| outer (1) square 40⁴ Float64 | 1.455 | 0.667 |
+| outer (1) square 40⁴ ComplexF64 | 2.269 | 1.531 |
+| outer (2) (80,20)×(20,80) Float64 | 1.309 | 0.661 |
+| outer (2) (80,20)×(20,80) ComplexF64 | 2.272 | 1.551 |
+| outer (3) (20,80)×(80,20) Float64 | 1.217 | 0.714 |
+| outer (3) (20,80)×(80,20) ComplexF64 | 2.281 | 1.499 |
+| manyinds (12+12→13 indices, dim 2) Float64 | 0.067 | 0.206 |
+| manyinds (12+12→13 indices, dim 2) ComplexF64 | 0.130 | 0.148 |
 
 ## Notes
 

--- a/strided-opteinsum/benches/perm.rs
+++ b/strided-opteinsum/benches/perm.rs
@@ -48,7 +48,7 @@ fn main() {
             .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
             .unwrap();
         match result {
-            EinsumOperand::F64(data) => black_box(data.as_array().data().as_ptr()),
+            EinsumOperand::F64(data) => black_box(data.as_view().ptr()),
             _ => unreachable!("expected f64 output"),
         };
     });
@@ -66,7 +66,7 @@ fn main() {
             .evaluate(vec![EinsumOperand::from_view_c64(&a_c_view)])
             .unwrap();
         match result {
-            EinsumOperand::C64(data) => black_box(data.as_array().data().as_ptr()),
+            EinsumOperand::C64(data) => black_box(data.as_view().ptr()),
             _ => unreachable!("expected complex output"),
         };
     });

--- a/strided-opteinsum/src/lib.rs
+++ b/strided-opteinsum/src/lib.rs
@@ -38,7 +38,7 @@ pub use typed_tensor::{needs_c64_promotion, TypedTensor};
 /// ```ignore
 /// let result = einsum("(ij,jk),kl->il", vec![a.into(), b.into(), c.into()])?;
 /// ```
-pub fn einsum(notation: &str, operands: Vec<EinsumOperand<'_>>) -> Result<EinsumOperand<'static>> {
+pub fn einsum<'a>(notation: &str, operands: Vec<EinsumOperand<'a>>) -> Result<EinsumOperand<'a>> {
     let code = parse_einsum(notation)?;
     code.evaluate(operands)
 }

--- a/strided-opteinsum/src/operand.rs
+++ b/strided-opteinsum/src/operand.rs
@@ -39,6 +39,16 @@ impl<'a, T> StridedData<'a, T> {
     }
 }
 
+impl<'a, T> StridedData<'a, T> {
+    /// Permute dimensions (metadata-only reorder, no data copy).
+    pub fn permuted(self, perm: &[usize]) -> strided_view::Result<Self> {
+        match self {
+            StridedData::Owned(arr) => Ok(StridedData::Owned(arr.permuted(perm)?)),
+            StridedData::View(view) => Ok(StridedData::View(view.permute(perm)?)),
+        }
+    }
+}
+
 impl<'a, T> StridedData<'a, T>
 where
     T: Copy + ElementOpApply + Send + Sync + Zero + Default,
@@ -84,6 +94,14 @@ impl<'a> EinsumOperand<'a> {
         match self {
             EinsumOperand::F64(data) => data.dims(),
             EinsumOperand::C64(data) => data.dims(),
+        }
+    }
+
+    /// Permute dimensions (metadata-only reorder, no data copy).
+    pub fn permuted(self, perm: &[usize]) -> crate::Result<Self> {
+        match self {
+            EinsumOperand::F64(data) => Ok(EinsumOperand::F64(data.permuted(perm)?)),
+            EinsumOperand::C64(data) => Ok(EinsumOperand::C64(data.permuted(perm)?)),
         }
     }
 


### PR DESCRIPTION
## Summary

- Change `eval_node` return type from `EinsumOperand<'static>` to `EinsumOperand<'a>`, allowing borrowed view operands to flow through the contraction tree without copying
- Add identity passthrough (skip allocation when `input_ids == output_ids`)
- Add permutation-only passthrough via zero-copy metadata reorder (`StridedArray::permuted()`, `EinsumOperand::permuted()`)
- Remove dead code: `to_owned_static`, consuming `eval_pair`/`eval_single`, `eval_pair_f64`/`eval_pair_c64`, and Leaf-detection special-case branches
- Simplify all Contract branches to uniform recursive eval + borrow pattern

### Performance highlights

| Case | Before | After | Speedup |
|---|---|---|---|
| perm f64 (30^4) | 1.556 ms | 0.002 ms | ~780x |
| perm c64 (30^4) | 1.973 ms | 0.001 ms | ~2000x |
| star f64 (50x50) | 2.117 ms | 0.551 ms | 3.8x |
| starandcontract f64 | 0.071 ms | 0.037 ms | 1.9x |
| outer f64 (40^4) | 1.592 ms | 0.667 ms | 2.4x |

Closes #50

## Test plan

- [x] All 231 existing tests pass (`cargo test`)
- [x] `cargo fmt --check` clean
- [x] All opteinsum benchmarks run successfully
- [x] Benchmark results updated in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)