### PR TITLE
Canonicalize binary intermediate id order in opteinsum

### DIFF
--- a/strided-opteinsum/src/expr.rs
+++ b/strided-opteinsum/src/expr.rs
@@ -235,7 +235,11 @@ fn out_dims_from_ids(
 /// - lo: ids only in left and needed
 /// - ro: ids only in right and needed
 /// - batch: ids in both and needed
-fn compute_binary_output_ids(left_ids: &[char], right_ids: &[char], needed_ids: &[char]) -> Vec<char> {
+fn compute_binary_output_ids(
+    left_ids: &[char],
+    right_ids: &[char],
+    needed_ids: &[char],
+) -> Vec<char> {
     let mut out = Vec::new();
     for &id in left_ids {
         if needed_ids.contains(&id) && !right_ids.contains(&id) && !out.contains(&id) {


### PR DESCRIPTION
## Summary
- canonicalize binary contraction intermediate ids to `[lo, ro, batch]` in `compute_contract_output_ids`
- keep non-binary behavior unchanged
- add a unit test for the canonical binary id ordering

## Performance Impact
Measured on `tensornetwork_permutation_light_415` with 1 thread (`BENCH_INSTANCE=tensornetwork_permutation_light_415`, `RAYON_NUM_THREADS=1`, `OMP_NUM_THREADS=1`):

| Strategy | Backend | canon0 (ms) | canon1 (ms) | Delta |
|---|---|---:|---:|---:|
| opt_flops | strided-rs faer | 414.405 | 392.212 | -5.36% |
| opt_flops | strided-rs OpenBLAS | 431.815 | 365.502 | -15.36% |
| opt_size | strided-rs faer | 413.195 | 361.768 | -12.45% |
| opt_size | strided-rs OpenBLAS | 430.087 | 362.473 | -15.72% |

Profile counters also show output writeback elimination in this workload:
- faer: `out_writeback_calls` 45 -> 0
- OpenBLAS: `out_writeback_calls` 200 -> 0

## Test Plan
- cargo test -p strided-opteinsum
- cargo test -p strided-einsum2
