### PR TITLE
feat: add per-file coverage CI with 80% threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,21 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage JSON
+        run: cargo llvm-cov --workspace --json --output-path coverage.json
+      - name: Check per-file thresholds
+        run: python3 scripts/check-coverage.py coverage.json
+
   doc:
     name: cargo doc
     runs-on: ubuntu-latest

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Per-file line coverage thresholds (%). Files not listed default to 'default'.",
+  "default": 80
+}

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Check per-file line coverage against thresholds defined in coverage-thresholds.json."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+    thresholds_path = root / "coverage-thresholds.json"
+
+    # Read thresholds
+    with open(thresholds_path) as f:
+        config = json.load(f)
+    default_threshold = config.get("default", 80)
+    file_thresholds = config.get("files", {})
+
+    # Read coverage JSON from stdin or first argument
+    if len(sys.argv) > 1:
+        with open(sys.argv[1]) as f:
+            cov_data = json.load(f)
+    else:
+        cov_data = json.load(sys.stdin)
+
+    files = cov_data["data"][0]["files"]
+    root_str = str(root) + "/"
+
+    failures = []
+    passed = 0
+
+    for entry in files:
+        abs_path = entry["filename"]
+        # Convert to relative path
+        if abs_path.startswith(root_str):
+            rel_path = abs_path[len(root_str):]
+        else:
+            rel_path = abs_path
+
+        lines = entry["summary"]["lines"]
+        percent = lines["percent"]
+        threshold = file_thresholds.get(rel_path, default_threshold)
+
+        if percent < threshold:
+            failures.append((rel_path, percent, threshold))
+        else:
+            passed += 1
+
+    # Print summary
+    total = passed + len(failures)
+    print(f"Coverage check: {passed}/{total} files passed\n")
+
+    if failures:
+        print("FAILED files:")
+        for path, actual, required in sorted(failures):
+            print(f"  {path}: {actual:.1f}% < {required}%")
+        print()
+        sys.exit(1)
+    else:
+        print("All files meet their coverage thresholds.")
+
+
+if __name__ == "__main__":
+    main()

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -26,6 +26,7 @@ criterion = "0.5"
 approx = "0.5"
 rand = "0.8"
 rand_distr = "0.4"
+num-complex = "0.4"
 
 [lib]
 bench = false

--- a/strided-kernel/tests/correctness_view.rs
+++ b/strided-kernel/tests/correctness_view.rs
@@ -1,7 +1,9 @@
 use approx::assert_relative_eq;
+use num_complex::Complex64;
 use strided_kernel::{
-    add, axpy, copy_into, copy_transpose_scale_into, dot, fma, map_into, mul, reduce, reduce_axis,
-    sum, symmetrize_into, zip_map2_into, zip_map4_into, StridedArray,
+    add, axpy, copy_conj, copy_into, copy_scale, copy_transpose_scale_into, dot, fma, map_into,
+    mul, reduce, reduce_axis, sum, symmetrize_conj_into, symmetrize_into, zip_map2_into,
+    zip_map3_into, zip_map4_into, StridedArray, StridedError,
 };
 
 fn make_tensor(rows: usize, cols: usize) -> StridedArray<f64> {
@@ -449,6 +451,898 @@ fn test_large_copy_into_permuted() {
     for i in (0..n).step_by(17) {
         for j in (0..n).step_by(19) {
             assert_relative_eq!(out.get(&[i, j]), a.get(&[j, i]), epsilon = 1e-10);
+        }
+    }
+}
+
+// ============================================================================
+// Additional coverage tests for ops_view.rs
+// ============================================================================
+
+// 1. mul — non-contiguous (permuted) path
+#[test]
+fn test_mul_permuted() {
+    let rows = 6;
+    let cols = 5;
+    let src =
+        StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| (idx[0] + idx[1] + 1) as f64);
+    let mut dest = StridedArray::<f64>::from_fn_col_major(&[cols, rows], |idx| {
+        (idx[0] * 2 + idx[1] + 1) as f64
+    });
+    // Snapshot dest values before mutation
+    let mut dest_orig = vec![0.0; cols * rows];
+    for i in 0..cols {
+        for j in 0..rows {
+            dest_orig[i * rows + j] = dest.get(&[i, j]);
+        }
+    }
+
+    let src_t = src.view().permute(&[1, 0]).unwrap(); // shape [cols, rows]
+    mul(&mut dest.view_mut(), &src_t).unwrap();
+
+    for i in 0..cols {
+        for j in 0..rows {
+            let expected = dest_orig[i * rows + j] * src.get(&[j, i]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 2. axpy — non-contiguous (permuted) path
+#[test]
+fn test_axpy_permuted() {
+    let rows = 6;
+    let cols = 5;
+    let x = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * cols + idx[1]) as f64
+    });
+    let mut y =
+        StridedArray::<f64>::from_fn_col_major(&[cols, rows], |idx| (idx[0] + idx[1]) as f64);
+    let mut y_orig = vec![0.0; cols * rows];
+    for i in 0..cols {
+        for j in 0..rows {
+            y_orig[i * rows + j] = y.get(&[i, j]);
+        }
+    }
+    let alpha = 3.5;
+
+    let x_t = x.view().permute(&[1, 0]).unwrap(); // shape [cols, rows]
+    axpy(&mut y.view_mut(), &x_t, alpha).unwrap();
+
+    for i in 0..cols {
+        for j in 0..rows {
+            let expected = alpha * x.get(&[j, i]) + y_orig[i * rows + j];
+            assert_relative_eq!(y.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 3. fma — non-contiguous (permuted) path
+#[test]
+fn test_fma_permuted() {
+    let rows = 6;
+    let cols = 5;
+    let a = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * cols + idx[1]) as f64
+    });
+    let b =
+        StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| (idx[0] + idx[1] + 1) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_col_major(&[cols, rows], |idx| (idx[0] * 3 + idx[1]) as f64);
+    let mut dest_orig = vec![0.0; cols * rows];
+    for i in 0..cols {
+        for j in 0..rows {
+            dest_orig[i * rows + j] = dest.get(&[i, j]);
+        }
+    }
+
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+    let b_t = b.view().permute(&[1, 0]).unwrap();
+    fma(&mut dest.view_mut(), &a_t, &b_t).unwrap();
+
+    for i in 0..cols {
+        for j in 0..rows {
+            let expected = dest_orig[i * rows + j] + a.get(&[j, i]) * b.get(&[j, i]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 4. dot — non-contiguous (permuted) path
+#[test]
+fn test_dot_permuted() {
+    let rows = 7;
+    let cols = 5;
+    let a = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * cols + idx[1]) as f64
+    });
+    let b =
+        StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| (idx[0] + idx[1] + 1) as f64);
+
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [cols, rows]
+    let b_t = b.view().permute(&[1, 0]).unwrap();
+
+    let result = dot(&a_t, &b_t).unwrap();
+
+    // dot should give same result regardless of memory layout
+    let mut expected = 0.0;
+    for i in 0..cols {
+        for j in 0..rows {
+            expected += a.get(&[j, i]) * b.get(&[j, i]);
+        }
+    }
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 5. sum — non-contiguous (permuted) path
+#[test]
+fn test_sum_permuted() {
+    let rows = 8;
+    let cols = 6;
+    let a = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * cols + idx[1]) as f64
+    });
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+
+    let result = sum(&a_t).unwrap();
+    let expected: f64 = a.iter().copied().sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 6. copy_into — with conj (element op) path using Complex64
+#[test]
+fn test_copy_into_conj_complex() {
+    let a = StridedArray::<Complex64>::from_fn_row_major(&[3, 4], |idx| {
+        Complex64::new((idx[0] * 4 + idx[1]) as f64, (idx[0] + idx[1]) as f64)
+    });
+    let mut out = StridedArray::<Complex64>::row_major(&[3, 4]);
+
+    let a_conj = a.view().conj();
+    copy_into(&mut out.view_mut(), &a_conj).unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            let expected = a.get(&[i, j]).conj();
+            assert_relative_eq!(out.get(&[i, j]).re, expected.re, epsilon = 1e-10);
+            assert_relative_eq!(out.get(&[i, j]).im, expected.im, epsilon = 1e-10);
+        }
+    }
+}
+
+// 7. copy_into — contiguous identity path (ptr::copy_nonoverlapping)
+#[test]
+fn test_copy_into_contiguous_identity() {
+    // Both src and dest are row-major contiguous => hits ptr::copy_nonoverlapping fast path
+    let a = StridedArray::<f64>::from_fn_row_major(&[10, 12], |idx| (idx[0] * 12 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[10, 12]);
+
+    copy_into(&mut out.view_mut(), &a.view()).unwrap();
+
+    for i in 0..10 {
+        for j in 0..12 {
+            assert_relative_eq!(out.get(&[i, j]), a.get(&[i, j]), epsilon = 1e-10);
+        }
+    }
+}
+
+// 8. copy_scale function
+#[test]
+fn test_copy_scale() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[5, 6], |idx| (idx[0] * 6 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[5, 6]);
+    let scale = 2.5;
+
+    copy_scale(&mut out.view_mut(), &a.view(), scale).unwrap();
+
+    for i in 0..5 {
+        for j in 0..6 {
+            let expected = scale * a.get(&[i, j]);
+            assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 9. copy_conj function
+#[test]
+fn test_copy_conj_complex() {
+    let a = StridedArray::<Complex64>::from_fn_row_major(&[4, 3], |idx| {
+        Complex64::new((idx[0] * 3 + idx[1]) as f64, idx[0] as f64 - idx[1] as f64)
+    });
+    let mut out = StridedArray::<Complex64>::row_major(&[4, 3]);
+
+    copy_conj(&mut out.view_mut(), &a.view()).unwrap();
+
+    for i in 0..4 {
+        for j in 0..3 {
+            let expected = a.get(&[i, j]).conj();
+            assert_relative_eq!(out.get(&[i, j]).re, expected.re, epsilon = 1e-10);
+            assert_relative_eq!(out.get(&[i, j]).im, expected.im, epsilon = 1e-10);
+        }
+    }
+}
+
+// 10. symmetrize_conj_into function
+#[test]
+fn test_symmetrize_conj_into_complex() {
+    let n = 4;
+    let a = StridedArray::<Complex64>::from_fn_row_major(&[n, n], |idx| {
+        Complex64::new((idx[0] * n + idx[1]) as f64, idx[0] as f64 - idx[1] as f64)
+    });
+    let mut out = StridedArray::<Complex64>::row_major(&[n, n]);
+
+    symmetrize_conj_into(&mut out.view_mut(), &a.view()).unwrap();
+
+    for i in 0..n {
+        for j in 0..n {
+            // (src + conj(src^T)) / 2 = (a[i,j] + conj(a[j,i])) / 2
+            let expected = (a.get(&[i, j]) + a.get(&[j, i]).conj()) * 0.5;
+            assert_relative_eq!(out.get(&[i, j]).re, expected.re, epsilon = 1e-10);
+            assert_relative_eq!(out.get(&[i, j]).im, expected.im, epsilon = 1e-10);
+        }
+    }
+}
+
+// 11. symmetrize_into error cases
+#[test]
+fn test_symmetrize_into_error_non_2d() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 3, 3], |idx| {
+        (idx[0] * 9 + idx[1] * 3 + idx[2]) as f64
+    });
+    let mut out = StridedArray::<f64>::row_major(&[3, 3, 3]);
+
+    let result = symmetrize_into(&mut out.view_mut(), &a.view());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        StridedError::RankMismatch(ndim, 2) => assert_eq!(ndim, 3),
+        e => panic!("expected RankMismatch, got: {:?}", e),
+    }
+}
+
+#[test]
+fn test_symmetrize_into_error_non_square() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 5], |idx| (idx[0] * 5 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[3, 5]);
+
+    let result = symmetrize_into(&mut out.view_mut(), &a.view());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        StridedError::NonSquare { rows, cols } => {
+            assert_eq!(rows, 3);
+            assert_eq!(cols, 5);
+        }
+        e => panic!("expected NonSquare, got: {:?}", e),
+    }
+}
+
+// 12. copy_transpose_scale_into error case (non-2D)
+#[test]
+fn test_copy_transpose_scale_into_error_non_2d() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 3, 4], |idx| {
+        (idx[0] * 12 + idx[1] * 4 + idx[2]) as f64
+    });
+    let mut out = StridedArray::<f64>::row_major(&[2, 3, 4]);
+
+    let result = copy_transpose_scale_into(&mut out.view_mut(), &a.view(), 2.0);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        StridedError::RankMismatch(ndim, 2) => assert_eq!(ndim, 3),
+        e => panic!("expected RankMismatch, got: {:?}", e),
+    }
+}
+
+// 13. add — small contiguous path
+#[test]
+fn test_add_small_contiguous() {
+    let src = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] + idx[1]) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] * 4 + idx[1]) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    add(&mut dest.view_mut(), &src.view()).unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            let flat = i * 4 + j;
+            let expected = dest_orig[flat] + src.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 14. mul — small contiguous path
+#[test]
+fn test_mul_small_contiguous() {
+    let src = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] + idx[1] + 1) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] * 4 + idx[1] + 1) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    mul(&mut dest.view_mut(), &src.view()).unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            let flat = i * 4 + j;
+            let expected = dest_orig[flat] * src.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 15. copy_scale with permuted source (non-contiguous)
+#[test]
+fn test_copy_scale_permuted() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[5, 7], |idx| (idx[0] * 7 + idx[1]) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [7, 5]
+    let mut out = StridedArray::<f64>::row_major(&[7, 5]);
+    let scale = -1.5;
+
+    copy_scale(&mut out.view_mut(), &a_t, scale).unwrap();
+
+    for i in 0..7 {
+        for j in 0..5 {
+            let expected = scale * a.get(&[j, i]);
+            assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// ============================================================================
+// Mixed-layout tests: dest row-major, src col-major to force blocked inner loops
+// These exercise inner_loop_add/mul/axpy/fma/dot (non-contiguous paths)
+// ============================================================================
+
+#[test]
+fn test_add_mixed_layout() {
+    // dest row-major [4,1], src col-major [1,4] => different contiguous orders => blocked path
+    let m = 5;
+    let n = 6;
+    let src = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] + idx[1]) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_row_major(&[m, n], |idx| (idx[0] * n + idx[1]) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    add(&mut dest.view_mut(), &src.view()).unwrap();
+
+    for i in 0..m {
+        for j in 0..n {
+            // row-major flat index
+            let flat = i * n + j;
+            let expected = dest_orig[flat] + src.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+#[test]
+fn test_mul_mixed_layout() {
+    let m = 5;
+    let n = 6;
+    let src = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] + idx[1] + 1) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_row_major(&[m, n], |idx| (idx[0] * n + idx[1] + 1) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    mul(&mut dest.view_mut(), &src.view()).unwrap();
+
+    for i in 0..m {
+        for j in 0..n {
+            let flat = i * n + j;
+            let expected = dest_orig[flat] * src.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+#[test]
+fn test_axpy_mixed_layout() {
+    let m = 5;
+    let n = 6;
+    let x = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] * n + idx[1]) as f64);
+    let mut y = StridedArray::<f64>::from_fn_row_major(&[m, n], |idx| (idx[0] + idx[1]) as f64);
+    let y_orig: Vec<f64> = y.iter().copied().collect();
+    let alpha = 2.5;
+
+    axpy(&mut y.view_mut(), &x.view(), alpha).unwrap();
+
+    for i in 0..m {
+        for j in 0..n {
+            let flat = i * n + j;
+            let expected = alpha * x.get(&[i, j]) + y_orig[flat];
+            assert_relative_eq!(y.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+#[test]
+fn test_fma_mixed_layout() {
+    let m = 5;
+    let n = 6;
+    let a = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] * n + idx[1]) as f64);
+    let b = StridedArray::<f64>::from_fn_row_major(&[m, n], |idx| (idx[0] + idx[1] + 1) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] * 3 + idx[1]) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    fma(&mut dest.view_mut(), &a.view(), &b.view()).unwrap();
+
+    // dest is col-major, so iter() gives col-major order
+    for i in 0..m {
+        for j in 0..n {
+            let flat = j * m + i; // col-major flat index
+            let expected = dest_orig[flat] + a.get(&[i, j]) * b.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+#[test]
+fn test_dot_mixed_layout() {
+    let m = 7;
+    let n = 5;
+    let a = StridedArray::<f64>::from_fn_row_major(&[m, n], |idx| (idx[0] * n + idx[1]) as f64);
+    let b = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] + idx[1] + 1) as f64);
+
+    let result = dot(&a.view(), &b.view()).unwrap();
+
+    let mut expected = 0.0;
+    for i in 0..m {
+        for j in 0..n {
+            expected += a.get(&[i, j]) * b.get(&[i, j]);
+        }
+    }
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+#[test]
+fn test_sum_col_major_small() {
+    // col-major small array — exercises reduce non-SIMD path with non-row-major layout
+    let a = StridedArray::<f64>::from_fn_col_major(&[3, 4], |idx| (idx[0] * 4 + idx[1]) as f64);
+    let result = sum(&a.view()).unwrap();
+    let expected: f64 = (0..3)
+        .flat_map(|i| (0..4).map(move |j| (i * 4 + j) as f64))
+        .sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// f32 tests for SIMD sum/dot paths
+#[test]
+fn test_sum_f32_contiguous() {
+    let a = StridedArray::<f32>::from_fn_row_major(&[100], |idx| (idx[0] + 1) as f32);
+    let result = sum(&a.view()).unwrap();
+    let expected: f32 = (1..=100).map(|x| x as f32).sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-3);
+}
+
+#[test]
+fn test_dot_f32_contiguous() {
+    let a = StridedArray::<f32>::from_fn_row_major(&[100], |idx| (idx[0] + 1) as f32);
+    let b = StridedArray::<f32>::from_fn_row_major(&[100], |idx| (idx[0] * 2 + 1) as f32);
+    let result = dot(&a.view(), &b.view()).unwrap();
+    let expected: f32 = (0..100).map(|i| (i + 1) as f32 * (i * 2 + 1) as f32).sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-1);
+}
+
+// copy_into with conj on non-contiguous layout to force blocked path
+#[test]
+fn test_copy_into_conj_mixed_layout() {
+    let a = StridedArray::<Complex64>::from_fn_col_major(&[3, 4], |idx| {
+        Complex64::new((idx[0] * 4 + idx[1]) as f64, (idx[0] + idx[1]) as f64)
+    });
+    let mut out = StridedArray::<Complex64>::row_major(&[3, 4]);
+
+    let a_conj = a.view().conj();
+    copy_into(&mut out.view_mut(), &a_conj).unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            let expected = a.get(&[i, j]).conj();
+            assert_relative_eq!(out.get(&[i, j]).re, expected.re, epsilon = 1e-10);
+            assert_relative_eq!(out.get(&[i, j]).im, expected.im, epsilon = 1e-10);
+        }
+    }
+}
+
+// ============================================================================
+// zip_map3_into coverage tests
+// ============================================================================
+
+// 16. zip_map3_into — contiguous data
+#[test]
+fn test_zip_map3_into_contiguous() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| (idx[0] * 5 + idx[1]) as f64);
+    let b = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| (idx[0] + idx[1] + 1) as f64);
+    let c = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| (idx[0] * 2 + idx[1] * 3) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[4, 5]);
+
+    zip_map3_into(
+        &mut out.view_mut(),
+        &a.view(),
+        &b.view(),
+        &c.view(),
+        |x, y, z| x + y * z,
+    )
+    .unwrap();
+
+    for i in 0..4 {
+        for j in 0..5 {
+            let expected = a.get(&[i, j]) + b.get(&[i, j]) * c.get(&[i, j]);
+            assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 17. zip_map3_into — non-contiguous (permuted) data
+#[test]
+fn test_zip_map3_into_permuted() {
+    let rows = 6;
+    let cols = 5;
+    let a = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * cols + idx[1]) as f64
+    });
+    let b =
+        StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| (idx[0] + idx[1] + 1) as f64);
+    let c = StridedArray::<f64>::from_fn_row_major(&[rows, cols], |idx| {
+        (idx[0] * 2 + idx[1] * 3) as f64
+    });
+
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [cols, rows]
+    let b_t = b.view().permute(&[1, 0]).unwrap();
+    let c_t = c.view().permute(&[1, 0]).unwrap();
+
+    let mut out = StridedArray::<f64>::row_major(&[cols, rows]);
+
+    zip_map3_into(&mut out.view_mut(), &a_t, &b_t, &c_t, |x, y, z| x * y + z).unwrap();
+
+    for i in 0..cols {
+        for j in 0..rows {
+            let expected = a.get(&[j, i]) * b.get(&[j, i]) + c.get(&[j, i]);
+            assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 18. zip_map3_into — mixed strides (some permuted, some not)
+#[test]
+fn test_zip_map3_into_mixed_strides() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[5, 4], |idx| (idx[0] * 4 + idx[1]) as f64);
+    let b = StridedArray::<f64>::from_fn_col_major(&[5, 4], |idx| (idx[0] + idx[1]) as f64);
+    let c = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| (idx[0] * 5 + idx[1] + 1) as f64);
+    let c_t = c.view().permute(&[1, 0]).unwrap(); // shape [5, 4]
+
+    let mut out = StridedArray::<f64>::col_major(&[5, 4]);
+
+    zip_map3_into(
+        &mut out.view_mut(),
+        &a.view(),
+        &b.view(),
+        &c_t,
+        |x, y, z| x + y + z,
+    )
+    .unwrap();
+
+    for i in 0..5 {
+        for j in 0..4 {
+            let expected = a.get(&[i, j]) + b.get(&[i, j]) + c.get(&[j, i]);
+            assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// ============================================================================
+// reduce_view.rs coverage tests
+// ============================================================================
+
+// 19. reduce — non-contiguous (mixed layout: force blocked path)
+#[test]
+fn test_reduce_mixed_layout() {
+    let m = 8;
+    let n = 6;
+    // col-major ensures non-contiguous when blocking algorithm picks row-major order
+    let a = StridedArray::<f64>::from_fn_col_major(&[m, n], |idx| (idx[0] * n + idx[1] + 1) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // different stride order
+
+    let result = reduce(&a_t, |x| x, |a, b| a + b, 0.0).unwrap();
+    let expected: f64 = (0..m)
+        .flat_map(|i| (0..n).map(move |j| (i * n + j + 1) as f64))
+        .sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 20. reduce — product over non-contiguous data
+#[test]
+fn test_reduce_product_permuted() {
+    // Use small values to avoid overflow
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| {
+        1.0 + 0.01 * (idx[0] * 4 + idx[1]) as f64
+    });
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+
+    let result = reduce(&a_t, |x| x, |a, b| a * b, 1.0).unwrap();
+    let expected: f64 = a.iter().copied().product();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 21. reduce_axis — invalid axis (error case)
+#[test]
+fn test_reduce_axis_invalid_axis() {
+    let a =
+        StridedArray::<f64>::from_fn_row_major(&[3, 4, 2], |idx| (idx[0] + idx[1] + idx[2]) as f64);
+
+    let result = reduce_axis(&a.view(), 3, |x| x, |a, b| a + b, 0.0);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        StridedError::InvalidAxis { axis, rank } => {
+            assert_eq!(axis, 3);
+            assert_eq!(rank, 3);
+        }
+        e => panic!("expected InvalidAxis, got: {:?}", e),
+    }
+}
+
+// 22. reduce_axis — 1D input (reduces to scalar wrapped in array)
+#[test]
+fn test_reduce_axis_1d_to_scalar() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[5], |idx| (idx[0] + 1) as f64);
+
+    let result = reduce_axis(&a.view(), 0, |x| x, |a, b| a + b, 0.0).unwrap();
+
+    // 1 + 2 + 3 + 4 + 5 = 15
+    assert_eq!(result.dims(), &[1]);
+    assert_relative_eq!(result.get(&[0]), 15.0, epsilon = 1e-10);
+}
+
+// 23. reduce_axis — with permuted source
+#[test]
+fn test_reduce_axis_permuted() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] * 4 + idx[1] + 1) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [4, 3]
+
+    // Reduce along axis 0 of the permuted view (axis 0 of transposed = axis 1 of original)
+    let result = reduce_axis(&a_t, 0, |x| x, |a, b| a + b, 0.0).unwrap();
+    assert_eq!(result.dims(), &[3]);
+
+    for j in 0..3 {
+        let mut expected = 0.0;
+        for i in 0..4 {
+            expected += a.get(&[j, i]); // a_t[i, j] = a[j, i]
+        }
+        assert_relative_eq!(result.get(&[j]), expected, epsilon = 1e-10);
+    }
+}
+
+// ============================================================================
+// Small array tests: exercise dispatch_if_large with len < 64
+// ============================================================================
+
+// 24. Small contiguous map_into (len = 6 < 64)
+#[test]
+fn test_small_contiguous_map_into() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 3 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[2, 3]);
+
+    map_into(&mut out.view_mut(), &a.view(), |x| x * 5.0).unwrap();
+
+    for i in 0..2 {
+        for j in 0..3 {
+            assert_relative_eq!(out.get(&[i, j]), a.get(&[i, j]) * 5.0, epsilon = 1e-10);
+        }
+    }
+}
+
+// 25. Small contiguous sum (len = 6 < 64)
+#[test]
+fn test_small_contiguous_sum() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 3 + idx[1]) as f64);
+    let result = sum(&a.view()).unwrap();
+    // 0 + 1 + 2 + 3 + 4 + 5 = 15
+    assert_relative_eq!(result, 15.0, epsilon = 1e-10);
+}
+
+// 26. Small contiguous dot (len = 6 < 64)
+#[test]
+fn test_small_contiguous_dot() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 3 + idx[1] + 1) as f64);
+    let b = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] + idx[1]) as f64);
+    let result = dot(&a.view(), &b.view()).unwrap();
+    let expected: f64 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 27. Small contiguous add (len = 6 < 64)
+#[test]
+fn test_small_contiguous_add() {
+    let src = StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] + idx[1]) as f64);
+    let mut dest =
+        StridedArray::<f64>::from_fn_row_major(&[2, 3], |idx| (idx[0] * 3 + idx[1]) as f64);
+    let dest_orig: Vec<f64> = dest.iter().copied().collect();
+
+    add(&mut dest.view_mut(), &src.view()).unwrap();
+
+    for i in 0..2 {
+        for j in 0..3 {
+            let flat = i * 3 + j;
+            let expected = dest_orig[flat] + src.get(&[i, j]);
+            assert_relative_eq!(dest.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 28. Small contiguous copy_into (len = 4 < 64)
+#[test]
+fn test_small_contiguous_copy_into() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| (idx[0] * 10 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[2, 2]);
+
+    copy_into(&mut out.view_mut(), &a.view()).unwrap();
+
+    for i in 0..2 {
+        for j in 0..2 {
+            assert_relative_eq!(out.get(&[i, j]), a.get(&[i, j]), epsilon = 1e-10);
+        }
+    }
+}
+
+// ============================================================================
+// reduce_view.rs coverage: non-contiguous blocked path for `reduce`
+// ============================================================================
+
+// 29. reduce on a 3D permuted view — forces non-contiguous blocked path
+#[test]
+fn test_reduce_3d_permuted_blocked() {
+    // 3D array with permutation [2,0,1] — strides become non-contiguous
+    let a = StridedArray::<f64>::from_fn_row_major(&[4, 5, 6], |idx| {
+        (idx[0] * 30 + idx[1] * 6 + idx[2] + 1) as f64
+    });
+    let a_perm = a.view().permute(&[2, 0, 1]).unwrap(); // shape [6,4,5], non-contiguous
+
+    let result = reduce(&a_perm, |x| x, |a, b| a + b, 0.0).unwrap();
+    let expected: f64 = a.iter().copied().sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 30. reduce with map_fn and non-contiguous data
+#[test]
+fn test_reduce_sum_of_squares_permuted() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[5, 7], |idx| (idx[0] * 7 + idx[1] + 1) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [7,5], non-contiguous
+
+    let result = reduce(&a_t, |x| x * x, |a, b| a + b, 0.0).unwrap();
+    let expected: f64 = a.iter().copied().map(|x| x * x).sum();
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 31. reduce max on non-contiguous data (non-additive reduce_fn)
+#[test]
+fn test_reduce_max_permuted() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[6, 8], |idx| (idx[0] * 8 + idx[1]) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+
+    let result = reduce(
+        &a_t,
+        |x| x,
+        |a, b| if a > b { a } else { b },
+        f64::NEG_INFINITY,
+    )
+    .unwrap();
+    let expected: f64 = a.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// 32. reduce on col-major 3D array — ensures blocked path with different stride order
+#[test]
+fn test_reduce_col_major_3d() {
+    let a = StridedArray::<f64>::from_fn_col_major(&[3, 5, 4], |idx| {
+        (idx[0] * 20 + idx[1] * 4 + idx[2] + 1) as f64
+    });
+    let a_perm = a.view().permute(&[1, 2, 0]).unwrap(); // shuffle strides
+
+    let result = reduce(&a_perm, |x| x, |a, b| a + b, 0.0).unwrap();
+    let mut expected = 0.0;
+    for i in 0..3 {
+        for j in 0..5 {
+            for k in 0..4 {
+                expected += a.get(&[i, j, k]);
+            }
+        }
+    }
+    assert_relative_eq!(result, expected, epsilon = 1e-10);
+}
+
+// ============================================================================
+// reduce_view.rs coverage: general blocked iteration path for `reduce_axis`
+// ============================================================================
+
+// 33. reduce_axis on a 3D permuted array — forces blocked iteration (lines 200-254)
+#[test]
+fn test_reduce_axis_3d_permuted_blocked() {
+    // Use permuted 3D array to ensure strides mismatch forces blocked path
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 4, 5], |idx| {
+        (idx[0] * 20 + idx[1] * 5 + idx[2] + 1) as f64
+    });
+    let a_perm = a.view().permute(&[2, 0, 1]).unwrap(); // shape [5, 3, 4]
+
+    // Reduce along axis 1 of the permuted view (axis 0 of original)
+    let result = reduce_axis(&a_perm, 1, |x| x, |a, b| a + b, 0.0).unwrap();
+    assert_eq!(result.dims(), &[5, 4]); // shape after removing axis 1
+
+    for i in 0..5 {
+        for j in 0..4 {
+            // a_perm[i, :, j] = a[:, j, i] — sum over axis 0 of original
+            let mut expected = 0.0;
+            for k in 0..3 {
+                expected += a.get(&[k, j, i]);
+            }
+            assert_relative_eq!(result.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 34. reduce_axis on col-major with mixed strides — ensures blocked iteration
+#[test]
+fn test_reduce_axis_col_major_mixed() {
+    let a = StridedArray::<f64>::from_fn_col_major(&[4, 3, 2], |idx| {
+        (idx[0] * 6 + idx[1] * 2 + idx[2] + 1) as f64
+    });
+
+    // Reduce along axis 2 — the remaining dims [4,3] have col-major strides
+    // while output will be col-major, but the source strides may differ
+    let result = reduce_axis(&a.view(), 2, |x| x, |a, b| a + b, 0.0).unwrap();
+    assert_eq!(result.dims(), &[4, 3]);
+
+    for i in 0..4 {
+        for j in 0..3 {
+            let mut expected = 0.0;
+            for k in 0..2 {
+                expected += a.get(&[i, j, k]);
+            }
+            assert_relative_eq!(result.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+// 35. reduce_axis with map_fn on permuted data
+#[test]
+fn test_reduce_axis_map_fn_permuted() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 4], |idx| (idx[0] * 4 + idx[1] + 1) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap(); // shape [4, 3]
+
+    // Reduce axis 1 of transposed with map_fn = |x| x * x
+    let result = reduce_axis(&a_t, 1, |x| x * x, |a, b| a + b, 0.0).unwrap();
+    assert_eq!(result.dims(), &[4]);
+
+    for i in 0..4 {
+        let mut expected = 0.0;
+        for j in 0..3 {
+            let val = a.get(&[j, i]); // a_t[i, j] = a[j, i]
+            expected += val * val;
+        }
+        assert_relative_eq!(result.get(&[i]), expected, epsilon = 1e-10);
+    }
+}
+
+// 36. reduce_axis on 4D data — higher dimensional blocked path
+#[test]
+fn test_reduce_axis_4d_blocked() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[2, 3, 4, 5], |idx| {
+        (idx[0] * 60 + idx[1] * 20 + idx[2] * 5 + idx[3] + 1) as f64
+    });
+    let a_perm = a.view().permute(&[3, 1, 0, 2]).unwrap(); // shape [5, 3, 2, 4]
+
+    // Reduce along axis 2 of permuted view
+    let result = reduce_axis(&a_perm, 2, |x| x, |a, b| a + b, 0.0).unwrap();
+    assert_eq!(result.dims(), &[5, 3, 4]); // shape after removing axis 2
+
+    for i in 0..5 {
+        for j in 0..3 {
+            for k in 0..4 {
+                // a_perm[i, j, :, k] — sum over axis 2 of permuted
+                // a_perm[i,j,l,k] = a[l, j, k, i]
+                let mut expected = 0.0;
+                for l in 0..2 {
+                    expected += a.get(&[l, j, k, i]);
+                }
+                assert_relative_eq!(result.get(&[i, j, k]), expected, epsilon = 1e-10);
+            }
         }
     }
 }

--- a/strided-opteinsum/tests/integration.rs
+++ b/strided-opteinsum/tests/integration.rs
@@ -1,7 +1,8 @@
 use approx::assert_abs_diff_eq;
 use num_complex::Complex64;
+use num_traits::Zero;
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use strided_opteinsum::{einsum, parse_einsum, EinsumNode, EinsumOperand};
+use strided_opteinsum::{einsum, einsum_into, parse_einsum, EinsumNode, EinsumOperand};
 use strided_view::{row_major_strides, StridedArray};
 
 #[path = "support/loop_einsum.rs"]
@@ -353,4 +354,1038 @@ fn test_differential_loop_einsum_c64() {
         let notation = notations[rng.gen_range(0..notations.len())];
         run_differential_case(notation, &mut rng, "c64", false, 1e-10);
     }
+}
+
+// ==========================================================================
+// Tests for the top-level einsum() public API (lib.rs)
+// ==========================================================================
+
+#[test]
+fn test_einsum_simple_matmul() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 19.0);
+            assert_abs_diff_eq!(arr.get(&[0, 1]), 22.0);
+            assert_abs_diff_eq!(arr.get(&[1, 0]), 43.0);
+            assert_abs_diff_eq!(arr.get(&[1, 1]), 50.0);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_einsum_single_tensor_permute() {
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let result = einsum("ij->ji", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.dims(), &[3, 2]);
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 1.0);
+            assert_abs_diff_eq!(arr.get(&[0, 1]), 4.0);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_einsum_scalar_output_trace() {
+    let a = make_f64(&[3, 3], vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
+    let result = einsum("ii->", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            assert_abs_diff_eq!(data.as_array().data()[0], 6.0);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_einsum_parse_error() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let err = einsum("ij,jk", vec![a]).unwrap_err();
+    assert!(
+        matches!(err, strided_opteinsum::EinsumError::ParseError(_)),
+        "expected ParseError, got {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_einsum_operand_count_mismatch() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let err = einsum("ij,jk->ik", vec![a]).unwrap_err();
+    assert!(matches!(
+        err,
+        strided_opteinsum::EinsumError::OperandCountMismatch {
+            expected: 2,
+            found: 1
+        }
+    ));
+}
+
+#[test]
+fn test_einsum_nested_notation() {
+    // Test that einsum parses nested notation correctly
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity
+    let b = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let c = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let result = einsum("(ij,jk),kl->il", vec![a, b, c]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            // I*B = B, B*C = [[19,22],[43,50]]
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 19.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]), 50.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_einsum_c64() {
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 1.0), c64(0.0, 0.0), c64(0.0, 0.0), c64(1.0, 1.0)],
+    );
+    let b = make_c64(
+        &[2, 2],
+        vec![c64(2.0, 0.0), c64(3.0, 0.0), c64(4.0, 0.0), c64(5.0, 0.0)],
+    );
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.dims(), &[2, 2]);
+            // (1+i)*[[2,3],[4,5]] = [[(1+i)*2, (1+i)*3],[(1+i)*4, (1+i)*5]]
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 2.0);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).im, 2.0);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_einsum_mixed_f64_c64() {
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity, f64
+    let c64 = |r, i| Complex64::new(r, i);
+    let b = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 2.0), c64(3.0, 4.0), c64(5.0, 6.0), c64(7.0, 8.0)],
+    );
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    // I * B = B, result should be C64
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 1.0);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).im, 2.0);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+// ==========================================================================
+// Tests for the top-level einsum_into() public API (lib.rs)
+// ==========================================================================
+
+#[test]
+fn test_einsum_into_f64_basic() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+    einsum_into("ij,jk->ik", vec![a, b], c.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(c.get(&[0, 0]), 19.0);
+    assert_abs_diff_eq!(c.get(&[0, 1]), 22.0);
+    assert_abs_diff_eq!(c.get(&[1, 0]), 43.0);
+    assert_abs_diff_eq!(c.get(&[1, 1]), 50.0);
+}
+
+#[test]
+fn test_einsum_into_f64_alpha_beta() {
+    // result = 2 * (A*B) + 3 * C_old
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    // A*B = [[19,22],[43,50]]
+    let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+    for v in c.data_mut().iter_mut() {
+        *v = 1.0;
+    }
+    einsum_into("ij,jk->ik", vec![a, b], c.view_mut(), 2.0, 3.0).unwrap();
+    // 2*19+3 = 41, 2*22+3 = 47, 2*43+3 = 89, 2*50+3 = 103
+    assert_abs_diff_eq!(c.get(&[0, 0]), 41.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(c.get(&[0, 1]), 47.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(c.get(&[1, 0]), 89.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(c.get(&[1, 1]), 103.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_einsum_into_c64_basic() {
+    let c64 = |r| Complex64::new(r, 0.0);
+    let a = make_c64(&[2, 2], vec![c64(1.0), c64(2.0), c64(3.0), c64(4.0)]);
+    let b = make_c64(&[2, 2], vec![c64(5.0), c64(6.0), c64(7.0), c64(8.0)]);
+    let mut out = StridedArray::<Complex64>::col_major(&[2, 2]);
+    einsum_into(
+        "ij,jk->ik",
+        vec![a, b],
+        out.view_mut(),
+        c64(1.0),
+        Complex64::zero(),
+    )
+    .unwrap();
+    assert_abs_diff_eq!(out.get(&[0, 0]).re, 19.0);
+    assert_abs_diff_eq!(out.get(&[1, 1]).re, 50.0);
+}
+
+#[test]
+fn test_einsum_into_mixed_types_c64_output() {
+    // f64 operand + c64 operand -> c64 output
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity
+    let c64 = |r| Complex64::new(r, 0.0);
+    let b = make_c64(&[2, 2], vec![c64(5.0), c64(6.0), c64(7.0), c64(8.0)]);
+    let mut out = StridedArray::<Complex64>::col_major(&[2, 2]);
+    einsum_into(
+        "ij,jk->ik",
+        vec![a, b],
+        out.view_mut(),
+        c64(1.0),
+        Complex64::zero(),
+    )
+    .unwrap();
+    // I * B = B
+    assert_abs_diff_eq!(out.get(&[0, 0]).re, 5.0);
+    assert_abs_diff_eq!(out.get(&[0, 1]).re, 6.0);
+    assert_abs_diff_eq!(out.get(&[1, 0]).re, 7.0);
+    assert_abs_diff_eq!(out.get(&[1, 1]).re, 8.0);
+}
+
+#[test]
+fn test_einsum_into_parse_error() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 2]);
+    let err = einsum_into("ij,jk", vec![a], out.view_mut(), 1.0, 0.0).unwrap_err();
+    assert!(matches!(err, strided_opteinsum::EinsumError::ParseError(_)));
+}
+
+#[test]
+fn test_einsum_into_type_mismatch_f64_output_c64_operand() {
+    let c64 = |r| Complex64::new(r, 0.0);
+    let a = make_c64(&[2, 2], vec![c64(1.0), c64(2.0), c64(3.0), c64(4.0)]);
+    let b = make_c64(&[2, 2], vec![c64(5.0), c64(6.0), c64(7.0), c64(8.0)]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 2]);
+    let err = einsum_into("ij,jk->ik", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap_err();
+    assert!(matches!(
+        err,
+        strided_opteinsum::EinsumError::TypeMismatch { .. }
+    ));
+}
+
+#[test]
+fn test_einsum_into_shape_mismatch() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut out = StridedArray::<f64>::col_major(&[3, 3]); // wrong shape
+    let err = einsum_into("ij,jk->ik", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap_err();
+    assert!(matches!(
+        err,
+        strided_opteinsum::EinsumError::OutputShapeMismatch { .. }
+    ));
+}
+
+#[test]
+fn test_einsum_into_operand_count_mismatch() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 2]);
+    let err = einsum_into("ij,jk->ik", vec![a], out.view_mut(), 1.0, 0.0).unwrap_err();
+    assert!(matches!(
+        err,
+        strided_opteinsum::EinsumError::OperandCountMismatch {
+            expected: 2,
+            found: 1
+        }
+    ));
+}
+
+#[test]
+fn test_einsum_into_single_tensor_identity() {
+    // ij->ij is identity (no permute, no trace)
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 3]);
+    einsum_into("ij->ij", vec![a], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.get(&[0, 0]), 1.0);
+    assert_abs_diff_eq!(out.get(&[0, 2]), 3.0);
+    assert_abs_diff_eq!(out.get(&[1, 0]), 4.0);
+    assert_abs_diff_eq!(out.get(&[1, 2]), 6.0);
+}
+
+#[test]
+fn test_einsum_into_single_tensor_permute() {
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut out = StridedArray::<f64>::col_major(&[3, 2]);
+    einsum_into("ij->ji", vec![a], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.get(&[0, 0]), 1.0);
+    assert_abs_diff_eq!(out.get(&[0, 1]), 4.0);
+    assert_abs_diff_eq!(out.get(&[1, 0]), 2.0);
+    assert_abs_diff_eq!(out.get(&[2, 1]), 6.0);
+}
+
+#[test]
+fn test_einsum_into_single_tensor_trace() {
+    let a = make_f64(&[3, 3], vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
+    let mut out = StridedArray::<f64>::col_major(&[]);
+    einsum_into("ii->", vec![a], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.data()[0], 6.0);
+}
+
+#[test]
+fn test_einsum_into_three_tensor_omeco() {
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity
+    let c_op = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 2]);
+    einsum_into("ij,jk,kl->il", vec![a, b, c_op], out.view_mut(), 1.0, 0.0).unwrap();
+    // A*I = A, A*C = [[19,22],[43,50]]
+    assert_abs_diff_eq!(out.get(&[0, 0]), 19.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[1, 1]), 50.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_einsum_into_nested_notation() {
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity
+    let b = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let c_op = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 2]);
+    einsum_into("(ij,jk),kl->il", vec![a, b, c_op], out.view_mut(), 1.0, 0.0).unwrap();
+    // I*B = B, B*C = [[19,22],[43,50]]
+    assert_abs_diff_eq!(out.get(&[0, 0]), 19.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[1, 1]), 50.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_einsum_into_dot_product() {
+    let a = make_f64(&[3], vec![1.0, 2.0, 3.0]);
+    let b = make_f64(&[3], vec![4.0, 5.0, 6.0]);
+    let mut out = StridedArray::<f64>::col_major(&[]);
+    einsum_into("i,i->", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap();
+    // 1*4 + 2*5 + 3*6 = 32
+    assert_abs_diff_eq!(out.data()[0], 32.0);
+}
+
+#[test]
+fn test_einsum_into_outer_product() {
+    let a = make_f64(&[2], vec![3.0, 5.0]);
+    let b = make_f64(&[3], vec![10.0, 20.0, 30.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 3]);
+    einsum_into("i,j->ij", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.get(&[0, 0]), 30.0);
+    assert_abs_diff_eq!(out.get(&[0, 2]), 90.0);
+    assert_abs_diff_eq!(out.get(&[1, 0]), 50.0);
+    assert_abs_diff_eq!(out.get(&[1, 2]), 150.0);
+}
+
+#[test]
+fn test_einsum_into_single_tensor_trace_alpha_beta() {
+    // Test alpha/beta with single-tensor path through evaluate_into (Leaf branch)
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 2.0]);
+    let mut out = StridedArray::<f64>::col_major(&[]);
+    out.data_mut()[0] = 10.0;
+    // out = alpha * trace(A) + beta * out = 2 * 3 + 5 * 10 = 56
+    einsum_into("ii->", vec![a], out.view_mut(), 2.0, 5.0).unwrap();
+    assert_abs_diff_eq!(out.data()[0], 56.0, epsilon = 1e-10);
+}
+
+// ==========================================================================
+// Additional StridedData coverage via EinsumOperand
+// ==========================================================================
+
+#[test]
+fn test_einsum_operand_from_view_roundtrip() {
+    let mut arr = StridedArray::<f64>::col_major(&[2, 3]);
+    for (i, v) in arr.data_mut().iter_mut().enumerate() {
+        *v = (i as f64) * 10.0;
+    }
+    let view = arr.view();
+    let op = EinsumOperand::from_view_f64(&view);
+    assert!(op.is_f64());
+    assert_eq!(op.dims(), &[2, 3]);
+
+    // Use it in an einsum to prove it works through the pipeline
+    let result = einsum("ij->ji", vec![op]).unwrap();
+    assert!(result.is_f64());
+    assert_eq!(result.dims(), &[3, 2]);
+}
+
+#[test]
+fn test_einsum_operand_from_view_c64_roundtrip() {
+    let mut arr = StridedArray::<Complex64>::col_major(&[2, 2]);
+    arr.data_mut()[0] = Complex64::new(1.0, 2.0);
+    arr.data_mut()[1] = Complex64::new(3.0, 4.0);
+    arr.data_mut()[2] = Complex64::new(5.0, 6.0);
+    arr.data_mut()[3] = Complex64::new(7.0, 8.0);
+    let view = arr.view();
+    let op = EinsumOperand::from_view_c64(&view);
+    assert!(op.is_c64());
+    assert_eq!(op.dims(), &[2, 2]);
+
+    let result = einsum("ij->ji", vec![op]).unwrap();
+    assert!(result.is_c64());
+    assert_eq!(result.dims(), &[2, 2]);
+}
+
+// ==========================================================================
+// expr.rs coverage: Complex64 operand paths
+// ==========================================================================
+
+#[test]
+fn test_eval_pair_c64_c64_matmul() {
+    // Exercises eval_pair C64/C64 branch (lines 200-266 of expr.rs)
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 1.0), c64(2.0, 0.0), c64(0.0, 1.0), c64(3.0, -1.0)],
+    );
+    let b = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 0.0), c64(0.0, 1.0), c64(-1.0, 0.0), c64(2.0, 0.0)],
+    );
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    assert!(result.is_c64());
+    // Verify correct complex multiplication
+    // C[0,0] = (1+i)*1 + 2*(-1) = 1+i-2 = -1+i
+    // C[0,1] = (1+i)*(0+i) + 2*2 = (0+i+i*i)+4 = (-1+i)+4 = 3+i  -- wait: i^2=-1
+    // (1+i)*(i) = i + i^2 = i - 1 = -1+i
+    // C[0,1] = -1+i + 4 = 3+i
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, -1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).im, 1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).re, 3.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).im, 1.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_eval_single_c64_trace() {
+    // Exercises eval_single C64 branch (lines 397-400 of expr.rs)
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[3, 3],
+        vec![
+            c64(1.0, 1.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(2.0, -1.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(3.0, 2.0),
+        ],
+    );
+    let result = einsum("ii->", vec![a]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            // trace = (1+i) + (2-i) + (3+2i) = 6+2i
+            assert_abs_diff_eq!(arr.data()[0].re, 6.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.data()[0].im, 2.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_eval_single_c64_permute() {
+    // Exercises eval_single C64 branch with permutation
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 3],
+        vec![
+            c64(1.0, 0.0),
+            c64(2.0, 1.0),
+            c64(3.0, -1.0),
+            c64(4.0, 2.0),
+            c64(5.0, 0.0),
+            c64(6.0, 3.0),
+        ],
+    );
+    let result = einsum("ij->ji", vec![a]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.dims(), &[3, 2]);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).re, 4.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).im, 2.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_eval_single_c64_sum_axis() {
+    // Exercises eval_single C64 with axis reduction (ij->i)
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 3],
+        vec![
+            c64(1.0, 1.0),
+            c64(2.0, 2.0),
+            c64(3.0, 3.0),
+            c64(4.0, -1.0),
+            c64(5.0, -2.0),
+            c64(6.0, -3.0),
+        ],
+    );
+    let result = einsum("ij->i", vec![a]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.dims(), &[2]);
+            // row 0: (1+i)+(2+2i)+(3+3i) = 6+6i
+            assert_abs_diff_eq!(arr.data()[0].re, 6.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.data()[0].im, 6.0, epsilon = 1e-10);
+            // row 1: (4-i)+(5-2i)+(6-3i) = 15-6i
+            assert_abs_diff_eq!(arr.data()[1].re, 15.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.data()[1].im, -6.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_mixed_f64_c64_eval_pair_promotion() {
+    // Exercises eval_pair mixed-type promotion branch (lines 267-272 of expr.rs)
+    // Use identity * B so the result must equal B regardless of internal layout
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 1.0]); // identity
+    let c64 = |r, i| Complex64::new(r, i);
+    let b = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 2.0), c64(3.0, 4.0), c64(5.0, 6.0), c64(7.0, 8.0)],
+    );
+    // I * B = B
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).im, 2.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).re, 3.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]).im, 4.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 0]).re, 5.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 0]).im, 6.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]).re, 7.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]).im, 8.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+// ==========================================================================
+// expr.rs coverage: accumulate_into paths via evaluate_into
+// ==========================================================================
+
+#[test]
+fn test_accumulate_into_copy_scale_path() {
+    // alpha != 1, beta == 0 -> exercises copy_scale branch (line 353 of expr.rs)
+    let a = make_f64(&[2, 2], vec![1.0, 0.0, 0.0, 2.0]);
+    let mut out = StridedArray::<f64>::col_major(&[]);
+    out.data_mut()[0] = 999.0; // should be overwritten
+                               // out = 3 * trace(A) + 0 * out = 3 * 3 = 9
+    einsum_into("ii->", vec![a], out.view_mut(), 3.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.data()[0], 9.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_accumulate_into_general_path() {
+    // alpha != 1, beta != 0 -> exercises general path (lines 356-378 of expr.rs)
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut out = StridedArray::<f64>::col_major(&[3, 2]);
+    // Fill output with known values
+    for (i, v) in out.data_mut().iter_mut().enumerate() {
+        *v = (i + 1) as f64;
+    }
+    // out = 2 * transpose(A) + 3 * out_old
+    einsum_into("ij->ji", vec![a], out.view_mut(), 2.0, 3.0).unwrap();
+    // Verify: out[0,0] = 2*A[0,0] + 3*old[0,0]
+    // A transposed: [[1,4],[2,5],[3,6]]
+    // old (col-major [3,2]): data = [1,2,3,4,5,6] -> col-major: [0,0]=1, [1,0]=2, [2,0]=3, [0,1]=4, [1,1]=5, [2,1]=6
+    // out[0,0] = 2*1 + 3*1 = 5
+    assert_abs_diff_eq!(out.get(&[0, 0]), 5.0, epsilon = 1e-10);
+    // out[1,0] = 2*2 + 3*2 = 10
+    assert_abs_diff_eq!(out.get(&[1, 0]), 10.0, epsilon = 1e-10);
+    // out[0,1] = 2*4 + 3*4 = 20
+    assert_abs_diff_eq!(out.get(&[0, 1]), 20.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_evaluate_into_single_child_contract_trace() {
+    // Exercises evaluate_into Contract with 1 child general trace/reduction path
+    // (lines 812-816 of expr.rs)
+    // Use parenthesized notation to create a Contract node wrapping a single Leaf
+    // that requires trace (not permutation-only)
+    // "ii->" wrapped in a Contract: the inner Contract node reduces to scalar
+    let a = make_f64(&[3, 3], vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
+    // Use parenthesized notation that creates a nested Contract around the trace
+    let mut out = StridedArray::<f64>::col_major(&[]);
+    einsum_into("ii->", vec![a], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.data()[0], 6.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_evaluate_into_single_child_contract_sum_axis() {
+    // Exercise evaluate_into Contract with 1 child that requires axis reduction
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    // ij->i : sum over j
+    einsum_into("ij->i", vec![a], out.view_mut(), 1.0, 0.0).unwrap();
+    // row 0: 1+2+3 = 6, row 1: 4+5+6 = 15
+    assert_abs_diff_eq!(out.data()[0], 6.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.data()[1], 15.0, epsilon = 1e-10);
+}
+
+#[test]
+fn test_c64_three_tensor_omeco() {
+    // Exercise the C64/C64 branch in eval_pair with 3+ tensor omeco path
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 0.0), c64(0.0, 0.0), c64(0.0, 0.0), c64(1.0, 0.0)], // identity
+    );
+    let b = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 1.0), c64(2.0, 0.0), c64(3.0, -1.0), c64(4.0, 0.0)],
+    );
+    let c_op = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 0.0), c64(0.0, 0.0), c64(0.0, 0.0), c64(1.0, 0.0)], // identity
+    );
+    // I * B * I = B
+    let result = einsum("ij,jk,kl->il", vec![a, b, c_op]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 0]).im, 1.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]).re, 4.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_evaluate_into_c64_alpha_beta() {
+    // Exercise accumulate_into with Complex64 alpha/beta
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 0.0), c64(0.0, 0.0), c64(0.0, 0.0), c64(2.0, 0.0)],
+    );
+    let mut out = StridedArray::<Complex64>::col_major(&[]);
+    out.data_mut()[0] = c64(10.0, 0.0);
+    // out = (2+i) * trace(A) + (1+0i) * out_old
+    // trace = 3+0i
+    // result = (2+i)*(3) + (1)*(10) = (6+3i) + 10 = 16+3i
+    einsum_into(
+        "ii->",
+        vec![a],
+        out.view_mut(),
+        c64(2.0, 1.0),
+        c64(1.0, 0.0),
+    )
+    .unwrap();
+    assert_abs_diff_eq!(out.data()[0].re, 16.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.data()[0].im, 3.0, epsilon = 1e-10);
+}
+
+// ==========================================================================
+// single_tensor.rs coverage: additional paths
+// ==========================================================================
+
+#[test]
+fn test_single_tensor_c64_trace() {
+    // Exercise single_tensor_einsum with Complex64 (full trace)
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2],
+        vec![c64(1.0, 1.0), c64(0.0, 0.0), c64(0.0, 0.0), c64(3.0, -2.0)],
+    );
+    let result = einsum("ii->", vec![a]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            // trace = (1+i) + (3-2i) = 4-i
+            assert_abs_diff_eq!(arr.data()[0].re, 4.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.data()[0].im, -1.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_c64_partial_trace() {
+    // Exercise single_tensor_einsum with Complex64 (partial trace iij->j)
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(
+        &[2, 2, 3],
+        vec![
+            // A[0,0,:] = [1+i, 2+i, 3+i]
+            c64(1.0, 1.0),
+            c64(2.0, 1.0),
+            c64(3.0, 1.0),
+            // A[0,1,:] = [0, 0, 0]
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            // A[1,0,:] = [0, 0, 0]
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            c64(0.0, 0.0),
+            // A[1,1,:] = [4-i, 5-i, 6-i]
+            c64(4.0, -1.0),
+            c64(5.0, -1.0),
+            c64(6.0, -1.0),
+        ],
+    );
+    let result = einsum("iij->j", vec![a]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.len(), 3);
+            // result[j] = A[0,0,j] + A[1,1,j]
+            // j=0: (1+i)+(4-i) = 5
+            // j=1: (2+i)+(5-i) = 7
+            // j=2: (3+i)+(6-i) = 9
+            let mut vals: Vec<(f64, f64)> = (0..3)
+                .map(|j| (arr.data()[j].re, arr.data()[j].im))
+                .collect();
+            vals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            assert_abs_diff_eq!(vals[0].0, 5.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(vals[0].1, 0.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(vals[1].0, 7.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(vals[2].0, 9.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_multi_pair_diagonal() {
+    // Exercise the general fallback path in single_tensor.rs (lines 135-207)
+    // with multiple repeated index pairs: iijj-> (double trace)
+    // This has TWO pairs: (i,i) and (j,j), so has_triple triggers and falls through
+    // to the general fallback path.
+    let n = 3;
+    let total = n * n * n * n;
+    let data: Vec<f64> = (0..total).map(|x| x as f64).collect();
+    let a = make_f64(&[n, n, n, n], data);
+    // iijj -> : sum of A[i,i,j,j] for all i,j
+    let result = einsum("iijj->", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            let mut expected = 0.0;
+            for i in 0..n {
+                for j in 0..n {
+                    // A[i,i,j,j] in row-major [n,n,n,n]:
+                    // flat index = i*n^3 + i*n^2 + j*n + j = i*(n^3+n^2) + j*(n+1)
+                    let flat = i * n * n * n + i * n * n + j * n + j;
+                    expected += flat as f64;
+                }
+            }
+            assert_abs_diff_eq!(arr.data()[0], expected, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_identity_copy() {
+    // Exercise the identity case at line 279-291 of single_tensor.rs
+    // where current_ids == output_ids, no diagonal, no reduction => copy src
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let result = einsum("ij->ij", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_eq!(arr.dims(), &[2, 3]);
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 1.0);
+            assert_abs_diff_eq!(arr.get(&[0, 1]), 2.0);
+            assert_abs_diff_eq!(arr.get(&[0, 2]), 3.0);
+            assert_abs_diff_eq!(arr.get(&[1, 0]), 4.0);
+            assert_abs_diff_eq!(arr.get(&[1, 1]), 5.0);
+            assert_abs_diff_eq!(arr.get(&[1, 2]), 6.0);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_diagonal_and_reduce() {
+    // Exercise the diagonal-then-reduce path (lines 180-200 of single_tensor.rs)
+    // ijj->i: extract diagonal on axes 1,2 then the result is already in output order
+    let data: Vec<f64> = (0..18).map(|x| x as f64).collect();
+    let a = make_f64(&[2, 3, 3], data);
+    // A[i,j,j] -> result[i] = sum_j A[i,j,j]
+    let result = einsum("ijj->i", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(rdata) => {
+            let arr = rdata.as_array();
+            assert_eq!(arr.dims(), &[2]);
+            // A[0,0,0]=0, A[0,1,1]=4, A[0,2,2]=8 -> sum=12
+            assert_abs_diff_eq!(arr.data()[0], 12.0, epsilon = 1e-10);
+            // A[1,0,0]=9, A[1,1,1]=13, A[1,2,2]=17 -> sum=39
+            assert_abs_diff_eq!(arr.data()[1], 39.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_diagonal_no_reduce() {
+    // Exercise diagonal extraction without reduction (ijj->ij at lines 201-206)
+    let data: Vec<f64> = (0..18).map(|x| x as f64).collect();
+    let a = make_f64(&[2, 3, 3], data);
+    // ijj->ij: just extract diagonal (no reduction)
+    let result = einsum("ijj->ij", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(rdata) => {
+            let arr = rdata.as_array();
+            assert_eq!(arr.dims(), &[2, 3]);
+            // A[0,0,0]=0, A[0,1,1]=4, A[0,2,2]=8
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 0.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 1]), 4.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[0, 2]), 8.0, epsilon = 1e-10);
+            // A[1,0,0]=9, A[1,1,1]=13, A[1,2,2]=17
+            assert_abs_diff_eq!(arr.get(&[1, 0]), 9.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]), 13.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 2]), 17.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_diagonal_and_reduce_with_permute() {
+    // Exercise diagonal + reduce + permute path
+    // iij->j uses the partial trace fast path; use jii->j to test with permutation needed
+    let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+    let a = make_f64(&[3, 2, 2], data);
+    // jii-> : sum over diagonal i of A[j,i,i], result is vector of j
+    let result = einsum("jii->j", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(rdata) => {
+            let arr = rdata.as_array();
+            assert_eq!(arr.dims(), &[3]);
+            // A[0,0,0]=0, A[0,1,1]=3 -> 3
+            // A[1,0,0]=4, A[1,1,1]=7 -> 11
+            // A[2,0,0]=8, A[2,1,1]=11 -> 19
+            let mut vals: Vec<f64> = arr.data().to_vec();
+            vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            assert_abs_diff_eq!(vals[0], 3.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(vals[1], 11.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(vals[2], 19.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_single_tensor_reduce_without_diagonal() {
+    // Exercise the reduction-only path (no diagonal, lines 222-234) in single_tensor.rs
+    // ij->j: sum over first axis. No repeated indices.
+    let a = make_f64(&[3, 4], (0..12).map(|x| x as f64).collect());
+    let result = einsum("ij->j", vec![a]).unwrap();
+    match result {
+        EinsumOperand::F64(rdata) => {
+            let arr = rdata.as_array();
+            assert_eq!(arr.dims(), &[4]);
+            // col j: sum over rows = sum(0+j, 4+j, 8+j) = 12+3j
+            for j in 0..4 {
+                let expected = (0 + j) as f64 + (4 + j) as f64 + (8 + j) as f64;
+                assert_abs_diff_eq!(arr.data()[j], expected, epsilon = 1e-10);
+            }
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_differential_loop_einsum_c64_single_tensor() {
+    // Run differential testing with single-tensor C64 operations
+    let mut rng = StdRng::seed_from_u64(0xC64_5171);
+    let notations = ["ij->ji", "ii->", "ij->i", "ij->j"];
+    for _ in 0..20 {
+        let notation = notations[rng.gen_range(0..notations.len())];
+        run_differential_case(notation, &mut rng, "c64", false, 1e-10);
+    }
+}
+
+#[test]
+fn test_mixed_c64_f64_dot_product() {
+    // Exercises the mixed-type promotion code path (eval_pair lines 267-272)
+    // using a dot product which is layout-agnostic (scalar result).
+    let c64 = |r, i| Complex64::new(r, i);
+    let a = make_c64(&[3], vec![c64(1.0, 1.0), c64(2.0, 0.0), c64(0.0, 3.0)]);
+    let b = make_f64(&[3], vec![1.0, 2.0, 3.0]);
+    // dot = (1+i)*1 + 2*2 + (0+3i)*3 = (1+i) + 4 + 9i = 5 + 10i
+    let result = einsum("i,i->", vec![a, b]).unwrap();
+    assert!(result.is_c64());
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.data()[0].re, 5.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.data()[0].im, 10.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+// ============================================================================
+// View-based operand tests: exercise (Owned,View), (View,Owned), (View,View)
+// branches in eval_pair (lines 161-195)
+// ============================================================================
+
+#[test]
+fn test_eval_pair_view_view_f64() {
+    // Both operands as View — covers (View, View) branch in eval_pair F64
+    let a_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [1.0, 2.0, 3.0, 4.0][idx[0] * 2 + idx[1]]
+    });
+    let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
+    });
+    let a = EinsumOperand::from_view_f64(&a_arr.view());
+    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 19.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]), 50.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_eval_pair_owned_view_f64() {
+    // Left Owned, Right View — covers (Owned, View) branch
+    let a = make_f64(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
+    });
+    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 19.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_eval_pair_view_owned_f64() {
+    // Left View, Right Owned — covers (View, Owned) branch
+    let a_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [1.0, 2.0, 3.0, 4.0][idx[0] * 2 + idx[1]]
+    });
+    let a = EinsumOperand::from_view_f64(&a_arr.view());
+    let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    match result {
+        EinsumOperand::F64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]), 19.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected F64"),
+    }
+}
+
+#[test]
+fn test_eval_pair_view_view_c64() {
+    // Both C64 Views — covers (View, View) branch in eval_pair C64
+    let c64 = |r, i| Complex64::new(r, i);
+    let a_arr = StridedArray::<Complex64>::from_fn_row_major(&[2, 2], |idx| {
+        [c64(1.0, 0.0), c64(2.0, 0.0), c64(3.0, 0.0), c64(4.0, 0.0)][idx[0] * 2 + idx[1]]
+    });
+    let b_arr = StridedArray::<Complex64>::from_fn_row_major(&[2, 2], |idx| {
+        [c64(5.0, 0.0), c64(6.0, 0.0), c64(7.0, 0.0), c64(8.0, 0.0)][idx[0] * 2 + idx[1]]
+    });
+    let a = EinsumOperand::from_view_c64(&a_arr.view());
+    let b = EinsumOperand::from_view_c64(&b_arr.view());
+    let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
+    match result {
+        EinsumOperand::C64(data) => {
+            let arr = data.as_array();
+            assert_abs_diff_eq!(arr.get(&[0, 0]).re, 19.0, epsilon = 1e-10);
+            assert_abs_diff_eq!(arr.get(&[1, 1]).re, 50.0, epsilon = 1e-10);
+        }
+        _ => panic!("expected C64"),
+    }
+}
+
+// ============================================================================
+// evaluate_into with 3+ tensors (omeco path, lines 836-877)
+// ============================================================================
+
+#[test]
+fn test_einsum_into_three_tensor_flat_omeco() {
+    // Flat three-tensor: "ij,jk,kl->il" — exercises evaluate_into 3+ children path
+    let a = make_f64(&[2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = make_f64(
+        &[3, 4],
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    );
+    let c = make_f64(&[4, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+
+    let mut out = StridedArray::<f64>::row_major(&[2, 2]);
+    einsum_into("ij,jk,kl->il", vec![a, b, c], out.view_mut(), 1.0, 0.0).unwrap();
+
+    // A*B = [[1,2,3,0],[4,5,6,0]], (A*B)*C = [[1*1+2*3+3*5, 1*2+2*4+3*6],[4*1+5*3+6*5, 4*2+5*4+6*6]]
+    //     = [[1+6+15, 2+8+18],[4+15+30, 8+20+36]] = [[22,28],[49,64]]
+    assert_abs_diff_eq!(out.get(&[0, 0]), 22.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[0, 1]), 28.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[1, 0]), 49.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[1, 1]), 64.0, epsilon = 1e-10);
+}
+
+// ============================================================================
+// evaluate_into with View operands — covers eval_pair_into View branches
+// ============================================================================
+
+#[test]
+fn test_einsum_into_view_operands() {
+    // View-based operands through einsum_into — covers eval_pair_into (View, View) branch
+    let a_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [1.0, 2.0, 3.0, 4.0][idx[0] * 2 + idx[1]]
+    });
+    let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
+        [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
+    });
+    let a = EinsumOperand::from_view_f64(&a_arr.view());
+    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let mut out = StridedArray::<f64>::row_major(&[2, 2]);
+    einsum_into("ij,jk->ik", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap();
+    assert_abs_diff_eq!(out.get(&[0, 0]), 19.0, epsilon = 1e-10);
+    assert_abs_diff_eq!(out.get(&[1, 1]), 50.0, epsilon = 1e-10);
 }


### PR DESCRIPTION
## Summary
- Add `coverage` job to CI workflow using `cargo-llvm-cov` with per-file 80% line coverage threshold
- Add `scripts/check-coverage.py` that parses llvm-cov JSON output and checks each file against thresholds in `coverage-thresholds.json`
- Add ~100 tests across `strided-kernel` and `strided-opteinsum` to bring all 25 source files above 80%
- Overall coverage: 90.6% (6689/7382 lines)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (385 tests, 0 failures)
- [x] `cargo llvm-cov --workspace --json` + `check-coverage.py` passes all 25 files
- [ ] CI coverage job runs successfully on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)