### PR TITLE
refactor: extend EinsumScalar trait for generic operand construction

### DIFF
--- a/mdarray-opteinsum/src/lib.rs
+++ b/mdarray-opteinsum/src/lib.rs
@@ -74,19 +74,19 @@ fn to_einsum_operand<'a>(op: &'a MdOperand<'a>) -> EinsumOperand<'a> {
     match op {
         MdOperand::F64Array(arr) => {
             let sv = array_to_strided_view(*arr);
-            EinsumOperand::from_view_f64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         MdOperand::C64Array(arr) => {
             let sv = array_to_strided_view(*arr);
-            EinsumOperand::from_view_c64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         MdOperand::F64View(view) => {
             let sv = view_to_strided_view(view);
-            EinsumOperand::from_view_f64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         MdOperand::C64View(view) => {
             let sv = view_to_strided_view(view);
-            EinsumOperand::from_view_c64(&sv)
+            EinsumOperand::from_view(&sv)
         }
     }
 }

--- a/ndarray-opteinsum/src/lib.rs
+++ b/ndarray-opteinsum/src/lib.rs
@@ -74,19 +74,19 @@ fn to_einsum_operand<'a>(op: &NdOperand<'a>) -> EinsumOperand<'a> {
     match op {
         NdOperand::F64Array(arr) => {
             let sv = array_to_strided_view(arr);
-            EinsumOperand::from_view_f64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         NdOperand::C64Array(arr) => {
             let sv = array_to_strided_view(arr);
-            EinsumOperand::from_view_c64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         NdOperand::F64View(view) => {
             let sv = view_to_strided_view(view);
-            EinsumOperand::from_view_f64(&sv)
+            EinsumOperand::from_view(&sv)
         }
         NdOperand::C64View(view) => {
             let sv = view_to_strided_view(view);
-            EinsumOperand::from_view_c64(&sv)
+            EinsumOperand::from_view(&sv)
         }
     }
 }

--- a/strided-opteinsum/benches/batchmul.rs
+++ b/strided-opteinsum/benches/batchmul.rs
@@ -55,8 +55,8 @@ fn run_batchmul_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_f64(&a_view),
-                    EinsumOperand::from_view_f64(&b_view),
+                    EinsumOperand::from_view(&a_view),
+                    EinsumOperand::from_view(&b_view),
                 ])
                 .unwrap();
             match result {
@@ -84,8 +84,8 @@ fn run_batchmul_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_c64(&a_c_view),
-                    EinsumOperand::from_view_c64(&b_c_view),
+                    EinsumOperand::from_view(&a_c_view),
+                    EinsumOperand::from_view(&b_c_view),
                 ])
                 .unwrap();
             match result {

--- a/strided-opteinsum/benches/diag.rs
+++ b/strided-opteinsum/benches/diag.rs
@@ -45,7 +45,7 @@ fn main() {
     println!("diag: Float64");
     bench_n("diag_f64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_view)])
             .unwrap();
         match result {
             EinsumOperand::F64(data) => black_box(data.as_array().data().as_ptr()),
@@ -63,7 +63,7 @@ fn main() {
     println!("diag: ComplexF64");
     bench_n("diag_Complex64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_c64(&a_c_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_c_view)])
             .unwrap();
         match result {
             EinsumOperand::C64(data) => black_box(data.as_array().data().as_ptr()),

--- a/strided-opteinsum/benches/dot.rs
+++ b/strided-opteinsum/benches/dot.rs
@@ -41,8 +41,8 @@ fn run_dot_case(case_name: &str, n1: usize, n2: usize, n3: usize, seed_f64: u64,
     bench_n(&format!("{case_name}_f64_{n1}x{n2}x{n3}"), 2, 5, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
             ])
             .unwrap();
         match result {
@@ -69,8 +69,8 @@ fn run_dot_case(case_name: &str, n1: usize, n2: usize, n3: usize, seed_f64: u64,
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_c64(&a_c_view),
-                    EinsumOperand::from_view_c64(&b_c_view),
+                    EinsumOperand::from_view(&a_c_view),
+                    EinsumOperand::from_view(&b_c_view),
                 ])
                 .unwrap();
             match result {

--- a/strided-opteinsum/benches/hadamard.rs
+++ b/strided-opteinsum/benches/hadamard.rs
@@ -46,8 +46,8 @@ fn main() {
     bench_n("hadamard_f64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
             ])
             .unwrap();
         match result {
@@ -69,8 +69,8 @@ fn main() {
     bench_n("hadamard_Complex64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_c64(&ac_view),
-                EinsumOperand::from_view_c64(&bc_view),
+                EinsumOperand::from_view(&ac_view),
+                EinsumOperand::from_view(&bc_view),
             ])
             .unwrap();
         match result {

--- a/strided-opteinsum/benches/indexsum.rs
+++ b/strided-opteinsum/benches/indexsum.rs
@@ -43,7 +43,7 @@ fn main() {
     println!("indexsum (Float64):");
     bench_n("indexsum_f64_large", 1, 3, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_view)])
             .unwrap();
         match result {
             EinsumOperand::F64(data) => black_box(data.as_array().data().as_ptr()),
@@ -59,7 +59,7 @@ fn main() {
     println!("indexsum (ComplexF64):");
     bench_n("indexsum_Complex64_large", 1, 3, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_c64(&ac_view)])
+            .evaluate(vec![EinsumOperand::from_view(&ac_view)])
             .unwrap();
         match result {
             EinsumOperand::C64(data) => black_box(data.as_array().data().as_ptr()),

--- a/strided-opteinsum/benches/manyinds.rs
+++ b/strided-opteinsum/benches/manyinds.rs
@@ -52,8 +52,8 @@ fn main() {
     bench_n("opteinsum_f64", 1, 5, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
             ])
             .unwrap();
         match result {
@@ -77,8 +77,8 @@ fn main() {
     bench_n("opteinsum_Complex64", 1, 5, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_c64(&a_c_view),
-                EinsumOperand::from_view_c64(&b_c_view),
+                EinsumOperand::from_view(&a_c_view),
+                EinsumOperand::from_view(&b_c_view),
             ])
             .unwrap();
         match result {

--- a/strided-opteinsum/benches/matmul.rs
+++ b/strided-opteinsum/benches/matmul.rs
@@ -45,8 +45,8 @@ fn run_matmul_case(case_name: &str, n1: usize, n2: usize, n3: usize, seed_f64: u
     bench_n(&format!("{case_name}_f64_{n1}x{n2}x{n3}"), 2, 5, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
             ])
             .unwrap();
         match result {
@@ -73,8 +73,8 @@ fn run_matmul_case(case_name: &str, n1: usize, n2: usize, n3: usize, seed_f64: u
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_c64(&a_c_view),
-                    EinsumOperand::from_view_c64(&b_c_view),
+                    EinsumOperand::from_view(&a_c_view),
+                    EinsumOperand::from_view(&b_c_view),
                 ])
                 .unwrap();
             match result {

--- a/strided-opteinsum/benches/outer.rs
+++ b/strided-opteinsum/benches/outer.rs
@@ -56,8 +56,8 @@ fn run_outer_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_f64(&a_view),
-                    EinsumOperand::from_view_f64(&b_view),
+                    EinsumOperand::from_view(&a_view),
+                    EinsumOperand::from_view(&b_view),
                 ])
                 .unwrap();
             match result {
@@ -85,8 +85,8 @@ fn run_outer_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_c64(&ac_view),
-                    EinsumOperand::from_view_c64(&bc_view),
+                    EinsumOperand::from_view(&ac_view),
+                    EinsumOperand::from_view(&bc_view),
                 ])
                 .unwrap();
             match result {

--- a/strided-opteinsum/benches/perm.rs
+++ b/strided-opteinsum/benches/perm.rs
@@ -45,7 +45,7 @@ fn main() {
     println!("perm: Float64");
     bench_n("perm_f64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_view)])
             .unwrap();
         match result {
             EinsumOperand::F64(data) => black_box(data.as_view().ptr()),
@@ -63,7 +63,7 @@ fn main() {
     println!("perm: ComplexF64");
     bench_n("perm_Complex64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_c64(&a_c_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_c_view)])
             .unwrap();
         match result {
             EinsumOperand::C64(data) => black_box(data.as_view().ptr()),

--- a/strided-opteinsum/benches/ptrace.rs
+++ b/strided-opteinsum/benches/ptrace.rs
@@ -45,7 +45,7 @@ fn main() {
     println!("ptrace: Float64");
     bench_n("ptrace_f64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_view)])
             .unwrap();
         match result {
             EinsumOperand::F64(data) => black_box(data.as_array().data().as_ptr()),
@@ -63,7 +63,7 @@ fn main() {
     println!("ptrace: ComplexF64");
     bench_n("ptrace_Complex64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_c64(&a_c_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_c_view)])
             .unwrap();
         match result {
             EinsumOperand::C64(data) => black_box(data.as_array().data().as_ptr()),

--- a/strided-opteinsum/benches/star.rs
+++ b/strided-opteinsum/benches/star.rs
@@ -48,9 +48,9 @@ fn main() {
     bench_n("star_f64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
-                EinsumOperand::from_view_f64(&c_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
+                EinsumOperand::from_view(&c_view),
             ])
             .unwrap();
         match result {
@@ -76,9 +76,9 @@ fn main() {
     bench_n("star_Complex64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_c64(&ac_view),
-                EinsumOperand::from_view_c64(&bc_view),
-                EinsumOperand::from_view_c64(&cc_view),
+                EinsumOperand::from_view(&ac_view),
+                EinsumOperand::from_view(&bc_view),
+                EinsumOperand::from_view(&cc_view),
             ])
             .unwrap();
         match result {

--- a/strided-opteinsum/benches/starandcontract.rs
+++ b/strided-opteinsum/benches/starandcontract.rs
@@ -48,9 +48,9 @@ fn main() {
     bench_n("starandcontract_f64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_f64(&a_view),
-                EinsumOperand::from_view_f64(&b_view),
-                EinsumOperand::from_view_f64(&c_view),
+                EinsumOperand::from_view(&a_view),
+                EinsumOperand::from_view(&b_view),
+                EinsumOperand::from_view(&c_view),
             ])
             .unwrap();
         match result {
@@ -76,9 +76,9 @@ fn main() {
     bench_n("starandcontract_Complex64_large", 1, 3, || {
         let result = code
             .evaluate(vec![
-                EinsumOperand::from_view_c64(&ac_view),
-                EinsumOperand::from_view_c64(&bc_view),
-                EinsumOperand::from_view_c64(&cc_view),
+                EinsumOperand::from_view(&ac_view),
+                EinsumOperand::from_view(&bc_view),
+                EinsumOperand::from_view(&cc_view),
             ])
             .unwrap();
         match result {

--- a/strided-opteinsum/benches/tcontract.rs
+++ b/strided-opteinsum/benches/tcontract.rs
@@ -55,8 +55,8 @@ fn run_tcontract_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_f64(&a_view),
-                    EinsumOperand::from_view_f64(&b_view),
+                    EinsumOperand::from_view(&a_view),
+                    EinsumOperand::from_view(&b_view),
                 ])
                 .unwrap();
             match result {
@@ -84,8 +84,8 @@ fn run_tcontract_case(
         || {
             let result = code
                 .evaluate(vec![
-                    EinsumOperand::from_view_c64(&a_c_view),
-                    EinsumOperand::from_view_c64(&b_c_view),
+                    EinsumOperand::from_view(&a_c_view),
+                    EinsumOperand::from_view(&b_c_view),
                 ])
                 .unwrap();
             match result {

--- a/strided-opteinsum/benches/trace.rs
+++ b/strided-opteinsum/benches/trace.rs
@@ -45,7 +45,7 @@ fn main() {
     println!("trace: Float64");
     bench_n("trace_f64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_f64(&a_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_view)])
             .unwrap();
         match result {
             EinsumOperand::F64(data) => black_box(data.as_array().data()[0]),
@@ -63,7 +63,7 @@ fn main() {
     println!("trace: ComplexF64");
     bench_n("trace_Complex64", 2, 5, || {
         let result = code
-            .evaluate(vec![EinsumOperand::from_view_c64(&a_c_view)])
+            .evaluate(vec![EinsumOperand::from_view(&a_c_view)])
             .unwrap();
         match result {
             EinsumOperand::C64(data) => black_box(data.as_array().data()[0]),

--- a/strided-opteinsum/tests/integration.rs
+++ b/strided-opteinsum/tests/integration.rs
@@ -706,13 +706,13 @@ fn test_einsum_into_single_tensor_trace_alpha_beta() {
 // ==========================================================================
 
 #[test]
-fn test_einsum_operand_from_view_roundtrip() {
+fn test_einsum_operand_from_view_f64_roundtrip() {
     let mut arr = StridedArray::<f64>::col_major(&[2, 3]);
     for (i, v) in arr.data_mut().iter_mut().enumerate() {
         *v = (i as f64) * 10.0;
     }
     let view = arr.view();
-    let op = EinsumOperand::from_view_f64(&view);
+    let op = EinsumOperand::from_view(&view);
     assert!(op.is_f64());
     assert_eq!(op.dims(), &[2, 3]);
 
@@ -730,7 +730,7 @@ fn test_einsum_operand_from_view_c64_roundtrip() {
     arr.data_mut()[2] = Complex64::new(5.0, 6.0);
     arr.data_mut()[3] = Complex64::new(7.0, 8.0);
     let view = arr.view();
-    let op = EinsumOperand::from_view_c64(&view);
+    let op = EinsumOperand::from_view(&view);
     assert!(op.is_c64());
     assert_eq!(op.dims(), &[2, 2]);
 
@@ -1272,8 +1272,8 @@ fn test_eval_pair_view_view_f64() {
     let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
         [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
     });
-    let a = EinsumOperand::from_view_f64(&a_arr.view());
-    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let a = EinsumOperand::from_view(&a_arr.view());
+    let b = EinsumOperand::from_view(&b_arr.view());
     let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
     match result {
         EinsumOperand::F64(data) => {
@@ -1292,7 +1292,7 @@ fn test_eval_pair_owned_view_f64() {
     let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
         [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
     });
-    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let b = EinsumOperand::from_view(&b_arr.view());
     let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
     match result {
         EinsumOperand::F64(data) => {
@@ -1309,7 +1309,7 @@ fn test_eval_pair_view_owned_f64() {
     let a_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
         [1.0, 2.0, 3.0, 4.0][idx[0] * 2 + idx[1]]
     });
-    let a = EinsumOperand::from_view_f64(&a_arr.view());
+    let a = EinsumOperand::from_view(&a_arr.view());
     let b = make_f64(&[2, 2], vec![5.0, 6.0, 7.0, 8.0]);
     let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
     match result {
@@ -1331,8 +1331,8 @@ fn test_eval_pair_view_view_c64() {
     let b_arr = StridedArray::<Complex64>::from_fn_row_major(&[2, 2], |idx| {
         [c64(5.0, 0.0), c64(6.0, 0.0), c64(7.0, 0.0), c64(8.0, 0.0)][idx[0] * 2 + idx[1]]
     });
-    let a = EinsumOperand::from_view_c64(&a_arr.view());
-    let b = EinsumOperand::from_view_c64(&b_arr.view());
+    let a = EinsumOperand::from_view(&a_arr.view());
+    let b = EinsumOperand::from_view(&b_arr.view());
     let result = einsum("ij,jk->ik", vec![a, b]).unwrap();
     match result {
         EinsumOperand::C64(data) => {
@@ -1382,8 +1382,8 @@ fn test_einsum_into_view_operands() {
     let b_arr = StridedArray::<f64>::from_fn_row_major(&[2, 2], |idx| {
         [5.0, 6.0, 7.0, 8.0][idx[0] * 2 + idx[1]]
     });
-    let a = EinsumOperand::from_view_f64(&a_arr.view());
-    let b = EinsumOperand::from_view_f64(&b_arr.view());
+    let a = EinsumOperand::from_view(&a_arr.view());
+    let b = EinsumOperand::from_view(&b_arr.view());
     let mut out = StridedArray::<f64>::row_major(&[2, 2]);
     einsum_into("ij,jk->ik", vec![a, b], out.view_mut(), 1.0, 0.0).unwrap();
     assert_abs_diff_eq!(out.get(&[0, 0]), 19.0, epsilon = 1e-10);


### PR DESCRIPTION
## Summary
- Add `wrap_data`, `wrap_array`, `wrap_typed_tensor` methods to the sealed `EinsumScalar` trait for generic type-erased construction
- Replace type-suffixed `from_view_f64`/`from_view_c64` with a single generic `from_view<T: EinsumScalar>` (updates ~60 call sites across all crates)
- Deduplicate `eval_pair` and `eval_single` in `expr.rs` via generic helpers (`eval_pair_alloc<T>`, `eval_single_typed<T>`) using a private `PoolOps` trait

Closes #60

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 341 tests pass across all crates (strided-opteinsum, mdarray-opteinsum, ndarray-opteinsum, strided-einsum2, strided-kernel, strided-view)
- [x] Pure refactor — no behavior change, only API and internal deduplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)