### PR TITLE
feat: add ndarray-opteinsum crate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ jobs:
           <a href="strided_einsum2/">strided-einsum2</a>
           <a href="strided_opteinsum/">strided-opteinsum</a>
           <a href="mdarray_opteinsum/">mdarray-opteinsum</a>
+          <a href="ndarray_opteinsum/">ndarray-opteinsum</a>
           </body></html>
           EOF
       - uses: actions/upload-pages-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["strided-view", "strided-kernel", "strided-einsum2", "strided-opteinsum", "mdarray-opteinsum"]
+members = ["strided-view", "strided-kernel", "strided-einsum2", "strided-opteinsum", "mdarray-opteinsum", "ndarray-opteinsum"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It is inspired by Julia's [Strided.jl](https://github.com/Jutho/Strided.jl),
 - [`strided-einsum2`](strided-einsum2/README.md): binary einsum (`einsum2_into`) on strided tensors
 - [`strided-opteinsum`](strided-opteinsum/README.md): N-ary einsum frontend with nested notation and contraction-order optimization
 - [`mdarray-opteinsum`](mdarray-opteinsum/): einsum wrapper for `mdarray` arrays (row-major ↔ column-major transparent conversion)
+- [`ndarray-opteinsum`](ndarray-opteinsum/): einsum wrapper for `ndarray` arrays (direct strides passthrough)
 
 ## Features
 
@@ -73,6 +74,7 @@ See each sub-crate README for detailed API examples and benchmarks:
 - [`strided-einsum2`](strided-einsum2/README.md) — binary einsum with GEMM backend
 - [`strided-opteinsum`](strided-opteinsum/README.md) — N-ary einsum, [benchmarks](strided-opteinsum/README.md#benchmarks)
 - [`mdarray-opteinsum`](mdarray-opteinsum/README.md) — einsum wrapper for `mdarray` arrays
+- [`ndarray-opteinsum`](ndarray-opteinsum/README.md) — einsum wrapper for `ndarray` arrays
 
 ## Acknowledgments
 

--- a/docs/plans/2026-02-09-ndarray-opteinsum-design.md
+++ b/docs/plans/2026-02-09-ndarray-opteinsum-design.md
@@ -1,0 +1,183 @@
+# ndarray-opteinsum Design
+
+## Summary
+
+A thin wrapper crate that lets `ndarray` users call N-ary einsum directly on `ArrayD<T>` and `ArrayViewD<T>` types. Delegates all computation to `strided-opteinsum`.
+
+## Scope
+
+- Accept `ndarray` dynamic-rank arrays and views as einsum operands (f64, Complex64)
+- Return results as owned `ArrayD<T>`
+- Provide `einsum_into` for writing into pre-allocated `ArrayViewMutD`
+- Direct dims/strides passthrough (no notation reversal needed, unlike mdarray-opteinsum)
+- Support negative strides (reversed views)
+
+## Key Difference from mdarray-opteinsum
+
+mdarray has implicit strides (always row-major dense), so mdarray-opteinsum reverses dims and notation labels to bridge the row-major/column-major gap. ndarray has **explicit strides** (`&[isize]`, element-based — same unit as StridedView), so dims and strides can be passed directly to StridedView without any reversal.
+
+| | mdarray-opteinsum | ndarray-opteinsum |
+|---|---|---|
+| notation | label reversal required | passthrough |
+| input conversion | reverse dims/strides | direct passthrough |
+| negative strides | N/A (always positive) | supported via offset calculation |
+| output construction | `ManuallyDrop` + `from_raw_parts` (unsafe) | `from_shape_vec` (safe) |
+
+## Public API
+
+```rust
+use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
+use num_complex::Complex64;
+
+/// Type-erased operand wrapping ndarray types.
+pub enum NdOperand<'a> {
+    F64Array(&'a ArrayD<f64>),
+    C64Array(&'a ArrayD<Complex64>),
+    F64View(ArrayViewD<'a, f64>),
+    C64View(ArrayViewD<'a, Complex64>),
+}
+
+impl From<&ArrayD<f64>> for NdOperand<'_> { ... }
+impl From<&ArrayD<Complex64>> for NdOperand<'_> { ... }
+impl<'a> From<ArrayViewD<'a, f64>> for NdOperand<'a> { ... }
+impl<'a> From<ArrayViewD<'a, Complex64>> for NdOperand<'a> { ... }
+
+/// Compute einsum, return owned ArrayD.
+pub fn einsum<T: EinsumScalar>(
+    notation: &str,
+    operands: Vec<NdOperand<'_>>,
+) -> Result<ArrayD<T>>
+
+/// Compute einsum into pre-allocated output.
+/// output = alpha * einsum(operands) + beta * output
+pub fn einsum_into<T: EinsumScalar>(
+    notation: &str,
+    operands: Vec<NdOperand<'_>>,
+    output: &mut ArrayViewMutD<'_, T>,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+```
+
+## Input Conversion (zero-copy)
+
+ndarray's `as_ptr()` points to element `[0,0,...,0]`. With negative strides, accessible memory extends before this pointer. We compute the offset range:
+
+```rust
+fn compute_offset_range(shape: &[usize], strides: &[isize]) -> (isize, isize) {
+    let mut min_off: isize = 0;
+    let mut max_off: isize = 0;
+    for (&d, &s) in shape.iter().zip(strides.iter()) {
+        if d == 0 { continue; }
+        let end = s * (d as isize - 1);
+        if end < 0 { min_off += end; } else { max_off += end; }
+    }
+    (min_off, max_off)
+}
+
+fn ndarray_to_strided_view<'a, T>(arr: &'a ArrayD<T>) -> StridedView<'a, T> {
+    let shape = arr.shape();
+    let strides = arr.strides();
+    let (min_off, max_off) = compute_offset_range(shape, strides);
+    let base_ptr = unsafe { arr.as_ptr().offset(min_off) };
+    let data_len = (max_off - min_off + 1) as usize;
+    let data = unsafe { std::slice::from_raw_parts(base_ptr, data_len) };
+    let offset = (-min_off) as usize;
+    StridedView::new(data, shape, strides, offset).expect("valid bounds")
+}
+```
+
+Same logic applies to `ArrayViewD` and `ArrayViewMutD` (with `as_mut_ptr`).
+
+## Output Conversion
+
+### `einsum()` — one copy to row-major
+
+```rust
+fn strided_array_to_ndarray<T>(arr: StridedArray<T>) -> ArrayD<T>
+where
+    T: Copy + ElementOpApply + Send + Sync + Zero + Default,
+{
+    let dims = arr.dims().to_vec();
+    let total: usize = dims.iter().product();
+    let mut buf = vec![T::default(); total];
+    let rm_strides = row_major_strides(&dims);
+    {
+        let mut dest = StridedViewMut::new(&mut buf, &dims, &rm_strides, 0).expect("valid");
+        copy_into(&mut dest, &arr.view()).expect("copy failed");
+    }
+    ArrayD::from_shape_vec(dims, buf).expect("shape matches")
+}
+```
+
+No dims reversal needed. `from_shape_vec` is safe (no `ManuallyDrop`/`from_raw_parts`).
+
+### `einsum_into()` — copy-free
+
+The output `ArrayViewMutD` is wrapped as `StridedViewMut` using the same offset calculation as input views.
+
+## File Structure
+
+```
+ndarray-opteinsum/
+  Cargo.toml
+  src/
+    lib.rs        # NdOperand, einsum(), einsum_into()
+    convert.rs    # ndarray ↔ StridedView, compute_offset_range
+```
+
+## Dependencies
+
+```toml
+[package]
+name = "ndarray-opteinsum"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.64"
+license = "MIT OR Apache-2.0"
+authors = ["Satoshi Terasaki", "Hiroshi Shinaoka"]
+repository = "https://github.com/tensor4all/strided-rs"
+description = "N-ary einsum frontend for ndarray arrays, powered by strided-opteinsum."
+publish = false
+
+[dependencies]
+ndarray = "0.17"
+strided-opteinsum = { path = "../strided-opteinsum", default-features = false }
+strided-view = { path = "../strided-view" }
+strided-kernel = { path = "../strided-kernel" }
+num-complex = "0.4"
+num-traits = "0.2"
+thiserror = "1.0"
+
+[features]
+default = ["faer"]
+faer = ["strided-opteinsum/faer"]
+blas = ["strided-opteinsum/blas"]
+
+[dev-dependencies]
+approx = "0.5"
+num-complex = "0.4"
+```
+
+## Error Handling
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Einsum(#[from] strided_opteinsum::EinsumError),
+}
+```
+
+All validation (dimension mismatch, bad notation, shape errors) delegated to `strided-opteinsum`.
+
+## Edge Cases
+
+- **Scalar output** (`"ij,ji->"`): 0-rank result. `IxDyn` supports empty dims.
+- **Negative strides**: Handled by offset calculation in `compute_offset_range`.
+- **Empty arrays** (dim = 0): `compute_offset_range` skips zero dims; `from_shape_vec` handles empty vecs.
+- **Nested notation** (`"(ij,jk),kl->il"`): Passed through unchanged to `strided-opteinsum`.
+
+## Estimated Size
+
+~200-250 lines total. Simpler than mdarray-opteinsum (no notation reversal logic).

--- a/ndarray-opteinsum/Cargo.toml
+++ b/ndarray-opteinsum/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ndarray-opteinsum"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.64"
+license = "MIT OR Apache-2.0"
+authors = ["Satoshi Terasaki", "Hiroshi Shinaoka"]
+repository = "https://github.com/tensor4all/strided-rs"
+description = "N-ary einsum frontend for ndarray arrays, powered by strided-opteinsum."
+publish = false
+
+[dependencies]
+ndarray = "0.17"
+strided-opteinsum = { path = "../strided-opteinsum", default-features = false }
+strided-view = { path = "../strided-view" }
+strided-kernel = { path = "../strided-kernel" }
+num-complex = "0.4"
+num-traits = "0.2"
+thiserror = "1.0"
+
+[features]
+default = ["faer"]
+faer = ["strided-opteinsum/faer"]
+blas = ["strided-opteinsum/blas"]
+
+[dev-dependencies]
+approx = "0.5"
+num-complex = "0.4"

--- a/ndarray-opteinsum/README.md
+++ b/ndarray-opteinsum/README.md
@@ -1,0 +1,65 @@
+# ndarray-opteinsum
+
+N-ary einsum frontend for [`ndarray`](https://crates.io/crates/ndarray) arrays, powered by `strided-opteinsum`.
+
+## Scope
+
+- Thin wrapper over `strided-opteinsum` that accepts `ndarray` `ArrayD<T>` and `ArrayViewD<T>` types directly
+- Direct dims/strides passthrough (no notation reversal needed, unlike mdarray-opteinsum)
+- Supports negative strides (reversed views)
+- `einsum()` returns an owned `ArrayD<T>`; `einsum_into()` writes into a pre-allocated `ArrayViewMutD`
+- Supports `f64` and `Complex64` operands
+
+## Quick Example
+
+```rust
+use ndarray::ArrayD;
+use ndarray_opteinsum::einsum;
+
+// Row-major 2x3 and 3x2 matrices
+let a = ArrayD::from_shape_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+let b = ArrayD::from_shape_vec(vec![3, 2], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
+
+// Matrix multiplication
+let c: ArrayD<f64> = einsum("ij,jk->ik", vec![(&a).into(), (&b).into()]).unwrap();
+```
+
+## How It Works
+
+ndarray has explicit strides (`&[isize]`, element-based) matching StridedView's convention,
+so dims and strides are passed through directly without any reversal.
+
+- **Input conversion**: Zero-copy wrapping of ndarray pointers, shapes, and strides as `StridedView`
+- **Negative strides**: Supported via offset calculation (`compute_offset_range`)
+- **`einsum_into()`**: Fully copy-free
+- **`einsum()`**: One copy via `copy_into` to materialize the result into contiguous row-major order
+
+### Comparison with mdarray-opteinsum
+
+| | mdarray-opteinsum | ndarray-opteinsum |
+|---|---|---|
+| notation | label reversal required | passthrough |
+| input conversion | reverse dims/strides | direct passthrough |
+| negative strides | N/A | supported |
+| output construction | unsafe `from_raw_parts` | safe `from_shape_vec` |
+
+## API
+
+```rust
+// Allocating: returns owned ArrayD
+pub fn einsum<T: EinsumScalar>(
+    notation: &str,
+    operands: Vec<NdOperand<'_>>,
+) -> Result<ArrayD<T>>
+
+// In-place: output = alpha * einsum(operands) + beta * output
+pub fn einsum_into<T: EinsumScalar>(
+    notation: &str,
+    operands: Vec<NdOperand<'_>>,
+    output: &mut ArrayViewMutD<'_, T>,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+```
+
+`NdOperand<'a>` is constructed via `From` impls on `&ArrayD<T>` and `ArrayViewD<'a, T>`.

--- a/ndarray-opteinsum/src/convert.rs
+++ b/ndarray-opteinsum/src/convert.rs
@@ -1,0 +1,151 @@
+use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
+use strided_kernel::copy_into;
+use strided_view::{row_major_strides, StridedArray, StridedView, StridedViewMut};
+
+/// Compute the min and max element-offset reachable from index [0,0,...,0].
+///
+/// For non-negative strides the min is 0; for negative strides (reversed views)
+/// the min can be negative relative to `as_ptr()`.
+fn compute_offset_range(shape: &[usize], strides: &[isize]) -> (isize, isize) {
+    let mut min_off: isize = 0;
+    let mut max_off: isize = 0;
+    for (&d, &s) in shape.iter().zip(strides.iter()) {
+        if d == 0 {
+            continue;
+        }
+        let end = s * (d as isize - 1);
+        if end < 0 {
+            min_off += end;
+        } else {
+            max_off += end;
+        }
+    }
+    (min_off, max_off)
+}
+
+/// Wrap an ndarray `ArrayD<T>` as a `StridedView` (zero-copy).
+///
+/// Dims and strides are passed through directly (no reversal).
+pub fn array_to_strided_view<T>(arr: &ArrayD<T>) -> StridedView<'_, T> {
+    let shape = arr.shape();
+    let strides = arr.strides();
+    let (min_off, max_off) = compute_offset_range(shape, strides);
+    let base_ptr = unsafe { arr.as_ptr().offset(min_off) };
+    let data_len = (max_off - min_off + 1) as usize;
+    let data = unsafe { std::slice::from_raw_parts(base_ptr, data_len) };
+    let offset = -min_off;
+    StridedView::new(data, shape, strides, offset).expect("valid bounds")
+}
+
+/// Wrap an ndarray `ArrayViewD<T>` as a `StridedView` (zero-copy).
+pub fn view_to_strided_view<'a, T>(view: &ArrayViewD<'a, T>) -> StridedView<'a, T> {
+    let shape = view.shape();
+    let strides = view.strides();
+    let (min_off, max_off) = compute_offset_range(shape, strides);
+    let base_ptr = unsafe { view.as_ptr().offset(min_off) };
+    let data_len = (max_off - min_off + 1) as usize;
+    let data = unsafe { std::slice::from_raw_parts(base_ptr, data_len) };
+    let offset = -min_off;
+    StridedView::new(data, shape, strides, offset).expect("valid bounds")
+}
+
+/// Wrap an ndarray `ArrayViewMutD<T>` as a `StridedViewMut` (zero-copy).
+pub fn view_mut_to_strided_view_mut<'a, T>(
+    view: &'a mut ArrayViewMutD<'a, T>,
+) -> StridedViewMut<'a, T> {
+    let shape: Vec<usize> = view.shape().to_vec();
+    let strides: Vec<isize> = view.strides().to_vec();
+    let (min_off, max_off) = compute_offset_range(&shape, &strides);
+    let base_ptr = unsafe { view.as_mut_ptr().offset(min_off) };
+    let data_len = (max_off - min_off + 1) as usize;
+    let data = unsafe { std::slice::from_raw_parts_mut(base_ptr, data_len) };
+    let offset = -min_off;
+    StridedViewMut::new(data, &shape, &strides, offset).expect("valid bounds")
+}
+
+/// Convert a `StridedArray` result into an ndarray `ArrayD<T>`.
+///
+/// A copy is performed to materialize data into dense row-major order,
+/// since the `StridedArray` from einsum may have arbitrary strides.
+pub fn strided_array_to_ndarray<T>(arr: StridedArray<T>) -> ArrayD<T>
+where
+    T: Copy + strided_view::ElementOpApply + Send + Sync + num_traits::Zero + Default,
+{
+    let dims = arr.dims().to_vec();
+    let total: usize = dims.iter().product();
+    let mut buf = vec![T::default(); total];
+    let rm_strides = row_major_strides(&dims);
+    {
+        let mut dest = StridedViewMut::new(&mut buf, &dims, &rm_strides, 0).expect("valid dest");
+        copy_into(&mut dest, &arr.view()).expect("copy_into failed");
+    }
+    ArrayD::from_shape_vec(dims, buf).expect("shape matches")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::ArrayD;
+
+    #[test]
+    fn test_array_to_strided_view_2d() {
+        // Row-major 2x3: [[1,2,3],[4,5,6]]
+        let arr = ArrayD::from_shape_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        let sv = array_to_strided_view(&arr);
+
+        // Dims passed through directly (no reversal)
+        assert_eq!(sv.dims(), &[2, 3]);
+        // Row-major strides for [2,3]: [3, 1]
+        assert_eq!(sv.strides(), &[3, 1]);
+
+        // Verify element access
+        let ptr = sv.ptr();
+        unsafe {
+            assert_eq!(*ptr, 1.0); // [0,0]
+            assert_eq!(*ptr.offset(1), 2.0); // [0,1]
+            assert_eq!(*ptr.offset(3), 4.0); // [1,0]
+            assert_eq!(*ptr.offset(5), 6.0); // [1,2]
+        }
+    }
+
+    #[test]
+    fn test_strided_array_to_ndarray_roundtrip() {
+        // Column-major StridedArray [2, 3] with strides [1, 2]
+        let data = vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0];
+        let arr = StridedArray::from_parts(data, &[2, 3], &[1, 2], 0).expect("valid strided array");
+
+        let nd = strided_array_to_ndarray(arr);
+        assert_eq!(nd.shape(), &[2, 3]);
+        // Row-major: [[1,2,3],[4,5,6]]
+        assert_eq!(nd[[0, 0]], 1.0);
+        assert_eq!(nd[[0, 1]], 2.0);
+        assert_eq!(nd[[0, 2]], 3.0);
+        assert_eq!(nd[[1, 0]], 4.0);
+        assert_eq!(nd[[1, 1]], 5.0);
+        assert_eq!(nd[[1, 2]], 6.0);
+    }
+
+    #[test]
+    fn test_negative_stride_view() {
+        // Create 3-element array [10, 20, 30], then reverse it
+        let arr = ArrayD::from_shape_vec(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
+        use ndarray::s;
+        let reversed = arr.slice(s![..;-1]);
+        // reversed = [30, 20, 10], stride = -1
+
+        // Convert the dynamic view
+        let dyn_view: ArrayViewD<'_, f64> = reversed.into_dimensionality().unwrap();
+        let sv = view_to_strided_view(&dyn_view);
+
+        assert_eq!(sv.dims(), &[3]);
+        assert_eq!(sv.strides(), &[-1]);
+
+        // sv.ptr() points to element [0] = 30 (data[offset])
+        let ptr = sv.ptr();
+        unsafe {
+            assert_eq!(*ptr, 30.0); // [0]
+            assert_eq!(*ptr.offset(-1), 20.0); // [1]: offset + 1*(-1)
+            assert_eq!(*ptr.offset(-2), 10.0); // [2]: offset + 2*(-1)
+        }
+    }
+}

--- a/ndarray-opteinsum/src/lib.rs
+++ b/ndarray-opteinsum/src/lib.rs
@@ -1,0 +1,258 @@
+//! N-ary Einstein summation for `ndarray` arrays.
+//!
+//! This crate provides a thin wrapper over [`strided_opteinsum`] that accepts
+//! `ndarray` `ArrayD<T>` and `ArrayViewD<T>` types directly.
+//! Dims and strides are passed through without reversal (ndarray has explicit strides).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use ndarray::ArrayD;
+//! use ndarray_opteinsum::einsum;
+//!
+//! let a = ArrayD::from_shape_vec(vec![2, 3], (1..=6).map(|x| x as f64).collect()).unwrap();
+//! let b = ArrayD::from_shape_vec(vec![3, 2], (7..=12).map(|x| x as f64).collect()).unwrap();
+//! let c: ArrayD<f64> = einsum("ij,jk->ik", vec![(&a).into(), (&b).into()]).unwrap();
+//! ```
+
+pub mod convert;
+
+use ndarray::{ArrayD, ArrayViewD, ArrayViewMutD};
+use num_complex::Complex64;
+use strided_opteinsum::{EinsumOperand, EinsumScalar};
+
+use crate::convert::{
+    array_to_strided_view, strided_array_to_ndarray, view_mut_to_strided_view_mut,
+    view_to_strided_view,
+};
+
+/// Error type for ndarray-opteinsum operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Einsum(#[from] strided_opteinsum::EinsumError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// A type-erased einsum operand wrapping ndarray types.
+///
+/// Construct via `From` impls on owned arrays or views.
+pub enum NdOperand<'a> {
+    F64Array(&'a ArrayD<f64>),
+    C64Array(&'a ArrayD<Complex64>),
+    F64View(ArrayViewD<'a, f64>),
+    C64View(ArrayViewD<'a, Complex64>),
+}
+
+impl<'a> From<&'a ArrayD<f64>> for NdOperand<'a> {
+    fn from(arr: &'a ArrayD<f64>) -> Self {
+        NdOperand::F64Array(arr)
+    }
+}
+
+impl<'a> From<&'a ArrayD<Complex64>> for NdOperand<'a> {
+    fn from(arr: &'a ArrayD<Complex64>) -> Self {
+        NdOperand::C64Array(arr)
+    }
+}
+
+impl<'a> From<ArrayViewD<'a, f64>> for NdOperand<'a> {
+    fn from(view: ArrayViewD<'a, f64>) -> Self {
+        NdOperand::F64View(view)
+    }
+}
+
+impl<'a> From<ArrayViewD<'a, Complex64>> for NdOperand<'a> {
+    fn from(view: ArrayViewD<'a, Complex64>) -> Self {
+        NdOperand::C64View(view)
+    }
+}
+
+/// Convert an `NdOperand` into a `strided_opteinsum::EinsumOperand`.
+fn to_einsum_operand<'a>(op: &NdOperand<'a>) -> EinsumOperand<'a> {
+    match op {
+        NdOperand::F64Array(arr) => {
+            let sv = array_to_strided_view(arr);
+            EinsumOperand::from_view_f64(&sv)
+        }
+        NdOperand::C64Array(arr) => {
+            let sv = array_to_strided_view(arr);
+            EinsumOperand::from_view_c64(&sv)
+        }
+        NdOperand::F64View(view) => {
+            let sv = view_to_strided_view(view);
+            EinsumOperand::from_view_f64(&sv)
+        }
+        NdOperand::C64View(view) => {
+            let sv = view_to_strided_view(view);
+            EinsumOperand::from_view_c64(&sv)
+        }
+    }
+}
+
+/// Parse and evaluate an einsum expression on ndarray operands.
+///
+/// Returns the result as an owned `ArrayD<T>`.
+///
+/// # Example
+///
+/// ```ignore
+/// let c: ArrayD<f64> = einsum("ij,jk->ik", vec![(&a).into(), (&b).into()])?;
+/// ```
+pub fn einsum<T: EinsumScalar>(notation: &str, operands: Vec<NdOperand<'_>>) -> Result<ArrayD<T>> {
+    let einsum_ops: Vec<EinsumOperand<'_>> =
+        operands.iter().map(|op| to_einsum_operand(op)).collect();
+    let result = strided_opteinsum::einsum(notation, einsum_ops)?;
+    let data = T::extract_data(result)?;
+    let strided_arr = data.into_array();
+    Ok(strided_array_to_ndarray(strided_arr))
+}
+
+/// Parse and evaluate an einsum expression, writing the result into a
+/// pre-allocated ndarray output with alpha/beta scaling.
+///
+/// `output = alpha * einsum(operands) + beta * output`
+pub fn einsum_into<'a, T: EinsumScalar>(
+    notation: &str,
+    operands: Vec<NdOperand<'_>>,
+    output: &'a mut ArrayViewMutD<'a, T>,
+    alpha: T,
+    beta: T,
+) -> Result<()> {
+    let einsum_ops: Vec<EinsumOperand<'_>> =
+        operands.iter().map(|op| to_einsum_operand(op)).collect();
+    let strided_out = view_mut_to_strided_view_mut(output);
+    strided_opteinsum::einsum_into(notation, einsum_ops, strided_out, alpha, beta)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+    use ndarray::ArrayD;
+
+    fn make_array(data: Vec<f64>, shape: Vec<usize>) -> ArrayD<f64> {
+        ArrayD::from_shape_vec(shape, data).unwrap()
+    }
+
+    #[test]
+    fn test_matmul_2x3_times_3x2() {
+        let a = make_array(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let b = make_array(vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0], vec![3, 2]);
+
+        let c: ArrayD<f64> = einsum("ij,jk->ik", vec![(&a).into(), (&b).into()]).unwrap();
+
+        assert_eq!(c.shape(), &[2, 2]);
+        assert_abs_diff_eq!(c[[0, 0]], 58.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[0, 1]], 64.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 0]], 139.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 1]], 154.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_trace() {
+        let a = make_array(vec![1.0, 2.0, 3.0, 4.0], vec![2, 2]);
+
+        let c: ArrayD<f64> = einsum("ii->", vec![(&a).into()]).unwrap();
+
+        assert_eq!(c.shape(), &[] as &[usize]);
+        assert_abs_diff_eq!(c[[]], 5.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_transpose() {
+        let a = make_array(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+
+        let c: ArrayD<f64> = einsum("ij->ji", vec![(&a).into()]).unwrap();
+
+        assert_eq!(c.shape(), &[3, 2]);
+        assert_abs_diff_eq!(c[[0, 0]], 1.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 0]], 2.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[0, 1]], 4.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[2, 1]], 6.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_dot_product() {
+        let a = make_array(vec![1.0, 2.0, 3.0], vec![3]);
+        let b = make_array(vec![4.0, 5.0, 6.0], vec![3]);
+
+        let c: ArrayD<f64> = einsum("i,i->", vec![(&a).into(), (&b).into()]).unwrap();
+
+        assert_eq!(c.shape(), &[] as &[usize]);
+        assert_abs_diff_eq!(c[[]], 32.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_outer_product() {
+        let a = make_array(vec![1.0, 2.0], vec![2]);
+        let b = make_array(vec![3.0, 4.0, 5.0], vec![3]);
+
+        let c: ArrayD<f64> = einsum("i,j->ij", vec![(&a).into(), (&b).into()]).unwrap();
+
+        assert_eq!(c.shape(), &[2, 3]);
+        assert_abs_diff_eq!(c[[0, 0]], 3.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[0, 2]], 5.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 1]], 8.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_three_operand_chain() {
+        let a = make_array((1..=6).map(|x| x as f64).collect(), vec![2, 3]);
+        let b = make_array((1..=12).map(|x| x as f64).collect(), vec![3, 4]);
+        let c = make_array((1..=8).map(|x| x as f64).collect(), vec![4, 2]);
+
+        let result: ArrayD<f64> =
+            einsum("ij,jk,kl->il", vec![(&a).into(), (&b).into(), (&c).into()]).unwrap();
+
+        assert_eq!(result.shape(), &[2, 2]);
+        assert_abs_diff_eq!(result[[0, 0]], 812.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(result[[0, 1]], 1000.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_view_input() {
+        let a = make_array(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let b = make_array(vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0], vec![3, 2]);
+
+        let va = a.view();
+        let vb = b.view();
+
+        let c: ArrayD<f64> = einsum(
+            "ij,jk->ik",
+            vec![
+                va.into_dimensionality().unwrap().into(),
+                vb.into_dimensionality().unwrap().into(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(c.shape(), &[2, 2]);
+        assert_abs_diff_eq!(c[[0, 0]], 58.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 1]], 154.0, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_einsum_into_matmul() {
+        let a = make_array(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]);
+        let b = make_array(vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0], vec![3, 2]);
+        let mut c = ArrayD::<f64>::zeros(vec![2, 2]);
+
+        {
+            let mut view = c.view_mut();
+            einsum_into(
+                "ij,jk->ik",
+                vec![(&a).into(), (&b).into()],
+                &mut view,
+                1.0,
+                0.0,
+            )
+            .unwrap();
+        }
+
+        assert_abs_diff_eq!(c[[0, 0]], 58.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(c[[1, 1]], 154.0, epsilon = 1e-10);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ndarray-opteinsum` crate: thin wrapper over `strided-opteinsum` that accepts `ndarray` `ArrayD<T>` and `ArrayViewD<T>` types directly
- Unlike `mdarray-opteinsum`, ndarray has explicit strides so dims/strides are passed through without notation or dim reversal
- Supports negative strides (reversed views) via offset calculation
- Safe output construction using `from_shape_vec` (no unsafe `from_raw_parts`)
- Update root README, docs workflow index, and add crate README

## Test plan

- [x] 11 unit/integration tests: matmul, trace, transpose, dot product, outer product, 3-operand chain, view inputs, einsum_into, negative strides
- [ ] CI passes (cargo test, cargo fmt --check, cargo doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)