### PR TITLE
perf: batch-last canonical order for einsum2 GEMM

### DIFF
--- a/docs/plans/2026-02-12-batch-last-canonical-order.md
+++ b/docs/plans/2026-02-12-batch-last-canonical-order.md
@@ -1,0 +1,83 @@
+# Batch-Last Canonical Order for einsum2
+
+## Problem
+
+The current `strided-einsum2` uses batch-first canonical order:
+- A[batch, lo, sum], B[batch, sum, ro], C[batch, lo, ro]
+
+This is a row-major convention. In column-major (which this library uses),
+the first dimension has stride 1. When col-major tensors have batch as the
+last dimension (Julia convention), permuting to batch-first puts the
+large-stride batch dims at the front, leaving inner dims with unit strides.
+But when batch is already at the front in the physical layout, the inner
+matrix gets non-unit strides (e.g., row_stride=b, col_stride=b*i), causing:
+
+1. CBLAS: forced copy (REQUIRES_UNIT_STRIDE)
+2. faer: slow non-vectorized path
+
+## Solution
+
+Change canonical order to batch-last:
+- A[lo, sum, batch], B[sum, ro, batch], C[lo, ro, batch]
+
+With column-major allocation, batch dims are last and naturally get the
+largest strides. Each batch slice is a contiguous col-major matrix with
+unit row stride.
+
+## Changes
+
+### 1. plan.rs - Permutation construction (3 lines)
+
+Change permutation chain order:
+
+```
+left_perm:  batch.chain(lo).chain(sum)  -->  lo.chain(sum).chain(batch)
+right_perm: batch.chain(sum).chain(ro)  -->  sum.chain(ro).chain(batch)
+c_to_internal_perm: batch.chain(lo).chain(ro)  -->  lo.chain(ro).chain(batch)
+```
+
+### 2. contiguous.rs - Allocation and group extraction
+
+Replace `alloc_batched_col_major` (row-major batch + col-major inner hack)
+with pure col-major allocation. Batch dims are last, so standard col-major
+gives them the largest strides automatically.
+
+Flip all group extraction indexing in `prepare_input_view`,
+`prepare_input_owned`, `prepare_output_view`, `prepare_output_owned`,
+`prepare_input_view_for_backend`, `prepare_output_view_for_backend`:
+
+```
+Before: batch=[..n_batch], group1=[n_batch..n_batch+n_g1], group2=[n_batch+n_g1..]
+After:  group1=[..n_g1], group2=[n_g1..n_g1+n_g2], batch=[n_g1+n_g2..]
+```
+
+### 3. bgemm_faer.rs - Dimension/stride extraction
+
+Same index flipping in `bgemm_strided_into` and `bgemm_contiguous_into`.
+
+### 4. bgemm_naive.rs - Dimension/stride extraction
+
+Same index flipping in `bgemm_strided_into` and
+`bgemm_strided_into_with_map`.
+
+### 5. bgemm_blas.rs - Dimension/stride extraction
+
+Same index flipping pattern.
+
+### 6. lib.rs - Entry point functions
+
+Same index flipping in `einsum2_into`, `einsum2_naive_into`,
+`einsum2_with_backend_into`, `einsum2_gemm_dispatch`, `einsum2_into_owned`.
+
+## Out of scope
+
+- `strided-opteinsum`: no changes needed (calls einsum2_into internally)
+- Public API: no changes (einsum2_into signature unchanged)
+
+## Testing
+
+- All existing tests should pass (they test einsum correctness, not internal
+  ordering)
+- Update plan.rs tests that assert specific permutation values
+- Add regression test: col-major batch-last input verifying zero-copy path
+  with unit inner strides

--- a/strided-einsum2/src/lib.rs
+++ b/strided-einsum2/src/lib.rs
@@ -459,11 +459,11 @@ where
         beta,
     )?;
 
-    // Dimension sizes
-    let batch_dims = &a_perm.dims()[..n_batch];
-    let lo_dims = &a_perm.dims()[n_batch..n_batch + n_lo];
-    let sum_dims = &a_perm.dims()[n_batch + n_lo..n_batch + n_lo + n_sum];
-    let ro_dims = &b_perm.dims()[n_batch + n_sum..n_batch + n_sum + n_ro];
+    // Dimension sizes (batch-last canonical order)
+    let lo_dims = &a_perm.dims()[..n_lo];
+    let sum_dims = &a_perm.dims()[n_lo..n_lo + n_sum];
+    let batch_dims = &a_perm.dims()[n_lo + n_sum..];
+    let ro_dims = &b_perm.dims()[n_sum..n_sum + n_ro];
     let m: usize = lo_dims.iter().product::<usize>().max(1);
     let k: usize = sum_dims.iter().product::<usize>().max(1);
     let n: usize = ro_dims.iter().product::<usize>().max(1);
@@ -546,10 +546,10 @@ where
     let mut c_op = contiguous::prepare_output_view(&mut c_perm, n_batch, n_lo, n_ro, beta)?;
 
     // Compute fused dimension sizes
-    let batch_dims = &a_perm.dims()[..n_batch];
-    let lo_dims = &a_perm.dims()[n_batch..n_batch + n_lo];
-    let sum_dims = &a_perm.dims()[n_batch + n_lo..n_batch + n_lo + n_sum];
-    let ro_dims = &b_perm.dims()[n_batch + n_sum..n_batch + n_sum + n_ro];
+    let lo_dims = &a_perm.dims()[..n_lo];
+    let sum_dims = &a_perm.dims()[n_lo..n_lo + n_sum];
+    let batch_dims = &a_perm.dims()[n_lo + n_sum..];
+    let ro_dims = &b_perm.dims()[n_sum..n_sum + n_ro];
     let m: usize = lo_dims.iter().product::<usize>().max(1);
     let k: usize = sum_dims.iter().product::<usize>().max(1);
     let n: usize = ro_dims.iter().product::<usize>().max(1);
@@ -654,10 +654,10 @@ where
     let a_dims_perm = a_perm.dims().to_vec();
     let b_dims_perm = b_perm.dims().to_vec();
 
-    let batch_dims = a_dims_perm[..n_batch].to_vec();
-    let lo_dims = &a_dims_perm[n_batch..n_batch + n_lo];
-    let sum_dims = &a_dims_perm[n_batch + n_lo..];
-    let ro_dims = &b_dims_perm[n_batch + n_sum..];
+    let lo_dims = &a_dims_perm[..n_lo];
+    let sum_dims = &a_dims_perm[n_lo..n_lo + n_sum];
+    let batch_dims = a_dims_perm[n_lo + n_sum..].to_vec();
+    let ro_dims = &b_dims_perm[n_sum..n_sum + n_ro];
     let m: usize = lo_dims.iter().product::<usize>().max(1);
     let k: usize = sum_dims.iter().product::<usize>().max(1);
     let n: usize = ro_dims.iter().product::<usize>().max(1);


### PR DESCRIPTION
## Summary

- Switch einsum2 canonical dimension order from batch-first `[batch, lo, sum]` to batch-last `[lo, sum, batch]`, aligning with Julia column-major convention
- Simplify `alloc_batched_col_major` to `alloc_col_major_uninit` (pure col-major, no more row-major batch hack)
- With batch-last, col-major allocation naturally gives batch dims the largest strides, so each GEMM batch slice is contiguous with unit row stride -- avoiding unnecessary CBLAS copies and enabling faer SIMD paths

## Test plan

- [x] All 83 strided-einsum2 tests pass (including updated batched GEMM tests)
- [x] All 82 strided-opteinsum integration tests pass
- [x] `cargo fmt --check` clean, zero warnings
- [ ] Benchmark batched einsum to confirm performance improvement