### PR TITLE
perf: source-stride-order copy in prepare_input_owned

### DIFF
--- a/strided-einsum2/Cargo.toml
+++ b/strided-einsum2/Cargo.toml
@@ -20,9 +20,11 @@ faer-traits = { version = "0.24", optional = true }
 cblas-sys = { version = "0.2", optional = true }
 cblas-inject = { version = "0.1", optional = true }
 num-complex = { version = "0.4", optional = true }
+rayon = { version = "1.10", optional = true }
 
 [features]
 default = ["faer", "faer-traits"]
+parallel = ["rayon"]
 blas = ["dep:cblas-sys", "dep:num-complex"]
 blas-inject = ["dep:cblas-inject", "dep:num-complex"]
 

--- a/strided-einsum2/src/contiguous.rs
+++ b/strided-einsum2/src/contiguous.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 use strided_perm::try_fuse_group;
 use strided_view::{StridedArray, StridedView, StridedViewMut};
 
+#[cfg(feature = "parallel")]
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
 /// GEMM-ready input operand with contiguous data.
 pub struct ContiguousOperand<T: Copy + 'static> {
     ptr: *const T,
@@ -370,6 +373,173 @@ pub fn prepare_input_view<T: Scalar + 'static>(
     }
 }
 
+/// Copy elements from `src` to `dst`, iterating in source-stride order.
+///
+/// Dimensions are traversed from smallest to largest source stride, giving
+/// sequential (or near-sequential) reads.  Writes to the destination may be
+/// scattered, but hardware write-combining buffers absorb much of the cost.
+///
+/// # Why not HPTT (`strided_kernel::copy_into_col_major`)?
+///
+/// HPTT iterates in *destination*-stride order (optimized for sequential
+/// writes).  This is ideal when the source data is warm in cache, but in
+/// `prepare_input_owned` the source is usually a large intermediate whose
+/// L3 cache lines have been evicted by subsequent contraction steps.
+/// With cold-cache source and many small non-contiguous dimensions (e.g.
+/// 24 binary dims of size 2 after a metadata-only permutation), HPTT's
+/// bilateral fusion leaves ~17 fused dims with a 2×2 inner tile and 15
+/// levels of recursion per 4 elements — both cache-unfriendly reads AND
+/// high per-element overhead.
+///
+/// Source-stride-order iteration gives sequential reads that exploit the
+/// hardware prefetcher, which dominates performance on cold-cache,
+/// memory-bandwidth-bound copies.
+unsafe fn copy_strided_src_order<T: Copy>(
+    src_ptr: *const T,
+    dst_ptr: *mut T,
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) {
+    let ndim = dims.len();
+    let n: usize = dims.iter().product();
+    if n == 0 {
+        return;
+    }
+
+    // Sort dimensions by source stride (ascending) → innermost = smallest src stride
+    let mut dim_order: Vec<usize> = (0..ndim).filter(|&i| dims[i] > 1).collect();
+    dim_order.sort_by_key(|&i| src_strides[i].unsigned_abs());
+
+    let sorted_dims: Vec<usize> = dim_order.iter().map(|&i| dims[i]).collect();
+    let sorted_src: Vec<isize> = dim_order.iter().map(|&i| src_strides[i]).collect();
+    let sorted_dst: Vec<isize> = dim_order.iter().map(|&i| dst_strides[i]).collect();
+    let nd = sorted_dims.len();
+
+    let mut idx = vec![0usize; nd];
+    let mut so: isize = 0;
+    let mut do_: isize = 0;
+
+    for _ in 0..n {
+        *dst_ptr.offset(do_) = *src_ptr.offset(so);
+
+        for d in 0..nd {
+            idx[d] += 1;
+            if idx[d] < sorted_dims[d] {
+                so += sorted_src[d];
+                do_ += sorted_dst[d];
+                break;
+            } else {
+                so -= sorted_src[d] * (sorted_dims[d] as isize - 1);
+                do_ -= sorted_dst[d] * (sorted_dims[d] as isize - 1);
+                idx[d] = 0;
+            }
+        }
+    }
+}
+
+/// Parallel version of [`copy_strided_src_order`].
+///
+/// Outer dimensions (by source stride) are split across rayon threads; each
+/// thread runs a sequential odometer over the inner dimensions.
+/// Falls back to the single-threaded version for small tensors.
+#[cfg(feature = "parallel")]
+unsafe fn copy_strided_src_order_par<T: Copy + Send + Sync>(
+    src_ptr: *const T,
+    dst_ptr: *mut T,
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) {
+    let ndim = dims.len();
+    let n: usize = dims.iter().product();
+    if n == 0 {
+        return;
+    }
+
+    // Fall back to sequential when parallelism would add overhead without gain.
+    const PAR_THRESHOLD: usize = 1 << 20; // 1M elements
+    if n < PAR_THRESHOLD || rayon::current_num_threads() <= 1 {
+        copy_strided_src_order(src_ptr, dst_ptr, dims, src_strides, dst_strides);
+        return;
+    }
+
+    // Sort dimensions by source stride (ascending) → innermost = smallest src stride
+    let mut dim_order: Vec<usize> = (0..ndim).filter(|&i| dims[i] > 1).collect();
+    dim_order.sort_by_key(|&i| src_strides[i].unsigned_abs());
+
+    let sorted_dims: Vec<usize> = dim_order.iter().map(|&i| dims[i]).collect();
+    let sorted_src: Vec<isize> = dim_order.iter().map(|&i| src_strides[i]).collect();
+    let sorted_dst: Vec<isize> = dim_order.iter().map(|&i| dst_strides[i]).collect();
+    let nd = sorted_dims.len();
+
+    // Peel outer dims until we have enough parallel tasks (>= 4× threads).
+    let min_tasks = rayon::current_num_threads() * 4;
+    let mut split_at = nd; // index into sorted arrays: [0..split_at) inner, [split_at..nd) outer
+    let mut par_count: usize = 1;
+    while split_at > 0 && par_count < min_tasks {
+        split_at -= 1;
+        par_count *= sorted_dims[split_at];
+    }
+
+    let inner_n: usize = sorted_dims[..split_at].iter().product::<usize>().max(1);
+
+    // Convert pointers to usize for Send (same pattern as strided-perm).
+    let src_addr = src_ptr as usize;
+    let dst_addr = dst_ptr as usize;
+
+    let outer_dims = sorted_dims[split_at..].to_vec();
+    let outer_src = sorted_src[split_at..].to_vec();
+    let outer_dst = sorted_dst[split_at..].to_vec();
+    let inner_dims = sorted_dims[..split_at].to_vec();
+    let inner_src = sorted_src[..split_at].to_vec();
+    let inner_dst = sorted_dst[..split_at].to_vec();
+
+    (0..par_count).into_par_iter().for_each(|outer_idx| {
+        // Compute base offsets from outer multi-index.
+        let mut src_off: isize = 0;
+        let mut dst_off: isize = 0;
+        let mut rem = outer_idx;
+        for d in 0..outer_dims.len() {
+            let i = rem % outer_dims[d];
+            rem /= outer_dims[d];
+            src_off += i as isize * outer_src[d];
+            dst_off += i as isize * outer_dst[d];
+        }
+
+        let sp = (src_addr as isize + src_off * std::mem::size_of::<T>() as isize) as *const T;
+        let dp = (dst_addr as isize + dst_off * std::mem::size_of::<T>() as isize) as *mut T;
+
+        if split_at == 0 {
+            // No inner dims — single element per task.
+            unsafe { *dp = *sp };
+            return;
+        }
+
+        // Sequential odometer over inner dims.
+        let mut idx = vec![0usize; split_at];
+        let mut so: isize = 0;
+        let mut do_: isize = 0;
+
+        for _ in 0..inner_n {
+            unsafe { *dp.offset(do_) = *sp.offset(so) };
+
+            for d in 0..split_at {
+                idx[d] += 1;
+                if idx[d] < inner_dims[d] {
+                    so += inner_src[d];
+                    do_ += inner_dst[d];
+                    break;
+                } else {
+                    so -= inner_src[d] * (inner_dims[d] as isize - 1);
+                    do_ -= inner_dst[d] * (inner_dims[d] as isize - 1);
+                    idx[d] = 0;
+                }
+            }
+        }
+    });
+}
+
 /// Prepare an owned input array for GEMM.
 ///
 /// Expects batch-last canonical order: `[group1..., group2..., batch...]`.
@@ -433,7 +603,37 @@ pub fn prepare_input_owned<T: Scalar + 'static>(
     if needs_copy {
         let m: usize = group1_dims.iter().product::<usize>().max(1);
         let (mut buf, buf_is_pooled) = alloc_col_major_uninit_with_pool(&dims);
-        strided_kernel::copy_into_col_major(&mut buf.view_mut(), &arr.view())?;
+        // Use source-stride-order copy instead of HPTT (strided_kernel::copy_into_col_major).
+        // einsum2 always produces col-major output and only metadata permutations
+        // are applied between steps, so the source is physically contiguous but has
+        // scattered strides.  HPTT iterates in destination order → scattered reads
+        // from cold L3 cache.  Source-order iteration gives sequential reads that
+        // exploit the hardware prefetcher.  See doc comment on copy_strided_src_order.
+        {
+            let dst_strides = buf.strides().to_vec();
+            unsafe {
+                #[cfg(feature = "parallel")]
+                {
+                    copy_strided_src_order_par(
+                        arr.view().ptr(),
+                        buf.view_mut().as_mut_ptr(),
+                        &dims,
+                        &strides,
+                        &dst_strides,
+                    );
+                }
+                #[cfg(not(feature = "parallel"))]
+                {
+                    copy_strided_src_order(
+                        arr.view().ptr(),
+                        buf.view_mut().as_mut_ptr(),
+                        &dims,
+                        &strides,
+                        &dst_strides,
+                    );
+                }
+            }
+        }
         let ptr = buf.view().ptr();
         let batch_strides = buf.strides()[n_inner..].to_vec();
         let row_stride = if m == 0 { 0 } else { 1isize };

--- a/strided-opteinsum/Cargo.toml
+++ b/strided-opteinsum/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0"
 [features]
 default = ["faer"]
 faer = ["strided-einsum2/faer", "strided-einsum2/faer-traits"]
+parallel = ["strided-einsum2/parallel"]
 blas = ["strided-einsum2/blas"]
 blas-inject = ["strided-einsum2/blas-inject"]
 


### PR DESCRIPTION
## Summary

- Replace HPTT-based `copy_into_col_major` with source-stride-order copy (`copy_strided_src_order`) in `prepare_input_owned`. HPTT iterates in destination-stride order, causing scattered reads from cold L3 cache when the source is contiguous with many small permuted dimensions (e.g. 24 binary dims of size 2). Source-stride-order iteration gives sequential reads that exploit the hardware prefetcher.
- Add optional rayon parallelization (`--features parallel`) via `copy_strided_src_order_par` that splits outer source-stride dimensions across threads, with automatic fallback to sequential for small tensors or `RAYON_NUM_THREADS=1`.
- Update `docs/permutation-optimization.md` to reflect the new strategy and benchmark results.

## Benchmark results

`tensornetwork_permutation_light_415` (415 tensors, 24 binary dims, AMD EPYC 7713P):

| Configuration | opt_flops (ms) | Change |
|---|---:|---:|
| HPTT (original) 1T | 455 | baseline |
| Source-order copy 1T | 298 | **-34%** |
| Source-order + parallel 4T | 228 | **-50%** |

Full benchmark suite (10 instances, 1T): no regressions on other instances.

4T parallel copy effect (isolated from faer GEMM parallelism):

| Instance | 4T no-parallel | 4T parallel | Change |
|---|---:|---:|---:|
| tensornetwork_light_415 | 318 ms | 228 ms | **-28%** |
| tensornetwork_focus_409 | 319 ms | 226 ms | **-29%** |
| mera_closed_120 | 987 ms | 797 ms | **-19%** |
| mera_open_26 | 605 ms | 529 ms | **-12%** |

## Test plan

- [x] `cargo test -p strided-einsum2 --features parallel` (84 tests pass)
- [x] `cargo test -p strided-opteinsum --features parallel` (163 tests pass)
- [x] Full benchmark suite 1T: no regressions
- [x] Full benchmark suite 4T: parallel copy improves large instances
- [ ] CI tests (default features + parallel feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)