### PR TITLE
perf(kernel): replace recursive ND fallback with iterative carry loop

### DIFF
--- a/strided-kernel/src/kernel.rs
+++ b/strided-kernel/src/kernel.rs
@@ -875,10 +875,16 @@ mod tests {
         let mut offsets = vec![0isize, 0isize];
         let mut total = 0usize;
 
-        kernel_nd_inner_iterative(&dims, &blocks, &strides, &mut offsets, &mut |_off, len, _s| {
-            total += len;
-            Ok(())
-        })
+        kernel_nd_inner_iterative(
+            &dims,
+            &blocks,
+            &strides,
+            &mut offsets,
+            &mut |_off, len, _s| {
+                total += len;
+                Ok(())
+            },
+        )
         .unwrap();
 
         assert_eq!(total, dims.iter().product::<usize>());


### PR DESCRIPTION
## Summary
- replace recursive `kernel_nd_inner_level` traversal with iterative carry-style traversal in ND fallback path
- keep level-0 block callback behavior identical while reducing branch-heavy recursive control flow
- add regression test `test_kernel_nd_iterative_total_elements_match` to verify full coverage and offset restoration

## Benchmark Impact
`tensornetwork_permutation_light_415`, single-thread (`RAYON_NUM_THREADS=1`, `OMP_NUM_THREADS=1`, `JULIA_NUM_THREADS=1`) using
`BENCH_INSTANCE=tensornetwork_permutation_light_415 ./scripts/run_all.sh 1 1`

Compared against previous t1 baseline (`results_t1_20260218_144513.md`), current run (`results_t1_20260218_162803.md`) shows:
- Rust faer / `opt_flops`: `353.578 ms` -> `290.416 ms` (**17.86% faster**)
- Rust faer / `opt_size`: `359.409 ms` -> `294.712 ms` (**18.00% faster**)
- Rust OpenBLAS / `opt_flops`: `359.447 ms` -> `304.865 ms` (**15.18% faster**)
- Rust OpenBLAS / `opt_size`: `359.234 ms` -> `307.098 ms` (**14.51% faster**)

## Test Plan
- [x] `cargo test -p strided-kernel`
- [x] `BENCH_INSTANCE=tensornetwork_permutation_light_415 ./scripts/run_all.sh 1 1` (run in `strided-rs-benchmark-suite`)
