### PR TITLE
feat: add einsum_into for writing results into pre-allocated output

### DIFF
--- a/strided-opteinsum/src/error.rs
+++ b/strided-opteinsum/src/error.rs
@@ -23,6 +23,18 @@ pub enum EinsumError {
     #[error("operand count mismatch: expected {expected}, found {found}")]
     OperandCountMismatch { expected: usize, found: usize },
 
+    #[error("type mismatch: output is {output_type} but computation requires {computed_type}")]
+    TypeMismatch {
+        output_type: &'static str,
+        computed_type: &'static str,
+    },
+
+    #[error("output shape mismatch: expected {expected:?}, got {got:?}")]
+    OutputShapeMismatch {
+        expected: Vec<usize>,
+        got: Vec<usize>,
+    },
+
     #[error("internal error: {0}")]
     Internal(String),
 }


### PR DESCRIPTION
## Summary

Closes #56.

- Add `einsum_into<T>` public API that writes results directly into a user-provided `StridedViewMut<T>` with alpha/beta scaling (`C = alpha * einsum(operands) + beta * C`)
- Add `EinsumScalar` sealed trait (implemented for `f64` and `Complex64`) for type-safe dispatch
- Binary root contractions write directly to user's buffer via `eval_pair_into` — zero allocation for the final output
- 3+ tensor (omeco) contractions use `execute_nested_into` — final contraction writes directly to user's buffer
- Single-tensor roots (permute, trace) use `accumulate_into` helper

## Key design decisions

- Only the **final contraction** uses the `_into` path; intermediate contractions still allocate temporaries as before
- `EinsumScalar` trait validates type compatibility upfront: `f64` output rejects `Complex64` operands; `Complex64` output promotes `f64` operands automatically
- Output shape is validated against the expected dimensions computed from operands + notation

## Test plan

- [x] 11 new unit tests covering: matmul, alpha/beta accumulation, permute, trace, omeco 3-tensor, nested, dot product, type mismatch error, shape mismatch error, Complex64 output, mixed f64+c64 promotion
- [x] All 260 existing tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)