### PR TITLE
feat(kernel): macro-generated rank-specialized kernels for 5D-8D

### DIFF
--- a/strided-kernel/src/kernel.rs
+++ b/strided-kernel/src/kernel.rs
@@ -336,14 +336,56 @@ macro_rules! make_kernel {
     };
 }
 
-make_kernel!(kernel_1d_inner, rank=1);
-make_kernel!(kernel_2d_inner, rank=2, block=[1, 0], elem=[1], top=1);
-make_kernel!(kernel_3d_inner, rank=3, block=[2, 1, 0], elem=[2, 1], top=2);
-make_kernel!(kernel_4d_inner, rank=4, block=[3, 2, 1, 0], elem=[3, 2, 1], top=3);
-make_kernel!(kernel_5d_inner, rank=5, block=[4, 3, 2, 1, 0], elem=[4, 3, 2, 1], top=4);
-make_kernel!(kernel_6d_inner, rank=6, block=[5, 4, 3, 2, 1, 0], elem=[5, 4, 3, 2, 1], top=5);
-make_kernel!(kernel_7d_inner, rank=7, block=[6, 5, 4, 3, 2, 1, 0], elem=[6, 5, 4, 3, 2, 1], top=6);
-make_kernel!(kernel_8d_inner, rank=8, block=[7, 6, 5, 4, 3, 2, 1, 0], elem=[7, 6, 5, 4, 3, 2, 1], top=7);
+make_kernel!(kernel_1d_inner, rank = 1);
+make_kernel!(
+    kernel_2d_inner,
+    rank = 2,
+    block = [1, 0],
+    elem = [1],
+    top = 1
+);
+make_kernel!(
+    kernel_3d_inner,
+    rank = 3,
+    block = [2, 1, 0],
+    elem = [2, 1],
+    top = 2
+);
+make_kernel!(
+    kernel_4d_inner,
+    rank = 4,
+    block = [3, 2, 1, 0],
+    elem = [3, 2, 1],
+    top = 3
+);
+make_kernel!(
+    kernel_5d_inner,
+    rank = 5,
+    block = [4, 3, 2, 1, 0],
+    elem = [4, 3, 2, 1],
+    top = 4
+);
+make_kernel!(
+    kernel_6d_inner,
+    rank = 6,
+    block = [5, 4, 3, 2, 1, 0],
+    elem = [5, 4, 3, 2, 1],
+    top = 5
+);
+make_kernel!(
+    kernel_7d_inner,
+    rank = 7,
+    block = [6, 5, 4, 3, 2, 1, 0],
+    elem = [6, 5, 4, 3, 2, 1],
+    top = 6
+);
+make_kernel!(
+    kernel_8d_inner,
+    rank = 8,
+    block = [7, 6, 5, 4, 3, 2, 1, 0],
+    elem = [7, 6, 5, 4, 3, 2, 1],
+    top = 7
+);
 
 /// N-dimensional kernel with inner block callback (iterative form).
 ///
@@ -955,7 +997,10 @@ mod tests {
         // Expected: all offsets 0..total
         let total: usize = dims.iter().product();
         let expected: std::collections::HashSet<isize> = (0..total as isize).collect();
-        assert_eq!(visited, expected, "rank={rank}: not all elements visited exactly once");
+        assert_eq!(
+            visited, expected,
+            "rank={rank}: not all elements visited exactly once"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #96

- Replace hand-written 1D-4D kernels with `macro_rules!`-generated kernels for ranks 1-8
- Three macros (`elem_loops!`, `block_loop!`, `make_kernel!`) generate nested loops with compile-time-known rank
- Ranks 5-8 now get fully unrolled loops instead of falling back to the generic carry-style `kernel_nd_inner_iterative`
- Generic N-D fallback still handles rank >= 9
- Net code reduction despite covering 2x more ranks (~80 lines of macros vs ~280 lines of hand-written kernels)

## Motivation

In the `tensornetwork_permutation_light_415` benchmark, most contractions produce tensors with rank 5-8 after dimension fusion. These previously hit the generic carry-style kernel which has per-iteration overhead from carry condition checks. Macro-generated nested loops eliminate this overhead.

## Test plan

- [x] All 82 strided-kernel unit tests pass
- [x] All 81 correctness tests pass
- [x] 12 new tests for macro-generated kernels (ranks 5-8)
- [x] `kernel_nd_inner_iterative` debug_assert updated to rank >= 9

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>