### PR TITLE
fix: enable multi-threaded faer GEMM via Par::rayon(0)

### DIFF
--- a/strided-einsum2/src/bgemm_faer.rs
+++ b/strided-einsum2/src/bgemm_faer.rs
@@ -301,7 +301,16 @@ where
                 c_col_stride,
             );
 
-            matmul_with_conj(c_mat, accum, a_mat, conj_a, b_mat, conj_b, alpha, Par::rayon(0));
+            matmul_with_conj(
+                c_mat,
+                accum,
+                a_mat,
+                conj_a,
+                b_mat,
+                conj_b,
+                alpha,
+                Par::rayon(0),
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `Par::Seq` with `Par::rayon(0)` in both `matmul_with_conj` call sites in `bgemm_faer.rs`
- `Par::rayon(0)` uses all available threads in rayon's pool, controlled by `RAYON_NUM_THREADS`

## Context

Benchmark results from [strided-rs-benchmark-suite](https://github.com/tensor4all/strided-rs-benchmark-suite) showed faer GEMM was not scaling with threads (1 thread vs 4 threads: only 4-12% improvement), while the blas backend scaled properly (30-35% improvement). Root cause: `Par::Seq` was hardcoded, forcing single-threaded execution.

Closes #65

## Test plan

- [x] `cargo test -p strided-einsum2 --features faer,faer-traits` — all 71 tests pass
- [ ] Re-run benchmarks with `RAYON_NUM_THREADS=4` to verify multi-thread scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
