### PR TITLE
Expand strided einsum CPU kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ See each sub-crate README for detailed API examples and benchmarks:
 - [`mdarray-opteinsum`](mdarray-opteinsum/README.md) — einsum wrapper for `mdarray` arrays
 - [`ndarray-opteinsum`](ndarray-opteinsum/README.md) — einsum wrapper for `ndarray` arrays
 
+Performance design notes:
+- [`faer-kernel-writing-guide`](docs/faer-kernel-writing-guide.md) — practical rules for writing hot strided kernels based on faer
+- [`faer_design`](docs/faer_design.md) — SIMD design analysis and optimization plan
+
 ## Acknowledgments
 
 This crate is inspired by and ports functionality from:

--- a/docs/faer-kernel-writing-guide.md
+++ b/docs/faer-kernel-writing-guide.md
@@ -1,0 +1,322 @@
+# faer-Inspired Kernel Writing Guide
+
+This note summarizes high-performance Rust kernel patterns observed in a
+local clone of `faer-rs` and translates them into practical rules for
+`strided-rs`.
+
+Reference clone:
+
+- Repository: `https://github.com/sarah-ek/faer-rs.git`
+- Commit: `618b567f508604ae08f99460a9404a1a8b2b75ea`
+- Local path used for this analysis: `../faer-rs`
+
+The goal is not to copy faer's matrix multiplication machinery. The goal is to
+write `strided-kernel` elementwise, reduction, broadcast, and binary-einsum
+backend code in a style that keeps bounds checks, shape checks, allocation, and
+dispatch overhead out of the inner loop.
+
+## Relevant faer Patterns
+
+### `zip!` as a TensorIterator-like abstraction
+
+faer's public coefficient-wise API is centered on `zip!`, which is close in
+spirit to PyTorch's TensorIterator:
+
+- `faer/src/lib.rs:288` documents `zip!` for same-shape coefficient-wise
+  operations.
+- `faer/src/lib.rs:291` explicitly leaves traversal order unspecified.
+- `faer/src/linalg/zip.rs:441` checks shape once when creating a zip.
+- `faer/src/linalg/zip.rs:1396` picks a preferred layout before iteration.
+- `faer/src/linalg/zip.rs:1413` chooses the contiguous slice path once, or a
+  raw `get_unchecked` path for non-contiguous traversal.
+
+Rule for `strided-rs`: the public API should specify shape and semantics, not
+physical traversal order. The kernel planner should be free to reorder, fuse,
+or reverse dimensions before the hot loop, as long as the logical result is the
+same.
+
+### Runtime SIMD dispatch, compile-time kernel body
+
+faer uses `pulp::WithSimd` so runtime ISA selection happens outside the hot
+loop, while the loop body is monomorphized over `S: pulp::Simd`.
+
+Key references:
+
+- `faer-traits/src/lib.rs:1146` defines `SimdArch::dispatch`.
+- `faer/src/lib.rs:201` defines the `dispatch!` macro.
+- `faer/src/linalg/reductions/sum.rs:10` implements `pulp::WithSimd` for a
+  concrete reduction body.
+- `faer-traits/src/lib.rs:1247` exposes `SIMD_CAPABILITIES` and SIMD associated
+  vector/mask types through `ComplexField`.
+
+Rule for `strided-rs`: do feature and type dispatch once before entering the
+element loop. Do not branch per element on scalar type, SIMD availability,
+conjugation, broadcasting, or layout class.
+
+### Head/body/tail instead of scalar remainder loops
+
+faer's `SimdCtx` partitions a contiguous vector into masked head, full SIMD
+body, and masked tail:
+
+- `faer/src/utils/simd.rs:6` stores `head_end`, `body_end`, `tail_end`, and
+  masks.
+- `faer/src/utils/simd.rs:59` uses normal SIMD load/store for body lanes.
+- `faer/src/utils/simd.rs:90` and `faer/src/utils/simd.rs:123` use masked
+  load/store for head and tail lanes.
+- `faer/src/utils/simd.rs:388` returns typed head/body/tail indices.
+- `faer-traits/src/lib.rs:806` wraps masked load/store.
+
+Rule for `strided-rs`: for fixed operations on contiguous inner loops, prefer a
+single vectorized path with masked head/tail over a vector body followed by a
+scalar cleanup loop. This matters for short and medium inner blocks because
+remainder handling can dominate.
+
+### Alignment is a loop-plan property
+
+`SimdCtx::new_align` computes the head/body/tail split from pointer alignment:
+
+- `faer/src/utils/simd.rs:201` computes `align_offset`.
+- `faer/src/utils/simd.rs:216` shifts the head so the body is aligned.
+- `faer/src/utils/simd.rs:249` and `faer/src/utils/simd.rs:254` construct
+  memory masks for partial head/tail loads.
+- `faer/src/lib.rs:1036` defines `simd_align(i) = i.wrapping_neg()`.
+
+Rule for `strided-rs`: if a specialized contiguous kernel uses explicit SIMD,
+calculate alignment once from the actual inner-block pointer. The hot loop
+should only consume the resulting plan.
+
+### Multiple accumulators for reductions
+
+faer avoids loop-carried dependency chains in reductions by using several SIMD
+accumulators:
+
+- `faer/src/linalg/reductions/sum.rs:17` allocates four SIMD accumulators.
+- `faer/src/linalg/reductions/sum.rs:18` iterates with `batch_indices(); 4`.
+- `faer/src/linalg/reductions/sum.rs:22` combines accumulators as a tree.
+- `faer/src/linalg/reductions/norm_l2_sqr.rs:20` applies the same pattern to
+  `abs2` accumulation.
+
+Rule for `strided-rs`: fixed reductions such as `sum`, `dot`, norm-like
+reductions, and inner-product kernels should use independent accumulators.
+Do not expect LLVM to vectorize a generic closure-based reduction with a single
+scalar accumulator.
+
+### Compile-time unrolling
+
+faer's `simd_iter!` macro expands a batched SIMD loop with a compile-time batch
+index:
+
+- `faer/src/utils/simd.rs:433` builds arrays of `SimdBody` indices.
+- `faer/src/lib.rs:1284` defines `simd_iter!`.
+- `faer/src/lib.rs:1309` makes each batch index a `const`.
+
+Rule for `strided-rs`: use small fixed unroll factors for reductions and
+regular pointwise kernels. Avoid dynamic indexing into accumulator arrays in
+the hot loop unless the optimizer can see the index as a compile-time constant.
+
+### FMA is explicit
+
+faer exposes fused multiply-add through the scalar trait layer:
+
+- `faer-traits/src/lib.rs:550` wraps `simd_mul_add`.
+- `faer-traits/src/lib.rs:565` wraps `simd_conj_mul_add`.
+- `faer-traits/src/lib.rs:582` uses a const-generic conjugation branch for
+  `maybe_conj_mul_add`.
+- `faer-traits/src/lib.rs:604` wraps `abs2_add`.
+
+Rule for `strided-rs`: fixed operations such as `axpy`, `fma`, `dot`, and GEMM
+fallbacks should call an explicit FMA-capable path where available. Do not
+write these kernels only as generic closures if the operation is known.
+
+### Complex SIMD uses native complex lanes
+
+faer has two complex SIMD layers:
+
+- The generic `num_complex::Complex<T>` implementation composes real SIMD lanes
+  as `Complex<T::SimdVec<S>>`.
+- Native `c32` and `c64` kernels dispatch through `ComplexImpl<f32>` or
+  `ComplexImpl<f64>` and use `pulp::Simd` native complex lanes (`S::c32s`,
+  `S::c64s`).
+
+The native path calls operations such as `mul_e_c32s`, `mul_e_c64s`,
+`conj_mul_e_c32s`, and `conj_mul_e_c64s` directly. For `strided-kernel`
+elementwise complex multiplication, prefer the same direct `pulp::Simd`
+operations at the fixed-operation TypeId dispatch boundary. Do not add a broad
+trait abstraction unless multiple complex kernels need the same dispatch
+surface.
+
+## Bounds-Check Avoidance
+
+faer's pattern is not "use unsafe everywhere." It is:
+
+1. Validate shape, layout, and aliasing before the loop.
+2. Convert the validated region to a slice or pointer-based representation.
+3. Run the hot loop without per-element validation.
+
+Examples:
+
+- `faer/src/linalg/zip.rs:377` defines `get_slice_unchecked`.
+- `faer/src/linalg/zip.rs:384` defines `get_unchecked`.
+- `faer/src/linalg/zip.rs:646` builds a mutable slice with
+  `core::slice::from_raw_parts_mut`.
+- `faer/src/linalg/zip.rs:672` advances through a contiguous slice with
+  `split_first_mut().unwrap_unchecked()`.
+- `faer/src/linalg/zip.rs:1413` chooses the contiguous slice path once and then
+  loops over unchecked slice elements.
+- `faer/src/mat/matref.rs:391` exposes an in-bounds pointer helper with explicit
+  safety requirements.
+- `faer/src/mat/matmut.rs:120` documents mutable view safety invariants,
+  including no aliasing and no two elements sharing the same address.
+
+Rule for `strided-rs`: expose safe public APIs, but inside validated kernels,
+move error handling and range checks outside the inner loop. The inner loop
+should be pointer increments, slice indexing that LLVM can eliminate, or
+unchecked slice progression.
+
+For mutable outputs, the planner must prove that every logical output element
+maps to a unique address. A stride-0 mutable destination is not a valid target
+for a pointwise write kernel.
+
+## Current strided-rs Baseline
+
+`strided-rs` already uses part of this style:
+
+- `strided-kernel/src/map_view.rs:57` specializes binary inner loops by stride
+  pattern.
+- `strided-kernel/src/map_view.rs:78` handles `dst stride = 1`, one input
+  contiguous, one input broadcast (`stride = 0`).
+- `strided-kernel/src/map_view.rs:87` handles the symmetric broadcast case.
+- `strided-kernel/src/simd.rs:63` implements f32 SIMD `sum`/`dot`.
+- `strided-kernel/src/simd.rs:148` implements f64 SIMD `sum`/`dot`.
+- `strided-kernel/src/simd.rs:73` and `strided-kernel/src/simd.rs:118` already
+  use four accumulators.
+
+The remaining gap versus faer is mostly:
+
+- `strided-kernel/src/simd.rs:71` and `strided-kernel/src/simd.rs:113` use
+  `as_simd_*` plus scalar tail loops, not masked head/body/tail.
+- Alignment is not treated as an inner-block property.
+- Fixed operations such as `add`, `mul`, `axpy`, and `fma` still mostly rely on
+  generic closure loops.
+- Generic reductions still have loop-carried scalar accumulators.
+
+## Direct Application to strided-kernel
+
+### Broadcasted binary pointwise operations
+
+PyTorch's `aten::mul` performance comes from a TensorIterator-like path:
+broadcasted inputs have stride `0`, output can be non-contiguous but dense, and
+the inner loop is specialized by stride pattern.
+
+`strided-rs` already has the necessary metadata operation:
+
+- `strided-view/src/view.rs:300` implements `StridedView::broadcast` by setting
+  expanded axes to stride `0`.
+
+faer uses the same representation for scalar repetition:
+
+- `faer/src/mat/matref.rs:124` creates a `1 x 1` view over a reference.
+- `faer/src/mat/matref.rs:134` creates repeated scalar views with row and
+  column stride `0`.
+
+The missing abstraction is a public API that performs TensorIterator-like shape
+promotion and then calls the existing stride-specialized machinery:
+
+```rust
+pub fn zip_map2_broadcast_into<D, A, B, OpA, OpB>(
+    dest: &mut StridedViewMut<D>,
+    a: &StridedView<A, OpA>,
+    b: &StridedView<B, OpB>,
+    f: impl Fn(A, B) -> D + MaybeSync,
+) -> Result<()>
+```
+
+For `mul`, add a fixed operation wrapper:
+
+```rust
+pub fn broadcast_mul_into<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    a: &StridedView<T, OpA>,
+    b: &StridedView<T, OpB>,
+) -> Result<()>
+```
+
+Rule: keep shape promotion and `broadcast()` calls outside the timed inner
+loop. Once views are aligned, dispatch to a stride-specialized kernel.
+
+### `zip_map2_into`
+
+Current `zip_map2_into` already has good first-order structure:
+
+- `strided-kernel/src/map_view.rs:357` has a fully sequential contiguous fast
+  path.
+- `strided-kernel/src/map_view.rs:376` skips full planning for small tensors.
+- `strided-kernel/src/map_view.rs:428` enters block iteration only after the
+  plan is built.
+
+The next improvements should be:
+
+- Add fixed-operation kernels for `copy`, `mul`, `add`, `axpy`, `fma`, and
+  `dot` instead of relying only on closure-based `zip_map2_into`.
+- Preserve the current generic `zip_map2_into` as the fallback for arbitrary
+  closures.
+- For known f32/f64 contiguous or stride-0 broadcast cases, use explicit SIMD
+  loops instead of hoping the closure path auto-vectorizes.
+
+### Batched outer product
+
+`batched_outer_product_into` is now a semantic wrapper around
+`broadcast_mul_into`. It validates the outer-product dimension grouping, builds
+the corresponding axis maps, and lets the generic broadcasted `mul` planner
+select the actual kernel.
+
+This avoids two competing implementations for the same operation. Add a
+specialized batched outer-product kernel only if the generic
+TensorIterator-like path leaves a measured gap that cannot be closed in the
+shared pointwise planner.
+
+## Checklist for New Hot Kernels
+
+Before adding a new optimized kernel:
+
+- Validate shapes, ranks, strides, and output size once.
+- Decide layout class once: contiguous, dst-contiguous with broadcast input,
+  compact grouped, or fully strided.
+- Allocate any offset vectors, workspace, or output storage outside the timed
+  loop.
+- Make broadcast explicit as stride `0`, not as repeated indexing logic.
+- Use a fixed-operation path for known operations; use closures only for the
+  generic fallback.
+- Keep scalar type dispatch outside the hot loop.
+- Use pointer increments or slices in the inner loop; avoid `Result`, `Option`,
+  `Vec`, `HashMap`, `SmallVec` mutation, or shape lookup per element.
+- For reductions, use multiple accumulators and a tree combine.
+- For FMA-like operations, use explicit FMA when possible.
+- Add a benchmark that isolates the kernel from tensor-wrapper overhead.
+
+## What Not To Do
+
+- Do not add one-off fast paths in tenferro for each benchmark shape.
+- Do not put layout detection inside the per-element loop.
+- Do not benchmark a kernel through the full tenferro eager/traced stack first.
+  Benchmark it directly in `strided-kernel` or `strided-einsum2`, then measure
+  tenferro overhead separately.
+- Do not treat `unsafe` as the optimization. The optimization is proving the
+  invariants once, then expressing the loop in a form LLVM can compile well.
+
+## Implication for Binary Einsum Backend
+
+The intended dependency direction is:
+
+```text
+tenferro CPU eager/traced
+  -> strided-einsum2 dot_general/tensordot/binary-einsum API
+    -> strided-kernel broadcasted pointwise, outer product, reduction, copy
+       kernels
+```
+
+`strided-einsum2` should expose axis-based `tensordot_into` and
+`dot_general_into` APIs so tenferro can call them without label parsing or
+contraction-plan allocation. For `sum_dims.is_empty()`, `strided-einsum2`
+should lower to a broadcasted pointwise kernel. For true contractions, it
+should keep using the existing GEMM backend path.

--- a/docs/plans/2026-06-06-dot-general-strided-einsum2-merge.md
+++ b/docs/plans/2026-06-06-dot-general-strided-einsum2-merge.md
@@ -1,0 +1,1121 @@
+# DotGeneral strided-einsum2 Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the reusable general dot product implementation into `strided-einsum2`, then replace tenferro's duplicated CPU GEMM/dot-general kernel with a thin adapter.
+
+**Architecture:** `strided-einsum2` becomes the kernel crate for binary tensor contraction and `DotGeneralConfig`-style axis APIs. tenferro keeps runtime concerns only: dtype dispatch, backend selection, buffer-pool allocation, runtime cache slots, and graph/compiler passes. The graph-level `DotGeneral` decomposition stays in `tenferro-runtime`.
+
+**Tech Stack:** Rust 2021, `strided-view`, `strided-kernel`, `strided-perm`, `strided-einsum2`, `tenferro-cpu`, `faer`, CBLAS provider features.
+
+---
+
+## File Structure
+
+- Modify: `strided-rs/strided-einsum2/Cargo.toml`
+  - Add `smallvec` for low-allocation dot-general planning.
+- Create: `strided-rs/strided-einsum2/src/dot_general.rs`
+  - Define borrowed-slice `DotGeneralConfig`.
+  - Validate axis roles and shape compatibility.
+  - Build a reusable axis-label plan for the existing `einsum2_dispatch`.
+  - Expose `dot_general_into`, `dot_general_with_backend_into`, and internal helpers.
+- Modify: `strided-rs/strided-einsum2/src/lib.rs`
+  - Export the new module/types/functions.
+  - Make the existing internal dispatch reusable by dot-general entry points.
+  - Adjust active backend selection so BLAS can coexist with faer and be preferred when explicitly enabled.
+- Modify: `strided-rs/strided-einsum2/src/backend.rs`
+  - Allow compiling `FaerBackend` and `BlasBackend` in the same crate build.
+  - Keep one `ActiveBackend` for legacy `einsum2_into`.
+- Create: `strided-rs/strided-einsum2/tests/dot_general.rs`
+  - Integration tests for matmul, batched matmul, rank-0 dot, transposed output, invalid configs, zero-sized outputs.
+- Modify: `tenferro-rs/Cargo.toml`
+  - Add `strided-einsum2` as a dependency pinned to the updated `strided-rs` revision after the strided change lands.
+- Modify: `tenferro-rs/crates/tenferro-cpu/Cargo.toml`
+  - Wire tenferro CPU features to `strided-einsum2` features without breaking `provider-src` and `provider-inject`.
+- Create: `tenferro-rs/crates/tenferro-cpu/src/gemm/strided_dot.rs`
+  - Convert `TypedTensorRead` inputs into `strided_view::StridedView`.
+  - Allocate tenferro outputs through `BufferPool`.
+  - Call `strided_einsum2::dot_general_with_backend_into`.
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/gemm/mod.rs`
+  - Route `dot_general_faer*_cached` and `dot_general_blas*_cached` through the adapter.
+  - Keep `GemmAnalysisCache` as the tenferro runtime cache wrapper during the first replacement.
+  - Remove duplicated direct GEMM loops only after all tests pass.
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs`
+  - Keep existing public behavior tests; add one test that confirms transposed `TensorRead` inputs stay accepted.
+- Modify: `tenferro-rs/crates/tenferro-cpu/benches/dot_general_overhead.rs`
+  - Compare old cache-slot behavior against the strided adapter path for direct matmul and view input cases.
+
+---
+
+### Task 1: Add dot-general correctness tests in strided-einsum2
+
+**Files:**
+- Create: `strided-rs/strided-einsum2/tests/dot_general.rs`
+
+- [ ] **Step 1: Write integration tests before implementation**
+
+Create `strided-rs/strided-einsum2/tests/dot_general.rs` with:
+
+```rust
+use strided_einsum2::{dot_general_into, DotGeneralConfig};
+use strided_view::StridedArray;
+
+fn get_col_major(data: &[f64], shape: &[usize], idx: &[usize]) -> f64 {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&i, &dim) in idx.iter().zip(shape) {
+        offset += i * stride;
+        stride *= dim;
+    }
+    data[offset]
+}
+
+fn expected_matmul_col_major(
+    a: &[f64],
+    a_shape: &[usize],
+    b: &[f64],
+    b_shape: &[usize],
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Vec<f64> {
+    let mut out = vec![0.0; m * n];
+    for j in 0..n {
+        for i in 0..m {
+            let mut acc = 0.0;
+            for p in 0..k {
+                acc += get_col_major(a, a_shape, &[i, p])
+                    * get_col_major(b, b_shape, &[p, j]);
+            }
+            out[i + m * j] = acc;
+        }
+    }
+    out
+}
+
+#[test]
+fn dot_general_matmul_matches_col_major_reference() {
+    let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let b_data = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
+    let a = StridedArray::<f64>::from_vec_col_major(&[2, 3], a_data.clone()).unwrap();
+    let b = StridedArray::<f64>::from_vec_col_major(&[3, 2], b_data.clone()).unwrap();
+    let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(
+        c.data(),
+        expected_matmul_col_major(&a_data, &[2, 3], &b_data, &[3, 2], 2, 2, 3).as_slice()
+    );
+}
+
+#[test]
+fn dot_general_batched_matmul_uses_batch_trailing_output_shape() {
+    let a = StridedArray::<f64>::from_fn_col_major(&[2, 3, 2], |idx| {
+        (100 * idx[2] + 10 * idx[1] + idx[0] + 1) as f64
+    });
+    let b = StridedArray::<f64>::from_fn_col_major(&[3, 4, 2], |idx| {
+        (100 * idx[2] + 10 * idx[1] + idx[0] + 1) as f64
+    });
+    let mut c = StridedArray::<f64>::col_major(&[2, 4, 2]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![2],
+            rhs_batch_dims: vec![2],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    for batch in 0..2 {
+        for j in 0..4 {
+            for i in 0..2 {
+                let mut expected = 0.0;
+                for p in 0..3 {
+                    expected += a[[i, p, batch]] * b[[p, j, batch]];
+                }
+                assert_eq!(c[[i, j, batch]], expected);
+            }
+        }
+    }
+}
+
+#[test]
+fn dot_general_inner_product_returns_rank0_scalar() {
+    let a = StridedArray::<f64>::from_vec_col_major(&[3], vec![1.0, 2.0, 3.0]).unwrap();
+    let b = StridedArray::<f64>::from_vec_col_major(&[3], vec![4.0, 5.0, 6.0]).unwrap();
+    let mut c = StridedArray::<f64>::col_major(&[]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![0],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(c.data(), &[32.0]);
+}
+
+#[test]
+fn dot_general_rejects_wrong_output_shape() {
+    let a = StridedArray::<f64>::col_major(&[2, 3]);
+    let b = StridedArray::<f64>::col_major(&[3, 4]);
+    let mut c = StridedArray::<f64>::col_major(&[4, 2]);
+
+    let err = dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("output shape mismatch"));
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo test -p strided-einsum2 --test dot_general
+```
+
+Expected: compile failure because `DotGeneralConfig` and `dot_general_into` are not defined.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+git add strided-einsum2/tests/dot_general.rs
+git commit -m "test: add dot-general coverage for strided-einsum2"
+```
+
+---
+
+### Task 2: Add DotGeneralConfig and axis-label planning in strided-einsum2
+
+**Files:**
+- Modify: `strided-rs/strided-einsum2/Cargo.toml`
+- Create: `strided-rs/strided-einsum2/src/dot_general.rs`
+- Modify: `strided-rs/strided-einsum2/src/lib.rs`
+
+- [ ] **Step 1: Add `smallvec` to strided-einsum2**
+
+In `strided-rs/strided-einsum2/Cargo.toml`, add:
+
+```toml
+smallvec.workspace = true
+```
+
+- [ ] **Step 2: Add error variants**
+
+In `strided-rs/strided-einsum2/src/lib.rs`, extend `EinsumError`:
+
+```rust
+#[error("invalid dot-general config: {0}")]
+InvalidDotGeneralConfig(String),
+#[error("output shape mismatch: expected {expected:?}, got {got:?}")]
+OutputShapeMismatch {
+    expected: Vec<usize>,
+    got: Vec<usize>,
+},
+```
+
+- [ ] **Step 3: Add dot-general planning module**
+
+Create `strided-rs/strided-einsum2/src/dot_general.rs`:
+
+```rust
+use smallvec::SmallVec;
+
+use crate::{EinsumError, Result};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct DotGeneralConfig {
+    pub lhs_contracting_dims: Vec<usize>,
+    pub rhs_contracting_dims: Vec<usize>,
+    pub lhs_batch_dims: Vec<usize>,
+    pub rhs_batch_dims: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DotGeneralLabels {
+    pub lhs_labels: SmallVec<[usize; 8]>,
+    pub rhs_labels: SmallVec<[usize; 8]>,
+    pub out_labels: SmallVec<[usize; 8]>,
+    pub out_shape: SmallVec<[usize; 8]>,
+}
+
+fn check_no_duplicates(dims: &[usize], label: &str) -> Result<()> {
+    for (i, &dim) in dims.iter().enumerate() {
+        if dims[..i].contains(&dim) {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "{label} contains duplicate dim {dim}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn check_bounds(dims: &[usize], rank: usize, label: &str) -> Result<()> {
+    for &dim in dims {
+        if dim >= rank {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "{label} dim {dim} out of bounds for rank {rank}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn free_dims(rank: usize, contracting: &[usize], batch: &[usize]) -> SmallVec<[usize; 8]> {
+    (0..rank)
+        .filter(|dim| !contracting.contains(dim) && !batch.contains(dim))
+        .collect()
+}
+
+impl DotGeneralConfig {
+    pub fn validate_dims_with_ranks(&self, lhs_rank: usize, rhs_rank: usize) -> Result<()> {
+        check_bounds(&self.lhs_contracting_dims, lhs_rank, "lhs_contracting")?;
+        check_bounds(&self.rhs_contracting_dims, rhs_rank, "rhs_contracting")?;
+        check_bounds(&self.lhs_batch_dims, lhs_rank, "lhs_batch")?;
+        check_bounds(&self.rhs_batch_dims, rhs_rank, "rhs_batch")?;
+        check_no_duplicates(&self.lhs_contracting_dims, "lhs_contracting_dims")?;
+        check_no_duplicates(&self.rhs_contracting_dims, "rhs_contracting_dims")?;
+        check_no_duplicates(&self.lhs_batch_dims, "lhs_batch_dims")?;
+        check_no_duplicates(&self.rhs_batch_dims, "rhs_batch_dims")?;
+        for &dim in &self.lhs_contracting_dims {
+            if self.lhs_batch_dims.contains(&dim) {
+                return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                    "lhs dim {dim} appears in both contracting and batch dims"
+                )));
+            }
+        }
+        for &dim in &self.rhs_contracting_dims {
+            if self.rhs_batch_dims.contains(&dim) {
+                return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                    "rhs dim {dim} appears in both contracting and batch dims"
+                )));
+            }
+        }
+        if self.lhs_contracting_dims.len() != self.rhs_contracting_dims.len() {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "lhs/rhs contracting dim counts differ ({} vs {})",
+                self.lhs_contracting_dims.len(),
+                self.rhs_contracting_dims.len()
+            )));
+        }
+        if self.lhs_batch_dims.len() != self.rhs_batch_dims.len() {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "lhs/rhs batch dim counts differ ({} vs {})",
+                self.lhs_batch_dims.len(),
+                self.rhs_batch_dims.len()
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn labels_for_shapes(
+        &self,
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+        out_shape: &[usize],
+    ) -> Result<DotGeneralLabels> {
+        self.validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())?;
+
+        let lhs_free = free_dims(lhs_shape.len(), &self.lhs_contracting_dims, &self.lhs_batch_dims);
+        let rhs_free = free_dims(rhs_shape.len(), &self.rhs_contracting_dims, &self.rhs_batch_dims);
+
+        let mut lhs_labels = SmallVec::<[usize; 8]>::from_vec(vec![usize::MAX; lhs_shape.len()]);
+        let mut rhs_labels = SmallVec::<[usize; 8]>::from_vec(vec![usize::MAX; rhs_shape.len()]);
+        let mut next_label = 0usize;
+
+        for (&lhs_dim, &rhs_dim) in self.lhs_batch_dims.iter().zip(&self.rhs_batch_dims) {
+            if lhs_shape[lhs_dim] != rhs_shape[rhs_dim] {
+                return Err(EinsumError::DimensionMismatch {
+                    axis: format!("batch lhs {lhs_dim} rhs {rhs_dim}"),
+                    dim_a: lhs_shape[lhs_dim],
+                    dim_b: rhs_shape[rhs_dim],
+                });
+            }
+            lhs_labels[lhs_dim] = next_label;
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+
+        for &lhs_dim in &lhs_free {
+            lhs_labels[lhs_dim] = next_label;
+            next_label += 1;
+        }
+        for &rhs_dim in &rhs_free {
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+
+        for (&lhs_dim, &rhs_dim) in self
+            .lhs_contracting_dims
+            .iter()
+            .zip(&self.rhs_contracting_dims)
+        {
+            if lhs_shape[lhs_dim] != rhs_shape[rhs_dim] {
+                return Err(EinsumError::DimensionMismatch {
+                    axis: format!("contract lhs {lhs_dim} rhs {rhs_dim}"),
+                    dim_a: lhs_shape[lhs_dim],
+                    dim_b: rhs_shape[rhs_dim],
+                });
+            }
+            lhs_labels[lhs_dim] = next_label;
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+
+        let mut expected_out_shape = SmallVec::<[usize; 8]>::new();
+        expected_out_shape.extend(lhs_free.iter().map(|&dim| lhs_shape[dim]));
+        expected_out_shape.extend(rhs_free.iter().map(|&dim| rhs_shape[dim]));
+        expected_out_shape.extend(self.lhs_batch_dims.iter().map(|&dim| lhs_shape[dim]));
+        if expected_out_shape.as_slice() != out_shape {
+            return Err(EinsumError::OutputShapeMismatch {
+                expected: expected_out_shape.iter().copied().collect(),
+                got: out_shape.to_vec(),
+            });
+        }
+
+        let mut out_labels = SmallVec::<[usize; 8]>::new();
+        out_labels.extend(lhs_free.iter().map(|&dim| lhs_labels[dim]));
+        out_labels.extend(rhs_free.iter().map(|&dim| rhs_labels[dim]));
+        out_labels.extend(self.lhs_batch_dims.iter().map(|&dim| lhs_labels[dim]));
+
+        Ok(DotGeneralLabels {
+            lhs_labels,
+            rhs_labels,
+            out_labels,
+            out_shape: expected_out_shape,
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Export the module**
+
+In `strided-rs/strided-einsum2/src/lib.rs`, add:
+
+```rust
+/// Axis-based general dot product API.
+pub mod dot_general;
+pub use dot_general::DotGeneralConfig;
+```
+
+- [ ] **Step 5: Run focused tests and verify failure has moved to missing functions**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo test -p strided-einsum2 --test dot_general
+```
+
+Expected: compile failure only for missing `dot_general_into`.
+
+- [ ] **Step 6: Commit config and planning**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+git add strided-einsum2/Cargo.toml strided-einsum2/src/lib.rs strided-einsum2/src/dot_general.rs
+git commit -m "feat: add dot-general axis planning"
+```
+
+---
+
+### Task 3: Implement strided-einsum2 dot_general entry points
+
+**Files:**
+- Modify: `strided-rs/strided-einsum2/src/lib.rs`
+- Modify: `strided-rs/strided-einsum2/src/dot_general.rs`
+
+- [ ] **Step 1: Make the internal dispatch reusable**
+
+In `strided-rs/strided-einsum2/src/lib.rs`, change:
+
+```rust
+fn einsum2_dispatch<T, B, ID>(
+```
+
+to:
+
+```rust
+pub(crate) fn einsum2_dispatch<T, B, ID>(
+```
+
+- [ ] **Step 2: Add generic backend dot-general function**
+
+In `strided-rs/strided-einsum2/src/dot_general.rs`, add:
+
+```rust
+use strided_view::{StridedView, StridedViewMut};
+
+use crate::backend::Backend;
+use crate::{einsum2_dispatch, Einsum2Plan, ScalarBase};
+
+pub fn dot_general_with_backend_into<T, B>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+where
+    T: ScalarBase,
+    B: Backend<T>,
+{
+    let labels = config.labels_for_shapes(a.dims(), b.dims(), c.dims())?;
+    let plan = Einsum2Plan::new(
+        labels.lhs_labels.as_slice(),
+        labels.rhs_labels.as_slice(),
+        labels.out_labels.as_slice(),
+    )?;
+    einsum2_dispatch::<T, B, _>(c, a, b, &plan, alpha, beta, false, false, None)
+}
+```
+
+- [ ] **Step 3: Add active-backend dot-general function**
+
+In `strided-rs/strided-einsum2/src/dot_general.rs`, add:
+
+```rust
+#[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
+pub fn dot_general_into<T: crate::Scalar>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+where
+    crate::backend::ActiveBackend: Backend<T>,
+{
+    dot_general_with_backend_into::<T, crate::backend::ActiveBackend>(c, a, b, config, alpha, beta)
+}
+
+#[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+pub fn dot_general_into<T: crate::Scalar>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig,
+    alpha: T,
+    beta: T,
+) -> Result<()> {
+    let labels = config.labels_for_shapes(a.dims(), b.dims(), c.dims())?;
+    crate::einsum2_naive_into(
+        c,
+        a,
+        b,
+        labels.out_labels.as_slice(),
+        labels.lhs_labels.as_slice(),
+        labels.rhs_labels.as_slice(),
+        alpha,
+        beta,
+        |x| x,
+        |x| x,
+    )
+}
+```
+
+- [ ] **Step 4: Re-export public functions**
+
+In `strided-rs/strided-einsum2/src/lib.rs`, replace the earlier re-export with:
+
+```rust
+pub use dot_general::{dot_general_into, dot_general_with_backend_into, DotGeneralConfig};
+```
+
+- [ ] **Step 5: Run strided dot-general tests**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo test -p strided-einsum2 --test dot_general
+```
+
+Expected: all tests in `tests/dot_general.rs` pass.
+
+- [ ] **Step 6: Run existing strided-einsum2 tests**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo test -p strided-einsum2
+cargo test -p strided-einsum2 --no-default-features
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit entry points**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+git add strided-einsum2/src/lib.rs strided-einsum2/src/dot_general.rs
+git commit -m "feat: add strided dot-general entry points"
+```
+
+---
+
+### Task 4: Allow faer and BLAS implementations to coexist in strided-einsum2
+
+**Files:**
+- Modify: `strided-rs/strided-einsum2/src/lib.rs`
+- Modify: `strided-rs/strided-einsum2/src/backend.rs`
+
+- [ ] **Step 1: Relax feature exclusivity**
+
+In `strided-rs/strided-einsum2/src/lib.rs`, remove the compile errors for `faer + blas` and `faer + blas-inject`. Keep the error for `blas + blas-inject`:
+
+```rust
+#[cfg(all(feature = "blas", feature = "blas-inject"))]
+compile_error!("Features `blas` and `blas-inject` are mutually exclusive.");
+```
+
+- [ ] **Step 2: Make `Scalar` bounds work when both faer and BLAS are enabled**
+
+Replace the cfg blocks for `Scalar` with precedence-based cfgs:
+
+```rust
+#[cfg(any(feature = "blas", feature = "blas-inject"))]
+pub trait Scalar: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
+
+#[cfg(any(feature = "blas", feature = "blas-inject"))]
+impl<T> Scalar for T where T: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
+
+#[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
+pub trait Scalar: ScalarBase + ElementOpApply + faer_traits::ComplexField {}
+
+#[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
+impl<T> Scalar for T where T: ScalarBase + ElementOpApply + faer_traits::ComplexField {}
+
+#[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+pub trait Scalar: ScalarBase + ElementOpApply {}
+
+#[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+impl<T> Scalar for T where T: ScalarBase + ElementOpApply {}
+```
+
+- [ ] **Step 3: Prefer BLAS for ActiveBackend when BLAS exists**
+
+In `strided-rs/strided-einsum2/src/backend.rs`, set `ActiveBackend` in this order:
+
+```rust
+#[cfg(any(feature = "blas", feature = "blas-inject"))]
+pub type ActiveBackend = BlasBackend;
+
+#[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
+pub type ActiveBackend = FaerBackend;
+
+#[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+pub type ActiveBackend = NaiveBackend;
+```
+
+- [ ] **Step 4: Compile the feature matrix**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo check -p strided-einsum2
+cargo check -p strided-einsum2 --no-default-features
+cargo check -p strided-einsum2 --no-default-features --features faer
+cargo check -p strided-einsum2 --no-default-features --features blas
+cargo check -p strided-einsum2 --no-default-features --features faer,blas
+cargo check -p strided-einsum2 --no-default-features --features blas,blas-inject
+```
+
+Expected:
+- The first five commands pass.
+- The final `blas,blas-inject` command fails with the intended compile error.
+
+- [ ] **Step 5: Commit backend coexistence**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+git add strided-einsum2/src/lib.rs strided-einsum2/src/backend.rs
+git commit -m "feat: allow explicit faer and blas dot backends"
+```
+
+---
+
+### Task 5: Add tenferro adapter using strided-einsum2
+
+**Files:**
+- Modify: `tenferro-rs/Cargo.toml`
+- Modify: `tenferro-rs/crates/tenferro-cpu/Cargo.toml`
+- Create: `tenferro-rs/crates/tenferro-cpu/src/gemm/strided_dot.rs`
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/gemm/mod.rs`
+
+- [ ] **Step 1: Add the dependency for local development**
+
+In `tenferro-rs/Cargo.toml`, add a temporary local dependency while developing:
+
+```toml
+strided-einsum2 = { path = "../strided-rs/strided-einsum2", default-features = false }
+```
+
+Before committing to `origin/main`, replace the path with a git revision from the pushed `strided-rs` commit:
+
+```toml
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "the output of git rev-parse HEAD from the pushed strided-rs commit", default-features = false }
+```
+
+- [ ] **Step 2: Wire tenferro-cpu features**
+
+In `tenferro-rs/crates/tenferro-cpu/Cargo.toml`, add:
+
+```toml
+[dependencies]
+strided-einsum2 = { workspace = true, optional = true }
+```
+
+Then update feature wiring so `cpu-faer` enables `strided-einsum2/faer`, and normal BLAS provider builds enable `strided-einsum2/blas`. Keep `provider-inject` on `strided-einsum2/blas-inject` only if the crate-level feature matrix confirms it does not also enable `strided-einsum2/blas`.
+
+- [ ] **Step 3: Add adapter skeleton**
+
+Create `tenferro-rs/crates/tenferro-cpu/src/gemm/strided_dot.rs`:
+
+```rust
+use num_traits::{One, Zero};
+use strided_view::{col_major_strides, StridedView, StridedViewMut};
+use tenferro_tensor::{Buffer, DotGeneralConfig, TypedTensor};
+
+use crate::buffer_pool::{BufferPool, PoolScalar};
+use crate::{default_placement, Error};
+
+use super::TypedTensorRead;
+
+fn map_strided_error(err: impl std::fmt::Display) -> Error {
+    Error::backend_failure("dot_general", err.to_string())
+}
+
+fn as_strided_view<'a, R, T>(read: &'a R) -> crate::Result<Option<StridedView<'a, T>>>
+where
+    R: TypedTensorRead<T>,
+    T: 'static,
+{
+    let Some(data) = read.host_data_opt() else {
+        return Ok(None);
+    };
+    StridedView::new(data, read.shape(), read.strides().as_slice(), read.offset())
+        .map(Some)
+        .map_err(map_strided_error)
+}
+
+pub(crate) fn dot_general_strided_with_backend<L, R, T, B>(
+    buffers: &mut BufferPool,
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<TypedTensor<T>>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: PoolScalar
+        + Copy
+        + Clone
+        + Zero
+        + One
+        + PartialEq
+        + strided_einsum2::ScalarBase
+        + 'static,
+    B: strided_einsum2::Backend<T>,
+{
+    let Some(lhs_view) = as_strided_view(lhs)? else {
+        return Ok(None);
+    };
+    let Some(rhs_view) = as_strided_view(rhs)? else {
+        return Ok(None);
+    };
+
+    let local_config = strided_einsum2::DotGeneralConfig {
+        lhs_contracting_dims: config.lhs_contracting_dims.clone(),
+        rhs_contracting_dims: config.rhs_contracting_dims.clone(),
+        lhs_batch_dims: config.lhs_batch_dims.clone(),
+        rhs_batch_dims: config.rhs_batch_dims.clone(),
+    };
+    let out_shape = local_config
+        .expected_output_shape(lhs.shape(), rhs.shape())
+        .map_err(map_strided_error)?;
+    let out_n = out_shape.iter().product::<usize>().max(1);
+    let mut out_data = unsafe { T::pool_acquire(buffers, out_n) };
+    if out_n > 0 {
+        out_data.fill(T::zero());
+    }
+    let out_strides = col_major_strides(&out_shape);
+    let out_view = StridedViewMut::new(&mut out_data, &out_shape, &out_strides, 0)
+        .map_err(map_strided_error)?;
+
+    strided_einsum2::dot_general_with_backend_into::<T, B>(
+        out_view,
+        &lhs_view,
+        &rhs_view,
+        &local_config,
+        T::one(),
+        T::zero(),
+    )
+    .map_err(map_strided_error)?;
+
+    Ok(Some(TypedTensor::from_buffer_col_major(
+        out_shape,
+        Buffer::Host(out_data),
+        default_placement(),
+    )))
+}
+```
+
+This step requires `expected_output_shape` to be exposed from `strided-einsum2::DotGeneralConfig`. If Task 2 kept it private inside `labels_for_shapes`, add:
+
+```rust
+pub fn expected_output_shape(
+    &self,
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+) -> Result<Vec<usize>> {
+    let lhs_free = free_dims(lhs_shape.len(), &self.lhs_contracting_dims, &self.lhs_batch_dims);
+    let rhs_free = free_dims(rhs_shape.len(), &self.rhs_contracting_dims, &self.rhs_batch_dims);
+    let mut out = Vec::with_capacity(lhs_free.len() + rhs_free.len() + self.lhs_batch_dims.len());
+    out.extend(lhs_free.iter().map(|&dim| lhs_shape[dim]));
+    out.extend(rhs_free.iter().map(|&dim| rhs_shape[dim]));
+    out.extend(self.lhs_batch_dims.iter().map(|&dim| lhs_shape[dim]));
+    Ok(out)
+}
+```
+
+- [ ] **Step 4: Expose the adapter module**
+
+In `tenferro-rs/crates/tenferro-cpu/src/gemm/mod.rs`, add:
+
+```rust
+mod strided_dot;
+```
+
+- [ ] **Step 5: Compile tenferro-cpu**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo check -p tenferro-cpu
+```
+
+Expected: the adapter compiles before it is used.
+
+- [ ] **Step 6: Commit adapter skeleton**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+git add Cargo.toml crates/tenferro-cpu/Cargo.toml crates/tenferro-cpu/src/gemm/mod.rs crates/tenferro-cpu/src/gemm/strided_dot.rs
+git commit -m "feat: add strided dot-general adapter"
+```
+
+---
+
+### Task 6: Route tenferro dot_general through the strided adapter
+
+**Files:**
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/gemm/mod.rs`
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs`
+
+- [ ] **Step 1: Replace faer direct GEMM call**
+
+In the faer dispatch path inside `dot_general_faer_read_cached`, replace the call to `typed_faer_gemm` with:
+
+```rust
+return strided_dot::dot_general_strided_with_backend::<_, _, _, strided_einsum2::backend::FaerBackend>(
+    buffers,
+    a,
+    b,
+    config,
+)
+.map(|result| result.map(crate::Tensor::$wrap));
+```
+
+Keep `typed_faer_gemm` in the file until all tests pass; this makes rollback and comparison easy during the task.
+
+- [ ] **Step 2: Replace BLAS direct GEMM call**
+
+In the BLAS dispatch path inside `dot_general_blas_read_cached`, replace the call to `typed_blas_gemm` or `typed_blas_gemm_with_conj` for non-conjugated inputs with:
+
+```rust
+return strided_dot::dot_general_strided_with_backend::<_, _, _, strided_einsum2::backend::BlasBackend>(
+    buffers,
+    a,
+    b,
+    config,
+)
+.map(|result| result.map(crate::Tensor::$wrap));
+```
+
+Keep existing conjugation fallback paths until `strided-einsum2` has a public conjugating dot-general entry point.
+
+- [ ] **Step 3: Preserve TensorRead transposed view behavior**
+
+Add this assertion to the existing transposed-view test in `tenferro-rs/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs`:
+
+```rust
+assert_eq!(out.shape(), &[2, 2]);
+assert_eq!(out.as_slice::<f64>().unwrap(), &[50.0, 122.0, 68.0, 167.0]);
+```
+
+This is already the expected behavior; the purpose is to keep the test tied to the adapter path after routing changes.
+
+- [ ] **Step 4: Run tenferro dot-general tests**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo test -p tenferro-cpu dot_general
+```
+
+Expected: all dot-general tests pass with the strided adapter route.
+
+- [ ] **Step 5: Run tenferro-cpu default tests**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo test -p tenferro-cpu
+```
+
+Expected: all default-feature tenferro-cpu tests pass.
+
+- [ ] **Step 6: Commit routing**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+git add crates/tenferro-cpu/src/gemm/mod.rs crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+git commit -m "refactor: route cpu dot-general through strided-einsum2"
+```
+
+---
+
+### Task 7: Remove duplicated tenferro GEMM analysis only after parity is proven
+
+**Files:**
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/gemm/mod.rs`
+- Modify: `tenferro-rs/crates/tenferro-cpu/src/gemm/tests.rs`
+
+- [ ] **Step 1: Identify dead functions**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+rg -n "typed_faer_gemm|typed_blas_gemm|analyse_gemm|canonical_gemm_layout|GemmDims|GemmAnalysisPlan" crates/tenferro-cpu/src/gemm
+```
+
+Expected: after Task 6, only tests and unused helper definitions reference the old direct-analysis path.
+
+- [ ] **Step 2: Remove old direct-analysis tests that duplicate strided coverage**
+
+Keep cache-stat tests if tenferro still stores cache slot metadata. Remove tests that only check `try_fuse_dims`, `canonical_gemm_layout`, or low-level BLAS/Faer pointer loops after equivalent tests exist in `strided-einsum2`.
+
+- [ ] **Step 3: Move retained cache tests to adapter-level behavior**
+
+Change the cache test to assert tenferro still records a runtime cache entry for the operation, not that it owns the GEMM stride-analysis logic.
+
+- [ ] **Step 4: Compile and test**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo test -p tenferro-cpu dot_general
+cargo test -p tenferro-cpu
+```
+
+Expected: tests pass and `rg` no longer finds unused direct GEMM analysis functions.
+
+- [ ] **Step 5: Commit cleanup**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+git add crates/tenferro-cpu/src/gemm/mod.rs crates/tenferro-cpu/src/gemm/tests.rs
+git commit -m "refactor: remove duplicated cpu gemm analysis"
+```
+
+---
+
+### Task 8: Add benchmark comparison and performance gate
+
+**Files:**
+- Modify: `tenferro-rs/crates/tenferro-cpu/benches/dot_general_overhead.rs`
+
+- [ ] **Step 1: Add cases that expose adapter overhead**
+
+Add benchmark cases for:
+
+```rust
+// Direct col-major matmul: [256, 256] x [256, 256]
+// Transposed lhs TensorRead view: [256, 256]^T x [256, 256]
+// Batched matmul: [64, 64, 32] x [64, 64, 32]
+// Rank-0 dot: [4096] dot [4096]
+```
+
+Use one warmed `CpuBackend`, pre-created inputs, and no input clone inside the timed loop.
+
+- [ ] **Step 2: Run default faer benchmark**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo bench -p tenferro-cpu --bench dot_general_overhead
+```
+
+Expected: adapter overhead is not larger than the old direct path by more than 5% for direct col-major matmul. If the old path has already been removed, compare against the last committed benchmark YAML in `tenferro-benchmark`.
+
+- [ ] **Step 3: Run BLAS provider benchmark when available**
+
+Run on macOS Accelerate:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+RUSTFLAGS="-C target-cpu=native" cargo bench -p tenferro-cpu --no-default-features --features cpu-faer,src-accelerate --bench dot_general_overhead
+```
+
+Expected: BLAS path still routes to the selected CPU backend and does not fall back to faer when `CpuBackendKind::Blas` is requested.
+
+- [ ] **Step 4: Commit benchmark coverage**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+git add crates/tenferro-cpu/benches/dot_general_overhead.rs
+git commit -m "bench: cover strided dot-general adapter overhead"
+```
+
+---
+
+### Task 9: Final verification and dependency pin update
+
+**Files:**
+- Modify: `tenferro-rs/Cargo.toml`
+- Modify: `tenferro-rs/Cargo.lock`
+
+- [ ] **Step 1: Verify strided-rs**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+cargo test -p strided-einsum2
+cargo test -p strided-einsum2 --no-default-features
+cargo check -p strided-einsum2 --no-default-features --features faer,blas
+git diff --check
+```
+
+Expected: tests pass, feature check passes, and `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 2: Push strided-rs and capture commit hash**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/strided-rs
+git rev-parse HEAD
+git push origin HEAD
+```
+
+Expected: output contains the commit hash used in tenferro dependency pinning.
+
+- [ ] **Step 3: Replace tenferro local path dependency with git rev**
+
+In `tenferro-rs/Cargo.toml`, replace:
+
+```toml
+strided-einsum2 = { path = "../strided-rs/strided-einsum2", default-features = false }
+```
+
+with:
+
+```toml
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "the exact commit printed by git rev-parse HEAD in Step 2", default-features = false }
+```
+
+- [ ] **Step 4: Verify tenferro-rs**
+
+Run:
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+cargo update -p strided-einsum2
+cargo test -p tenferro-cpu
+cargo test -p tenferro-runtime
+git diff --check
+```
+
+Expected: tests pass and `git diff --check` reports no whitespace errors.
+
+- [ ] **Step 5: Commit tenferro dependency pin**
+
+```bash
+cd /Users/hiroshi/projects/tensor4all/tenferro-rs
+git add Cargo.toml Cargo.lock
+git commit -m "chore: pin strided-einsum2 dot-general dependency"
+```
+
+---
+
+## Nontrivial Decisions
+
+1. **Merge base:** use `strided-einsum2` as the base. tenferro's implementation is the behavior reference and integration adapter source, not the kernel-library base.
+2. **Backend choice:** `strided-einsum2` should compile faer and BLAS together. `ActiveBackend` should prefer BLAS when BLAS is present, matching tenferro's expected default priority.
+3. **provider-inject:** verify this separately. If Cargo feature unification enables both `strided-einsum2/blas` and `strided-einsum2/blas-inject`, split tenferro CPU BLAS feature wiring before routing through the adapter.
+4. **Cache location:** tenferro keeps runtime cache slots. `strided-einsum2` should not depend on tenferro cache types. Add a reusable `PreparedDotGeneralPlan` in `strided-einsum2` only after adapter overhead is measured.
+5. **Graph optimizer:** keep `tenferro-runtime/src/compiler/dot_decomposer.rs` in tenferro. It is graph/symbolic lowering, not a strided kernel concern.
+6. **Conjugation:** first replacement can preserve tenferro's existing conjugation fallback. Add public conjugating dot-general APIs to `strided-einsum2` after non-conjugated parity is established.
+
+## Self-Review
+
+- Spec coverage: the plan compares the two implementations by assigning kernel ownership to `strided-einsum2` and tenferro ownership to runtime integration, then defines tasks for both repos.
+- Placeholder scan: the plan contains concrete files, code snippets, commands, expected outcomes, and commit boundaries.
+- Type consistency: public `DotGeneralConfig` borrows `&[usize]` axis slices so tenferro can pass its existing config metadata without cloning. Internal planning uses `SmallVec` to reduce allocation after validation.

--- a/mdarray-opteinsum/Cargo.toml
+++ b/mdarray-opteinsum/Cargo.toml
@@ -21,6 +21,9 @@ thiserror.workspace = true
 default = ["faer"]
 faer = ["strided-opteinsum/faer"]
 blas = ["strided-opteinsum/blas"]
+blas-accelerate = ["blas", "strided-opteinsum/blas-accelerate"]
+blas-openblas = ["blas", "strided-opteinsum/blas-openblas"]
+blas-mkl = ["blas", "strided-opteinsum/blas-mkl"]
 
 [dev-dependencies]
 approx.workspace = true

--- a/ndarray-opteinsum/Cargo.toml
+++ b/ndarray-opteinsum/Cargo.toml
@@ -21,6 +21,9 @@ thiserror.workspace = true
 default = ["faer"]
 faer = ["strided-opteinsum/faer"]
 blas = ["strided-opteinsum/blas"]
+blas-accelerate = ["blas", "strided-opteinsum/blas-accelerate"]
+blas-openblas = ["blas", "strided-opteinsum/blas-openblas"]
+blas-mkl = ["blas", "strided-opteinsum/blas-mkl"]
 
 [dev-dependencies]
 approx.workspace = true

--- a/strided-einsum2/Cargo.toml
+++ b/strided-einsum2/Cargo.toml
@@ -20,12 +20,18 @@ cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 num-complex = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
+smallvec.workspace = true
 
 [features]
-default = ["faer", "faer-traits"]
+default = ["faer"]
+faer = ["dep:faer", "dep:faer-traits"]
+faer-traits = ["dep:faer-traits"]
 parallel = ["dep:rayon", "strided-kernel/parallel", "strided-perm/parallel"]
 blas = ["dep:cblas-sys", "dep:num-complex"]
 blas-inject = ["dep:cblas-inject", "dep:num-complex"]
+blas-accelerate = ["blas"]
+blas-openblas = ["blas"]
+blas-mkl = ["blas"]
 
 [dev-dependencies]
 approx.workspace = true
@@ -34,3 +40,7 @@ rand.workspace = true
 
 [lib]
 bench = false
+
+[[bench]]
+name = "dot_general_pytorch_compare"
+harness = false

--- a/strided-einsum2/README.md
+++ b/strided-einsum2/README.md
@@ -3,8 +3,49 @@
 
 The `strided-einsum2` crate provides `einsum2_into` for binary tensor contractions.
 
-Rust benchmark runners were moved to `strided-opteinsum/benches/`.
-Latest benchmark results are documented in `strided-opteinsum/README.md`.
+Most Rust benchmark runners were moved to `strided-opteinsum/benches/`.
+Latest broad benchmark results are documented in `strided-opteinsum/README.md`.
+
+The `dot_general` batched matmul diagnostic compares the tenferro-benchmark
+`bij,bjk->bik` cases against PyTorch `bmm` with memory-matched row-major and
+col-major layouts. Allocation and setup are outside the timed loop: Rust
+prepares GEMM operands once, and PyTorch uses `torch.bmm(..., out=...)`.
+On macOS, the runner uses `blas-accelerate` by default and verifies the
+benchmark binary with `otool -L`. Losing this Accelerate path is a benchmark
+regression. Use `STRIDED_EINSUM2_DOT_GENERAL_RUST_FEATURES` to test another
+provider such as `parallel,blas-openblas` or `parallel,blas-mkl`.
+Set `STRIDED_EINSUM2_DOT_GENERAL_BENCH_DIAGNOSTICS=1` to emit extra Rust-side
+diagnostic rows (`raw-cblas-dgemm`, `raw-trait-dgemm`, and on macOS
+`raw-fortran-dgemm`) for separating BLAS call overhead from PyTorch `bmm`.
+On macOS without MKL, PyTorch CPU `bmm` falls back to per-batch `addmm` rather
+than MKL batched GEMM; current 1T Accelerate runs do not show a stable TN-layout
+loss once measured with enough repetitions.
+
+```bash
+STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE=full \
+STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES=f64,c64,c128 \
+bash strided-einsum2/benches/run_dot_general_pytorch_compare.sh 1 4
+```
+
+Latest local allocation-free Accelerate run (`runs=30`, `warmups=5`):
+
+| benchmark | dtype | threads | strided-einsum2-accelerate-prepared ms | pytorch-bmm ms | ratio |
+|---|---:|---:|---:|---:|---:|
+| `bin_batched_matmul_b32_m64_n64_k64` | f64 | 1 | 0.046375 | 0.077375 | 0.60x |
+| `bin_batched_matmul_b32_m64_n64_k64` | f64 | 4 | 0.046417 | 0.078521 | 0.59x |
+| `bin_batched_matmul_b32_m64_n64_k64` | c64 | 1 | 0.343666 | 0.332021 | 1.04x |
+| `bin_batched_matmul_b32_m64_n64_k64` | c64 | 4 | 0.342417 | 0.332604 | 1.03x |
+| `bin_batched_matmul_b32_m64_n64_k64` | c128 | 1 | 0.748334 | 0.760542 | 0.98x |
+| `bin_batched_matmul_b32_m64_n64_k64` | c128 | 4 | 0.755875 | 0.758333 | 1.00x |
+| `bin_batched_matmul_b32_m128_n128_k128` | f64 | 1 | 0.301042 | 0.376313 | 0.80x |
+| `bin_batched_matmul_b32_m128_n128_k128` | f64 | 4 | 0.307916 | 0.378687 | 0.81x |
+| `bin_batched_matmul_b32_m128_n128_k128` | c64 | 1 | 1.224958 | 1.251854 | 0.98x |
+| `bin_batched_matmul_b32_m128_n128_k128` | c64 | 4 | 1.238375 | 1.243312 | 1.00x |
+| `bin_batched_matmul_b32_m128_n128_k128` | c128 | 1 | 2.981833 | 2.979667 | 1.00x |
+| `bin_batched_matmul_b32_m128_n128_k128` | c128 | 4 | 2.999375 | 2.977917 | 1.01x |
+
+The faer-prepared path is useful for isolating non-BLAS behavior, but macOS
+regression checks should use the Accelerate path above.
 
 **Julia reference scripts** (e.g. `julia_matmul.jl`, `julia_dot.jl`) use OMEinsum. Run single-threaded for comparison (from repo root):
 

--- a/strided-einsum2/benches/dot_general_pytorch_compare.py
+++ b/strided-einsum2/benches/dot_general_pytorch_compare.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""PyTorch reference runner for strided-einsum2 dot_general benchmarks."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import statistics
+import sys
+import time
+from collections.abc import Callable
+
+
+DEFAULT_WARMUPS = 3
+DEFAULT_RUNS = 15
+
+BATCHED_MATMUL = "batched_matmul"
+LAYOUTS_FULL = ("memory_matched", "NN", "TN", "NT", "TT")
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def parse_dtypes(value: str) -> list[str]:
+    dtypes = []
+    for item in value.split(","):
+        item = item.strip()
+        if item in {"f64", "c64", "c128"}:
+            dtypes.append(item)
+        elif item:
+            raise argparse.ArgumentTypeError(f"unknown dtype: {item}")
+    return dtypes or ["f64"]
+
+
+def configure_thread_env(num_threads: int) -> None:
+    value = str(num_threads)
+    xla_multi_thread = "true" if num_threads > 1 else "false"
+    os.environ.update(
+        {
+            "OMP_NUM_THREADS": value,
+            "OMP_THREAD_LIMIT": value,
+            "OMP_DYNAMIC": "FALSE",
+            "RAYON_NUM_THREADS": value,
+            "OPENBLAS_NUM_THREADS": value,
+            "GOTO_NUM_THREADS": value,
+            "MKL_NUM_THREADS": value,
+            "VECLIB_MAXIMUM_THREADS": value,
+            "VECLIB_NUM_THREADS": value,
+            "NUMEXPR_NUM_THREADS": value,
+            "BLIS_NUM_THREADS": value,
+            "XLA_FLAGS": (
+                f"--xla_cpu_multi_thread_eigen={xla_multi_thread} "
+                f"intra_op_parallelism_threads={value}"
+            ),
+        }
+    )
+
+
+def case_specs(profile: str) -> list[tuple[str, tuple[int, ...]]]:
+    if profile == "smoke":
+        return [
+            (BATCHED_MATMUL, (2, 8, 8, 8, "memory_matched")),
+            (BATCHED_MATMUL, (2, 8, 8, 8, "TN")),
+        ]
+    if profile == "quick":
+        return [(BATCHED_MATMUL, (32, 64, 64, 64, layout)) for layout in LAYOUTS_FULL]
+    cases = []
+    for dims in ((32, 64, 64, 64), (32, 128, 128, 128)):
+        for layout in LAYOUTS_FULL:
+            cases.append((BATCHED_MATMUL, (*dims, layout)))
+    return cases
+
+
+def benchmark_name(kind: str, dims: tuple[int, ...]) -> str:
+    if kind == BATCHED_MATMUL:
+        batch, m, n, k, layout = dims
+        suffix = "" if layout == "memory_matched" else f"_{layout.lower()}"
+        return f"bin_batched_matmul_b{batch}_m{m}_n{n}_k{k}{suffix}"
+    raise ValueError(f"unknown benchmark kind: {kind}")
+
+
+def shape_label(kind: str, dims: tuple[int, ...]) -> str:
+    if kind == BATCHED_MATMUL:
+        batch, m, n, k, layout = dims
+        return f"b={batch};m={m};n={n};k={k};layout={layout}"
+    raise ValueError(f"unknown benchmark kind: {kind}")
+
+
+def median_iqr(samples: list[float]) -> tuple[float, float]:
+    ordered = sorted(samples)
+    return statistics.median(ordered), ordered[(3 * len(ordered)) // 4] - ordered[len(ordered) // 4]
+
+
+def bench(fn: Callable[[], object], runs: int, warmups: int) -> tuple[float, float]:
+    for _ in range(warmups):
+        fn()
+    samples = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        value = fn()
+        samples.append((time.perf_counter() - start) * 1000.0)
+        if hasattr(value, "numel"):
+            value.numel()
+    return median_iqr(samples)
+
+
+def torch_dtype(torch, dtype: str):
+    if dtype == "f64":
+        return torch.float64
+    if dtype == "c64":
+        return torch.complex64
+    if dtype == "c128":
+        return torch.complex128
+    raise ValueError(f"unknown dtype: {dtype}")
+
+
+def randn_tensor(torch, shape: tuple[int, ...], dtype: str):
+    if dtype == "f64":
+        return torch.randn(shape, dtype=torch_dtype(torch, dtype))
+    real_dtype = torch.float32 if dtype == "c64" else torch.float64
+    return torch.randn(shape, dtype=real_dtype) + 1j * torch.randn(shape, dtype=real_dtype)
+
+
+def empty_tensor(torch, shape: tuple[int, ...], dtype: str):
+    return torch.empty(shape, dtype=torch_dtype(torch, dtype))
+
+
+def strided_randn_matrix(torch, dtype: str, batch: int, rows: int, cols: int, row_major: bool):
+    if row_major:
+        return randn_tensor(torch, (batch, rows, cols), dtype).contiguous()
+    base = randn_tensor(torch, (batch * rows * cols,), dtype)
+    return torch.as_strided(base, (batch, rows, cols), (rows * cols, 1, rows))
+
+
+def empty_strided_matrix(torch, dtype: str, batch: int, rows: int, cols: int, row_major: bool):
+    if row_major:
+        return empty_tensor(torch, (batch, rows, cols), dtype).contiguous()
+    return torch.empty_strided((batch, rows, cols), (rows * cols, 1, rows), dtype=torch_dtype(torch, dtype))
+
+
+def make_batched_matmul_case(torch, dtype: str, batch: int, m: int, n: int, k: int, layout: str):
+    if layout == "memory_matched":
+        return make_memory_matched_batched_matmul_case(torch, dtype, batch, m, n, k)
+
+    lhs = strided_randn_matrix(torch, dtype, batch, m, k, row_major=layout[0] == "T")
+    rhs = strided_randn_matrix(torch, dtype, batch, k, n, row_major=layout[1] == "T")
+    out = empty_strided_matrix(torch, dtype, batch, m, n, row_major=False)
+    shape = f"b={batch};m={m};n={n};k={k};layout={layout}"
+    return shape, {"pytorch-bmm": lambda: torch.bmm(lhs, rhs, out=out)}
+
+
+def make_memory_matched_batched_matmul_case(torch, dtype: str, batch: int, m: int, n: int, k: int):
+    lhs = randn_tensor(torch, (batch, m, k), dtype).contiguous()
+    rhs = randn_tensor(torch, (batch, k, n), dtype).contiguous()
+    out = empty_tensor(torch, (batch, m, n), dtype)
+    shape = f"b={batch};m={m};n={n};k={k};layout=memory_matched"
+    return shape, {"pytorch-bmm": lambda: torch.bmm(lhs, rhs, out=out)}
+
+
+def make_case(torch, dtype: str, kind: str, dims: tuple[int, ...]):
+    if kind == BATCHED_MATMUL:
+        return make_batched_matmul_case(torch, dtype, *dims)
+    raise ValueError(f"unknown benchmark kind: {kind}")
+
+
+def emit_error_rows(writer: csv.DictWriter, args: argparse.Namespace, status: str) -> None:
+    for dtype in parse_dtypes(args.dtypes):
+        for kind, dims in case_specs(args.profile):
+            for backend in ("pytorch-bmm",):
+                writer.writerow(
+                    {
+                        "suite": "dot_general",
+                        "benchmark": benchmark_name(kind, dims),
+                        "dtype": dtype,
+                        "threads": args.num_threads,
+                        "shape": shape_label(kind, dims),
+                        "backend": backend,
+                        "median_ms": "",
+                        "iqr_ms": "",
+                        "status": status,
+                    }
+                )
+
+
+def run(args: argparse.Namespace, writer: csv.DictWriter) -> None:
+    try:
+        import torch
+    except Exception as exc:
+        emit_error_rows(writer, args, f"error: {exc}")
+        return
+
+    torch.manual_seed(0)
+    torch.set_num_threads(args.num_threads)
+    torch.set_num_interop_threads(args.num_threads)
+
+    for dtype in parse_dtypes(args.dtypes):
+        for kind, dims in case_specs(args.profile):
+            try:
+                shape, cases = make_case(torch, dtype, kind, dims)
+            except Exception as exc:
+                shape = ""
+                cases = {
+                    "pytorch-bmm": None,
+                }
+                setup_status = f"error: {exc}"
+            else:
+                setup_status = "ok"
+
+            for backend, fn in cases.items():
+                if fn is None:
+                    status = setup_status
+                    median = ""
+                    iqr = ""
+                else:
+                    try:
+                        median_ms, iqr_ms = bench(fn, args.runs, args.warmups)
+                        status = "ok"
+                        median = f"{median_ms:.6f}"
+                        iqr = f"{iqr_ms:.6f}"
+                    except Exception as exc:
+                        status = f"error: {exc}"
+                        median = ""
+                        iqr = ""
+
+                writer.writerow(
+                    {
+                        "suite": "dot_general",
+                        "benchmark": benchmark_name(kind, dims),
+                        "dtype": dtype,
+                        "threads": args.num_threads,
+                        "shape": shape,
+                        "backend": backend,
+                        "median_ms": median,
+                        "iqr_ms": iqr,
+                        "status": status,
+                    }
+                )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-threads", type=positive_int, default=int(os.environ.get("OMP_NUM_THREADS", "1")))
+    parser.add_argument(
+        "--profile",
+        choices=["smoke", "quick", "full"],
+        default=os.environ.get("STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE", "full"),
+    )
+    parser.add_argument(
+        "--runs",
+        type=positive_int,
+        default=int(os.environ.get("STRIDED_EINSUM2_DOT_GENERAL_BENCH_RUNS", DEFAULT_RUNS)),
+    )
+    parser.add_argument(
+        "--warmups",
+        type=int,
+        default=int(os.environ.get("STRIDED_EINSUM2_DOT_GENERAL_BENCH_WARMUPS", DEFAULT_WARMUPS)),
+    )
+    parser.add_argument("--dtypes", default=os.environ.get("STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES", "f64"))
+    parser.add_argument("--output", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.warmups < 0:
+        raise SystemExit("--warmups must be non-negative")
+    configure_thread_env(args.num_threads)
+
+    fieldnames = [
+        "suite",
+        "benchmark",
+        "dtype",
+        "threads",
+        "shape",
+        "backend",
+        "median_ms",
+        "iqr_ms",
+        "status",
+    ]
+    if args.output:
+        file_exists = os.path.exists(args.output) and os.path.getsize(args.output) > 0
+        with open(args.output, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, lineterminator="\n")
+            if not file_exists:
+                writer.writeheader()
+            run(args, writer)
+    else:
+        writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        run(args, writer)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strided-einsum2/benches/dot_general_pytorch_compare.rs
+++ b/strided-einsum2/benches/dot_general_pytorch_compare.rs
@@ -1,0 +1,1023 @@
+use std::env;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use strided_einsum2::backend::{ActiveBackend, Backend};
+use strided_einsum2::contiguous::{
+    prepare_input_view, prepare_output_view, ContiguousOperand, ContiguousOperandMut,
+};
+use strided_einsum2::Scalar;
+use strided_view::StridedArray;
+
+const DEFAULT_WARMUPS: usize = 3;
+const DEFAULT_RUNS: usize = 15;
+
+#[derive(Clone, Copy)]
+enum BenchCase {
+    BatchedMatmul {
+        batch: usize,
+        m: usize,
+        n: usize,
+        k: usize,
+        layout: MatmulLayout,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum MatmulLayout {
+    MemoryMatched,
+    NN,
+    TN,
+    NT,
+    TT,
+}
+
+impl MatmulLayout {
+    fn label(self) -> &'static str {
+        match self {
+            Self::MemoryMatched => "memory_matched",
+            Self::NN => "NN",
+            Self::TN => "TN",
+            Self::NT => "NT",
+            Self::TT => "TT",
+        }
+    }
+
+    fn benchmark_suffix(self) -> &'static str {
+        match self {
+            Self::MemoryMatched => "",
+            Self::NN => "_nn",
+            Self::TN => "_tn",
+            Self::NT => "_nt",
+            Self::TT => "_tt",
+        }
+    }
+
+    fn lhs_row_major(self) -> bool {
+        matches!(self, Self::TN | Self::TT)
+    }
+
+    fn rhs_row_major(self) -> bool {
+        matches!(self, Self::NT | Self::TT)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BenchDType {
+    F64,
+    C64,
+    C128,
+}
+
+impl BenchDType {
+    fn label(self) -> &'static str {
+        match self {
+            Self::F64 => "f64",
+            Self::C64 => "c64",
+            Self::C128 => "c128",
+        }
+    }
+}
+
+impl BenchCase {
+    fn benchmark(self) -> String {
+        match self {
+            Self::BatchedMatmul {
+                batch,
+                m,
+                n,
+                k,
+                layout,
+            } => {
+                format!(
+                    "bin_batched_matmul_b{batch}_m{m}_n{n}_k{k}{}",
+                    layout.benchmark_suffix()
+                )
+            }
+        }
+    }
+
+    fn shape_label(self) -> String {
+        match self {
+            Self::BatchedMatmul {
+                batch,
+                m,
+                n,
+                k,
+                layout,
+            } => {
+                format!("b={batch};m={m};n={n};k={k};layout={}", layout.label())
+            }
+        }
+    }
+}
+
+trait BenchScalar: Scalar + Copy + Default + 'static {
+    fn from_indices(indices: &[usize], salt: usize) -> Self;
+    fn one() -> Self;
+}
+
+impl BenchScalar for f64 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        fill_value(indices, salt)
+    }
+
+    fn one() -> Self {
+        1.0
+    }
+}
+
+impl BenchScalar for num_complex::Complex32 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        Self::new(
+            fill_value(indices, salt) as f32,
+            fill_value(indices, salt + 17) as f32,
+        )
+    }
+
+    fn one() -> Self {
+        Self::new(1.0, 0.0)
+    }
+}
+
+impl BenchScalar for num_complex::Complex64 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        Self::new(fill_value(indices, salt), fill_value(indices, salt + 17))
+    }
+
+    fn one() -> Self {
+        Self::new(1.0, 0.0)
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(default)
+}
+
+fn env_bool(name: &str) -> bool {
+    matches!(
+        env::var(name).ok().as_deref(),
+        Some("1" | "true" | "TRUE" | "yes" | "YES" | "on" | "ON")
+    )
+}
+
+fn fill_value(indices: &[usize], salt: usize) -> f64 {
+    let mut acc = salt.wrapping_mul(1_099);
+    for (axis, &idx) in indices.iter().enumerate() {
+        acc = acc.wrapping_add((axis + 1).wrapping_mul(1_003).wrapping_mul(idx + 1));
+    }
+    ((acc % 1024) as f64 - 512.0) / 512.0
+}
+
+fn make_col_major<T: BenchScalar>(dims: &[usize], salt: usize) -> StridedArray<T> {
+    StridedArray::<T>::from_fn_col_major(dims, |idx| T::from_indices(idx, salt))
+}
+
+fn make_batched_matrix<T: BenchScalar>(
+    rows: usize,
+    cols: usize,
+    batch: usize,
+    row_major: bool,
+    salt: usize,
+) -> StridedArray<T> {
+    let dims = [rows, cols, batch];
+    let strides = if row_major {
+        [cols as isize, 1, (rows * cols) as isize]
+    } else {
+        [1, rows as isize, (rows * cols) as isize]
+    };
+    let len = rows * cols * batch;
+    let data = (0..len)
+        .map(|i| T::from_indices(&[i], salt))
+        .collect::<Vec<_>>();
+    StridedArray::<T>::from_parts(data, &dims, &strides, 0).unwrap()
+}
+
+fn matmul_cases(
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    layouts: &[MatmulLayout],
+) -> Vec<BenchCase> {
+    layouts
+        .iter()
+        .copied()
+        .map(|layout| BenchCase::BatchedMatmul {
+            batch,
+            m,
+            n,
+            k,
+            layout,
+        })
+        .collect()
+}
+
+fn profile_cases() -> Vec<BenchCase> {
+    match env::var("STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE")
+        .unwrap_or_else(|_| "full".to_string())
+        .as_str()
+    {
+        "smoke" => matmul_cases(2, 8, 8, 8, &[MatmulLayout::MemoryMatched, MatmulLayout::TN]),
+        "quick" => matmul_cases(
+            32,
+            64,
+            64,
+            64,
+            &[
+                MatmulLayout::MemoryMatched,
+                MatmulLayout::NN,
+                MatmulLayout::TN,
+                MatmulLayout::NT,
+                MatmulLayout::TT,
+            ],
+        ),
+        _ => {
+            let layouts = [
+                MatmulLayout::MemoryMatched,
+                MatmulLayout::NN,
+                MatmulLayout::TN,
+                MatmulLayout::NT,
+                MatmulLayout::TT,
+            ];
+            let mut cases = matmul_cases(32, 64, 64, 64, &layouts);
+            cases.extend(matmul_cases(32, 128, 128, 128, &layouts));
+            cases
+        }
+    }
+}
+
+fn profile_dtypes() -> Vec<BenchDType> {
+    let dtypes: Vec<_> = env::var("STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES")
+        .unwrap_or_else(|_| "f64".to_string())
+        .split(',')
+        .filter_map(|value| match value.trim() {
+            "f64" => Some(BenchDType::F64),
+            "c64" => Some(BenchDType::C64),
+            "c128" => Some(BenchDType::C128),
+            _ => None,
+        })
+        .collect();
+
+    if dtypes.is_empty() {
+        vec![BenchDType::F64]
+    } else {
+        dtypes
+    }
+}
+
+fn duration_stats(mut durations: Vec<Duration>) -> (f64, f64) {
+    durations.sort_unstable();
+    let median = durations[durations.len() / 2];
+    let q1 = durations[durations.len() / 4];
+    let q3 = durations[3 * durations.len() / 4];
+    (
+        median.as_secs_f64() * 1e3,
+        q3.saturating_sub(q1).as_secs_f64() * 1e3,
+    )
+}
+
+fn measure(mut f: impl FnMut()) -> (f64, f64) {
+    let warmups = env_usize("STRIDED_EINSUM2_DOT_GENERAL_BENCH_WARMUPS", DEFAULT_WARMUPS);
+    let runs = env_usize("STRIDED_EINSUM2_DOT_GENERAL_BENCH_RUNS", DEFAULT_RUNS);
+    for _ in 0..warmups {
+        f();
+    }
+
+    let mut durations = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let start = Instant::now();
+        f();
+        durations.push(start.elapsed());
+    }
+    duration_stats(durations)
+}
+
+fn run_batched_matmul<T: BenchScalar>(batch: usize, m: usize, n: usize, k: usize) -> (f64, f64)
+where
+    ActiveBackend: Backend<T>,
+{
+    // tenferro-benchmark's row-major `bij,bjk->bik` instance maps to
+    // col-major buffers as `jib,kjb->kib`. This prepared benchmark excludes
+    // allocation/setup from the timed loop: operands are converted to GEMM-ready
+    // metadata once, then the backend batched GEMM is called repeatedly.
+    let lhs_row_memory = make_col_major::<T>(&[k, m, batch], 11);
+    let rhs_row_memory = make_col_major::<T>(&[n, k, batch], 12);
+    let mut out = StridedArray::<T>::col_major(&[n, m, batch]);
+    let a_op = prepare_input_view(
+        &rhs_row_memory.view(),
+        1,
+        1,
+        false,
+        ActiveBackend::REQUIRES_UNIT_STRIDE,
+        true,
+        None,
+    )
+    .unwrap();
+    let b_op = prepare_input_view(
+        &lhs_row_memory.view(),
+        1,
+        1,
+        false,
+        ActiveBackend::REQUIRES_UNIT_STRIDE,
+        true,
+        None,
+    )
+    .unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(
+            &mut out_view,
+            1,
+            1,
+            T::default(),
+            ActiveBackend::REQUIRES_UNIT_STRIDE,
+            true,
+        )
+        .unwrap()
+    };
+
+    measure(|| {
+        ActiveBackend::bgemm_contiguous_into(
+            &mut c_op,
+            &a_op,
+            &b_op,
+            &[batch],
+            n,
+            m,
+            k,
+            <T as BenchScalar>::one(),
+            T::default(),
+        )
+        .unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_batched_matmul_layout<T: BenchScalar>(
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    layout: MatmulLayout,
+) -> (f64, f64)
+where
+    ActiveBackend: Backend<T>,
+{
+    if matches!(layout, MatmulLayout::MemoryMatched) {
+        return run_batched_matmul::<T>(batch, m, n, k);
+    }
+
+    let lhs = make_batched_matrix::<T>(m, k, batch, layout.lhs_row_major(), 11);
+    let rhs = make_batched_matrix::<T>(k, n, batch, layout.rhs_row_major(), 12);
+    let mut out = StridedArray::<T>::col_major(&[m, n, batch]);
+
+    let a_op = prepare_input_view(
+        &lhs.view(),
+        1,
+        1,
+        false,
+        ActiveBackend::REQUIRES_UNIT_STRIDE,
+        true,
+        None,
+    )
+    .unwrap();
+    let b_op = prepare_input_view(
+        &rhs.view(),
+        1,
+        1,
+        false,
+        ActiveBackend::REQUIRES_UNIT_STRIDE,
+        true,
+        None,
+    )
+    .unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(
+            &mut out_view,
+            1,
+            1,
+            T::default(),
+            ActiveBackend::REQUIRES_UNIT_STRIDE,
+            true,
+        )
+        .unwrap()
+    };
+
+    measure(|| {
+        ActiveBackend::bgemm_contiguous_into(
+            &mut c_op,
+            &a_op,
+            &b_op,
+            &[batch],
+            m,
+            n,
+            k,
+            <T as BenchScalar>::one(),
+            T::default(),
+        )
+        .unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(feature = "blas")]
+fn raw_cblas_flip_transpose(t: cblas_sys::CBLAS_TRANSPOSE) -> cblas_sys::CBLAS_TRANSPOSE {
+    match t {
+        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans => cblas_sys::CBLAS_TRANSPOSE::CblasTrans,
+        cblas_sys::CBLAS_TRANSPOSE::CblasTrans => cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans,
+        other => other,
+    }
+}
+
+#[cfg(feature = "blas")]
+fn raw_cblas_operand_layout(
+    row_stride: isize,
+    col_stride: isize,
+    nrows: usize,
+    ncols: usize,
+) -> (cblas_sys::CBLAS_TRANSPOSE, i32) {
+    if row_stride == 1 || row_stride == 0 {
+        let lda = col_stride.max(nrows as isize).max(1) as i32;
+        (cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans, lda)
+    } else if col_stride == 1 || col_stride == 0 {
+        let lda = row_stride.max(ncols as isize).max(1) as i32;
+        (cblas_sys::CBLAS_TRANSPOSE::CblasTrans, lda)
+    } else {
+        panic!(
+            "raw cblas benchmark input has non-unit strides (row={row_stride}, col={col_stride})"
+        );
+    }
+}
+
+#[cfg(feature = "blas")]
+fn raw_cblas_dgemm_batched(
+    c: &mut ContiguousOperandMut<f64>,
+    a: &ContiguousOperand<f64>,
+    b: &ContiguousOperand<f64>,
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let (trans_a, lda) = raw_cblas_operand_layout(a.row_stride(), a.col_stride(), m, k);
+    let (trans_b, ldb) = raw_cblas_operand_layout(b.row_stride(), b.col_stride(), k, n);
+    let c_is_col_major = c.row_stride() == 1 || c.row_stride() == 0;
+    let a_batch_step = a.batch_strides().first().copied().unwrap_or(0);
+    let b_batch_step = b.batch_strides().first().copied().unwrap_or(0);
+    let c_batch_step = c.batch_strides().first().copied().unwrap_or(0);
+
+    for batch_idx in 0..batch {
+        let a_off = batch_idx as isize * a_batch_step;
+        let b_off = batch_idx as isize * b_batch_step;
+        let c_off = batch_idx as isize * c_batch_step;
+        unsafe {
+            if c_is_col_major {
+                let ldc = c.col_stride().max(m as isize).max(1) as i32;
+                cblas_sys::cblas_dgemm(
+                    cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                    trans_a,
+                    trans_b,
+                    m as i32,
+                    n as i32,
+                    k as i32,
+                    1.0,
+                    a.ptr().offset(a_off),
+                    lda,
+                    b.ptr().offset(b_off),
+                    ldb,
+                    0.0,
+                    c.ptr().offset(c_off),
+                    ldc,
+                );
+            } else {
+                let ldc = c.row_stride().max(n as isize).max(1) as i32;
+                cblas_sys::cblas_dgemm(
+                    cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                    raw_cblas_flip_transpose(trans_b),
+                    raw_cblas_flip_transpose(trans_a),
+                    n as i32,
+                    m as i32,
+                    k as i32,
+                    1.0,
+                    b.ptr().offset(b_off),
+                    ldb,
+                    a.ptr().offset(a_off),
+                    lda,
+                    0.0,
+                    c.ptr().offset(c_off),
+                    ldc,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "blas")]
+fn raw_trait_dgemm_batched(
+    c: &mut ContiguousOperandMut<f64>,
+    a: &ContiguousOperand<f64>,
+    b: &ContiguousOperand<f64>,
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let (trans_a, lda) = raw_cblas_operand_layout(a.row_stride(), a.col_stride(), m, k);
+    let (trans_b, ldb) = raw_cblas_operand_layout(b.row_stride(), b.col_stride(), k, n);
+    let c_is_col_major = c.row_stride() == 1 || c.row_stride() == 0;
+    let a_batch_step = a.batch_strides().first().copied().unwrap_or(0);
+    let b_batch_step = b.batch_strides().first().copied().unwrap_or(0);
+    let c_batch_step = c.batch_strides().first().copied().unwrap_or(0);
+
+    for batch_idx in 0..batch {
+        let a_off = batch_idx as isize * a_batch_step;
+        let b_off = batch_idx as isize * b_batch_step;
+        let c_off = batch_idx as isize * c_batch_step;
+        unsafe {
+            if c_is_col_major {
+                let ldc = c.col_stride().max(m as isize).max(1) as i32;
+                <f64 as strided_einsum2::bgemm_blas::BlasGemm>::gemm(
+                    trans_a,
+                    trans_b,
+                    m as i32,
+                    n as i32,
+                    k as i32,
+                    1.0,
+                    a.ptr().offset(a_off),
+                    lda,
+                    b.ptr().offset(b_off),
+                    ldb,
+                    0.0,
+                    c.ptr().offset(c_off),
+                    ldc,
+                );
+            } else {
+                let ldc = c.row_stride().max(n as isize).max(1) as i32;
+                <f64 as strided_einsum2::bgemm_blas::BlasGemm>::gemm(
+                    raw_cblas_flip_transpose(trans_b),
+                    raw_cblas_flip_transpose(trans_a),
+                    n as i32,
+                    m as i32,
+                    k as i32,
+                    1.0,
+                    b.ptr().offset(b_off),
+                    ldb,
+                    a.ptr().offset(a_off),
+                    lda,
+                    0.0,
+                    c.ptr().offset(c_off),
+                    ldc,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+extern "C" {
+    fn dgemm_(
+        transa: *const std::os::raw::c_char,
+        transb: *const std::os::raw::c_char,
+        m: *const std::os::raw::c_int,
+        n: *const std::os::raw::c_int,
+        k: *const std::os::raw::c_int,
+        alpha: *const f64,
+        a: *const f64,
+        lda: *const std::os::raw::c_int,
+        b: *const f64,
+        ldb: *const std::os::raw::c_int,
+        beta: *const f64,
+        c: *mut f64,
+        ldc: *const std::os::raw::c_int,
+    );
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+fn raw_fortran_transpose(t: cblas_sys::CBLAS_TRANSPOSE) -> std::os::raw::c_char {
+    match t {
+        cblas_sys::CBLAS_TRANSPOSE::CblasNoTrans => b'N' as std::os::raw::c_char,
+        cblas_sys::CBLAS_TRANSPOSE::CblasTrans => b'T' as std::os::raw::c_char,
+        cblas_sys::CBLAS_TRANSPOSE::CblasConjTrans => b'C' as std::os::raw::c_char,
+    }
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+fn raw_fortran_dgemm_batched(
+    c: &mut ContiguousOperandMut<f64>,
+    a: &ContiguousOperand<f64>,
+    b: &ContiguousOperand<f64>,
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    let (trans_a, lda) = raw_cblas_operand_layout(a.row_stride(), a.col_stride(), m, k);
+    let (trans_b, ldb) = raw_cblas_operand_layout(b.row_stride(), b.col_stride(), k, n);
+    let c_is_col_major = c.row_stride() == 1 || c.row_stride() == 0;
+    let a_batch_step = a.batch_strides().first().copied().unwrap_or(0);
+    let b_batch_step = b.batch_strides().first().copied().unwrap_or(0);
+    let c_batch_step = c.batch_strides().first().copied().unwrap_or(0);
+
+    for batch_idx in 0..batch {
+        let a_off = batch_idx as isize * a_batch_step;
+        let b_off = batch_idx as isize * b_batch_step;
+        let c_off = batch_idx as isize * c_batch_step;
+        unsafe {
+            if c_is_col_major {
+                let trans_a = raw_fortran_transpose(trans_a);
+                let trans_b = raw_fortran_transpose(trans_b);
+                let m = m as std::os::raw::c_int;
+                let n = n as std::os::raw::c_int;
+                let k = k as std::os::raw::c_int;
+                let alpha = 1.0;
+                let beta = 0.0;
+                let ldc = c.col_stride().max(m as isize).max(1) as std::os::raw::c_int;
+                dgemm_(
+                    &trans_a,
+                    &trans_b,
+                    &m,
+                    &n,
+                    &k,
+                    &alpha,
+                    a.ptr().offset(a_off),
+                    &lda,
+                    b.ptr().offset(b_off),
+                    &ldb,
+                    &beta,
+                    c.ptr().offset(c_off),
+                    &ldc,
+                );
+            } else {
+                let trans_a_flipped = raw_fortran_transpose(raw_cblas_flip_transpose(trans_b));
+                let trans_b_flipped = raw_fortran_transpose(raw_cblas_flip_transpose(trans_a));
+                let m_i32 = n as std::os::raw::c_int;
+                let n_i32 = m as std::os::raw::c_int;
+                let k_i32 = k as std::os::raw::c_int;
+                let alpha = 1.0;
+                let beta = 0.0;
+                let ldc = c.row_stride().max(n as isize).max(1) as std::os::raw::c_int;
+                dgemm_(
+                    &trans_a_flipped,
+                    &trans_b_flipped,
+                    &m_i32,
+                    &n_i32,
+                    &k_i32,
+                    &alpha,
+                    b.ptr().offset(b_off),
+                    &ldb,
+                    a.ptr().offset(a_off),
+                    &lda,
+                    &beta,
+                    c.ptr().offset(c_off),
+                    &ldc,
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "blas")]
+fn run_batched_matmul_raw_cblas_f64(batch: usize, m: usize, n: usize, k: usize) -> (f64, f64) {
+    let lhs_row_memory = make_col_major::<f64>(&[k, m, batch], 11);
+    let rhs_row_memory = make_col_major::<f64>(&[n, k, batch], 12);
+    let mut out = StridedArray::<f64>::col_major(&[n, m, batch]);
+    let a_op = prepare_input_view(&rhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&lhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_cblas_dgemm_batched(&mut c_op, &a_op, &b_op, batch, n, m, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(feature = "blas")]
+fn run_batched_matmul_raw_trait_f64(batch: usize, m: usize, n: usize, k: usize) -> (f64, f64) {
+    let lhs_row_memory = make_col_major::<f64>(&[k, m, batch], 11);
+    let rhs_row_memory = make_col_major::<f64>(&[n, k, batch], 12);
+    let mut out = StridedArray::<f64>::col_major(&[n, m, batch]);
+    let a_op = prepare_input_view(&rhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&lhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_trait_dgemm_batched(&mut c_op, &a_op, &b_op, batch, n, m, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+fn run_batched_matmul_raw_fortran_f64(batch: usize, m: usize, n: usize, k: usize) -> (f64, f64) {
+    let lhs_row_memory = make_col_major::<f64>(&[k, m, batch], 11);
+    let rhs_row_memory = make_col_major::<f64>(&[n, k, batch], 12);
+    let mut out = StridedArray::<f64>::col_major(&[n, m, batch]);
+    let a_op = prepare_input_view(&rhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&lhs_row_memory.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_fortran_dgemm_batched(&mut c_op, &a_op, &b_op, batch, n, m, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(feature = "blas")]
+fn run_batched_matmul_layout_raw_cblas_f64(
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    layout: MatmulLayout,
+) -> (f64, f64) {
+    if matches!(layout, MatmulLayout::MemoryMatched) {
+        return run_batched_matmul_raw_cblas_f64(batch, m, n, k);
+    }
+
+    let lhs = make_batched_matrix::<f64>(m, k, batch, layout.lhs_row_major(), 11);
+    let rhs = make_batched_matrix::<f64>(k, n, batch, layout.rhs_row_major(), 12);
+    let mut out = StridedArray::<f64>::col_major(&[m, n, batch]);
+    let a_op = prepare_input_view(&lhs.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&rhs.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_cblas_dgemm_batched(&mut c_op, &a_op, &b_op, batch, m, n, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(feature = "blas")]
+fn run_batched_matmul_layout_raw_trait_f64(
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    layout: MatmulLayout,
+) -> (f64, f64) {
+    if matches!(layout, MatmulLayout::MemoryMatched) {
+        return run_batched_matmul_raw_trait_f64(batch, m, n, k);
+    }
+
+    let lhs = make_batched_matrix::<f64>(m, k, batch, layout.lhs_row_major(), 11);
+    let rhs = make_batched_matrix::<f64>(k, n, batch, layout.rhs_row_major(), 12);
+    let mut out = StridedArray::<f64>::col_major(&[m, n, batch]);
+    let a_op = prepare_input_view(&lhs.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&rhs.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_trait_dgemm_batched(&mut c_op, &a_op, &b_op, batch, m, n, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+fn run_batched_matmul_layout_raw_fortran_f64(
+    batch: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    layout: MatmulLayout,
+) -> (f64, f64) {
+    if matches!(layout, MatmulLayout::MemoryMatched) {
+        return run_batched_matmul_raw_fortran_f64(batch, m, n, k);
+    }
+
+    let lhs = make_batched_matrix::<f64>(m, k, batch, layout.lhs_row_major(), 11);
+    let rhs = make_batched_matrix::<f64>(k, n, batch, layout.rhs_row_major(), 12);
+    let mut out = StridedArray::<f64>::col_major(&[m, n, batch]);
+    let a_op = prepare_input_view(&lhs.view(), 1, 1, false, true, true, None).unwrap();
+    let b_op = prepare_input_view(&rhs.view(), 1, 1, false, true, true, None).unwrap();
+    let mut c_op = {
+        let mut out_view = out.view_mut();
+        prepare_output_view(&mut out_view, 1, 1, 0.0, true, true).unwrap()
+    };
+
+    measure(|| {
+        raw_fortran_dgemm_batched(&mut c_op, &a_op, &b_op, batch, m, n, k);
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_case_typed<T: BenchScalar>(case: BenchCase) -> (f64, f64)
+where
+    ActiveBackend: Backend<T>,
+{
+    match case {
+        BenchCase::BatchedMatmul {
+            batch,
+            m,
+            n,
+            k,
+            layout,
+        } => run_batched_matmul_layout::<T>(batch, m, n, k, layout),
+    }
+}
+
+#[cfg(feature = "blas")]
+fn run_raw_cblas_case_for_dtype(dtype: BenchDType, case: BenchCase) -> Option<(f64, f64)> {
+    if !matches!(dtype, BenchDType::F64) {
+        return None;
+    }
+    match case {
+        BenchCase::BatchedMatmul {
+            batch,
+            m,
+            n,
+            k,
+            layout,
+        } => Some(run_batched_matmul_layout_raw_cblas_f64(
+            batch, m, n, k, layout,
+        )),
+    }
+}
+
+#[cfg(feature = "blas")]
+fn run_raw_trait_case_for_dtype(dtype: BenchDType, case: BenchCase) -> Option<(f64, f64)> {
+    if !matches!(dtype, BenchDType::F64) {
+        return None;
+    }
+    match case {
+        BenchCase::BatchedMatmul {
+            batch,
+            m,
+            n,
+            k,
+            layout,
+        } => Some(run_batched_matmul_layout_raw_trait_f64(
+            batch, m, n, k, layout,
+        )),
+    }
+}
+
+#[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+fn run_raw_fortran_case_for_dtype(dtype: BenchDType, case: BenchCase) -> Option<(f64, f64)> {
+    if !matches!(dtype, BenchDType::F64) {
+        return None;
+    }
+    match case {
+        BenchCase::BatchedMatmul {
+            batch,
+            m,
+            n,
+            k,
+            layout,
+        } => Some(run_batched_matmul_layout_raw_fortran_f64(
+            batch, m, n, k, layout,
+        )),
+    }
+}
+
+fn run_case_for_dtype(dtype: BenchDType, case: BenchCase) -> (f64, f64) {
+    match dtype {
+        BenchDType::F64 => run_case_typed::<f64>(case),
+        BenchDType::C64 => run_case_typed::<num_complex::Complex32>(case),
+        BenchDType::C128 => run_case_typed::<num_complex::Complex64>(case),
+    }
+}
+
+fn threads_label() -> String {
+    env::var("RAYON_NUM_THREADS")
+        .or_else(|_| env::var("OMP_NUM_THREADS"))
+        .unwrap_or_else(|_| "unset".to_string())
+}
+
+fn backend_label() -> &'static str {
+    #[cfg(feature = "blas-accelerate")]
+    {
+        "strided-einsum2-accelerate-prepared"
+    }
+    #[cfg(feature = "blas-openblas")]
+    {
+        "strided-einsum2-openblas-prepared"
+    }
+    #[cfg(feature = "blas-mkl")]
+    {
+        "strided-einsum2-mkl-prepared"
+    }
+    #[cfg(all(
+        feature = "blas",
+        not(any(
+            feature = "blas-accelerate",
+            feature = "blas-openblas",
+            feature = "blas-mkl",
+            feature = "blas-inject"
+        )),
+        not(feature = "blas-inject"),
+        target_os = "macos"
+    ))]
+    {
+        "strided-einsum2-accelerate-prepared"
+    }
+    #[cfg(all(
+        feature = "blas",
+        not(any(
+            feature = "blas-accelerate",
+            feature = "blas-openblas",
+            feature = "blas-mkl",
+            feature = "blas-inject"
+        )),
+        not(feature = "blas-inject"),
+        not(target_os = "macos")
+    ))]
+    {
+        "strided-einsum2-blas-prepared"
+    }
+    #[cfg(all(feature = "blas-inject", not(feature = "blas")))]
+    {
+        "strided-einsum2-blas-inject-prepared"
+    }
+    #[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
+    {
+        "strided-einsum2-faer-prepared"
+    }
+    #[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+    {
+        "strided-einsum2-naive-prepared"
+    }
+}
+
+fn main() {
+    println!("suite,benchmark,dtype,threads,shape,backend,median_ms,iqr_ms,status");
+    let threads = threads_label();
+    let backend = backend_label();
+    let emit_diagnostics = env_bool("STRIDED_EINSUM2_DOT_GENERAL_BENCH_DIAGNOSTICS");
+    for dtype in profile_dtypes() {
+        for case in profile_cases() {
+            let (median_ms, iqr_ms) = run_case_for_dtype(dtype, case);
+            println!(
+                "dot_general,{},{},{},{},{},{:.6},{:.6},ok",
+                case.benchmark(),
+                dtype.label(),
+                threads,
+                case.shape_label(),
+                backend,
+                median_ms,
+                iqr_ms
+            );
+            if !emit_diagnostics {
+                continue;
+            }
+            #[cfg(feature = "blas")]
+            if let Some((median_ms, iqr_ms)) = run_raw_cblas_case_for_dtype(dtype, case) {
+                println!(
+                    "dot_general,{},{},{},{},{},{:.6},{:.6},ok",
+                    case.benchmark(),
+                    dtype.label(),
+                    threads,
+                    case.shape_label(),
+                    "raw-cblas-dgemm",
+                    median_ms,
+                    iqr_ms
+                );
+            }
+            #[cfg(feature = "blas")]
+            if let Some((median_ms, iqr_ms)) = run_raw_trait_case_for_dtype(dtype, case) {
+                println!(
+                    "dot_general,{},{},{},{},{},{:.6},{:.6},ok",
+                    case.benchmark(),
+                    dtype.label(),
+                    threads,
+                    case.shape_label(),
+                    "raw-trait-dgemm",
+                    median_ms,
+                    iqr_ms
+                );
+            }
+            #[cfg(all(feature = "blas-accelerate", target_os = "macos"))]
+            if let Some((median_ms, iqr_ms)) = run_raw_fortran_case_for_dtype(dtype, case) {
+                println!(
+                    "dot_general,{},{},{},{},{},{:.6},{:.6},ok",
+                    case.benchmark(),
+                    dtype.label(),
+                    threads,
+                    case.shape_label(),
+                    "raw-fortran-dgemm",
+                    median_ms,
+                    iqr_ms
+                );
+            }
+        }
+    }
+}

--- a/strided-einsum2/benches/run_dot_general_pytorch_compare.sh
+++ b/strided-einsum2/benches/run_dot_general_pytorch_compare.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THREAD_COUNTS=("$@")
+if (( ${#THREAD_COUNTS[@]} == 0 )); then
+    THREAD_COUNTS=(1 4)
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$CRATE_DIR/.." && pwd)"
+PROFILE="${STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE:-full}"
+RUNS="${STRIDED_EINSUM2_DOT_GENERAL_BENCH_RUNS:-15}"
+WARMUPS="${STRIDED_EINSUM2_DOT_GENERAL_BENCH_WARMUPS:-3}"
+DTYPES="${STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES:-f64}"
+RUST_FEATURES="${STRIDED_EINSUM2_DOT_GENERAL_RUST_FEATURES:-}"
+RUST_NO_DEFAULT_FEATURES="${STRIDED_EINSUM2_DOT_GENERAL_RUST_NO_DEFAULT_FEATURES:-}"
+THREAD_LABEL="$(IFS=_; echo "${THREAD_COUNTS[*]}")"
+DTYPE_LABEL="${DTYPES//,/_}"
+OUT="${STRIDED_EINSUM2_DOT_GENERAL_BENCH_OUTPUT:-$CRATE_DIR/target/dot_general_pytorch_compare_t${THREAD_LABEL}_${PROFILE}_${DTYPE_LABEL}.csv}"
+REQUIRE_ACCELERATE="${STRIDED_EINSUM2_DOT_GENERAL_REQUIRE_ACCELERATE:-}"
+
+export STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE="$PROFILE"
+export STRIDED_EINSUM2_DOT_GENERAL_BENCH_RUNS="$RUNS"
+export STRIDED_EINSUM2_DOT_GENERAL_BENCH_WARMUPS="$WARMUPS"
+export STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES="$DTYPES"
+
+if [[ -z "$RUST_FEATURES" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        RUST_FEATURES="parallel,blas-accelerate"
+        RUST_NO_DEFAULT_FEATURES=1
+    else
+        RUST_FEATURES="parallel"
+    fi
+fi
+
+if [[ -z "$REQUIRE_ACCELERATE" ]]; then
+    REQUIRE_ACCELERATE=0
+    RUST_FEATURES_COMPACT="${RUST_FEATURES//[[:space:]]/}"
+    if [[ "$(uname -s)" == "Darwin" ]] \
+        && ([[ ",$RUST_FEATURES_COMPACT," == *",blas-accelerate,"* ]] \
+            || ([[ ",$RUST_FEATURES_COMPACT," == *",blas,"* ]] \
+                && [[ ",$RUST_FEATURES_COMPACT," != *",blas-openblas,"* ]] \
+                && [[ ",$RUST_FEATURES_COMPACT," != *",blas-mkl,"* ]] \
+                && [[ ",$RUST_FEATURES_COMPACT," != *",blas-inject,"* ]])); then
+        REQUIRE_ACCELERATE=1
+    fi
+fi
+
+mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
+
+configure_cpu_thread_env() {
+    local threads="${1:?threads required}"
+    local xla_multi_thread="false"
+    if [[ "$threads" =~ ^[0-9]+$ ]] && (( threads > 1 )); then
+        xla_multi_thread="true"
+    fi
+
+    export OMP_NUM_THREADS="$threads"
+    export OMP_THREAD_LIMIT="$threads"
+    export OMP_DYNAMIC=FALSE
+    export RAYON_NUM_THREADS="$threads"
+    export OPENBLAS_NUM_THREADS="$threads"
+    export GOTO_NUM_THREADS="$threads"
+    export MKL_NUM_THREADS="$threads"
+    export VECLIB_MAXIMUM_THREADS="$threads"
+    export VECLIB_NUM_THREADS="$threads"
+    export NUMEXPR_NUM_THREADS="$threads"
+    export BLIS_NUM_THREADS="$threads"
+    export XLA_FLAGS="--xla_cpu_multi_thread_eigen=${xla_multi_thread} intra_op_parallelism_threads=${threads}"
+}
+
+run_rust() {
+    local rust_bench_bin
+    local rust_build_log
+    local rust_bench_log
+    local cargo_args=(
+        bench
+        --manifest-path "$WORKSPACE_DIR/Cargo.toml"
+        -p strided-einsum2
+        --bench dot_general_pytorch_compare
+        --features "$RUST_FEATURES"
+    )
+    if [[ -n "$RUST_NO_DEFAULT_FEATURES" ]]; then
+        cargo_args+=(--no-default-features)
+    fi
+
+    rust_build_log="$(mktemp)"
+    cargo "${cargo_args[@]}" --no-run >"$rust_build_log" 2>&1
+    rust_bench_bin="$(awk -F'[()]' '/Executable .*dot_general_pytorch_compare/ {print $(NF - 1)}' "$rust_build_log" | tail -n 1)"
+    rm -f "$rust_build_log"
+
+    if [[ "$REQUIRE_ACCELERATE" == "1" ]]; then
+        if [[ -z "$rust_bench_bin" || ! -x "$rust_bench_bin" ]]; then
+            echo "error: could not locate dot_general_pytorch_compare bench binary for Accelerate verification" >&2
+            exit 1
+        fi
+        if ! command -v otool >/dev/null 2>&1; then
+            echo "error: otool is required to verify Accelerate linkage on macOS" >&2
+            exit 1
+        fi
+        if ! otool -L "$rust_bench_bin" | grep -q 'Accelerate.framework'; then
+            echo "error: macOS benchmark requires Accelerate, but the binary is not linked against it; this is a regression" >&2
+            otool -L "$rust_bench_bin" >&2
+            exit 1
+        fi
+    fi
+
+    rust_bench_log="$(mktemp)"
+    cargo "${cargo_args[@]}" >"$rust_bench_log"
+
+    if [[ -s "$OUT" ]]; then
+        awk '/^dot_general,/' "$rust_bench_log" >>"$OUT"
+    else
+        awk '/^suite,/ || /^dot_general,/' "$rust_bench_log" >"$OUT"
+    fi
+    rm -f "$rust_bench_log"
+}
+
+run_pytorch() {
+    local threads="${1:?threads required}"
+    if command -v uv >/dev/null 2>&1; then
+        uv run --with torch --with numpy python "$SCRIPT_DIR/dot_general_pytorch_compare.py" \
+            --num-threads "$threads" \
+            --profile "$PROFILE" \
+            --runs "$RUNS" \
+            --warmups "$WARMUPS" \
+            --dtypes "$DTYPES" \
+            --output "$OUT"
+    else
+        python3 "$SCRIPT_DIR/dot_general_pytorch_compare.py" \
+            --num-threads "$threads" \
+            --profile "$PROFILE" \
+            --runs "$RUNS" \
+            --warmups "$WARMUPS" \
+            --dtypes "$DTYPES" \
+            --output "$OUT"
+    fi
+}
+
+for num_threads in "${THREAD_COUNTS[@]}"; do
+    configure_cpu_thread_env "$num_threads"
+    run_rust
+    run_pytorch "$num_threads"
+done
+
+echo "dot_general comparison results saved to: $OUT"

--- a/strided-einsum2/build.rs
+++ b/strided-einsum2/build.rs
@@ -1,20 +1,71 @@
 fn main() {
     #[cfg(feature = "blas")]
     {
-        // Re-run if the library path changes.
         println!("cargo:rerun-if-env-changed=OPENBLAS_LIB_DIR");
+        println!("cargo:rerun-if-env-changed=MKLROOT");
+        println!("cargo:rerun-if-env-changed=MKL_LIB_DIR");
 
-        // Link against system OpenBLAS which provides CBLAS symbols.
-        // On macOS: brew install openblas
-        // On Ubuntu: apt install libopenblas-dev
-        if let Ok(lib_dir) = std::env::var("OPENBLAS_LIB_DIR") {
-            println!("cargo:rustc-link-search=native={}", lib_dir);
-        } else if cfg!(target_os = "macos") {
-            // Homebrew default path on Apple Silicon
-            println!("cargo:rustc-link-search=native=/opt/homebrew/opt/openblas/lib");
-            // Homebrew default path on Intel
-            println!("cargo:rustc-link-search=native=/usr/local/opt/openblas/lib");
+        let explicit_providers = [
+            cfg!(feature = "blas-accelerate"),
+            cfg!(feature = "blas-openblas"),
+            cfg!(feature = "blas-mkl"),
+        ]
+        .into_iter()
+        .filter(|enabled| *enabled)
+        .count();
+
+        if explicit_providers > 1 {
+            panic!("Select at most one explicit BLAS provider feature.");
         }
-        println!("cargo:rustc-link-lib=openblas");
+
+        if cfg!(feature = "blas-accelerate")
+            || (explicit_providers == 0 && cfg!(target_os = "macos"))
+        {
+            link_accelerate();
+        } else if cfg!(feature = "blas-mkl") {
+            link_mkl_dynamic_parallel();
+        } else {
+            link_openblas();
+        }
+    }
+}
+
+#[cfg(feature = "blas")]
+fn link_accelerate() {
+    println!("cargo:rustc-link-lib=framework=Accelerate");
+}
+
+#[cfg(feature = "blas")]
+fn link_openblas() {
+    // Link against system OpenBLAS which provides CBLAS symbols.
+    // On Ubuntu: apt install libopenblas-dev
+    if let Ok(lib_dir) = std::env::var("OPENBLAS_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    } else if cfg!(target_os = "macos") {
+        // Homebrew default paths on Apple Silicon and Intel Macs.
+        println!("cargo:rustc-link-search=native=/opt/homebrew/opt/openblas/lib");
+        println!("cargo:rustc-link-search=native=/usr/local/opt/openblas/lib");
+    }
+    println!("cargo:rustc-link-lib=openblas");
+}
+
+#[cfg(feature = "blas")]
+fn link_mkl_dynamic_parallel() {
+    if let Ok(lib_dir) = std::env::var("MKL_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    } else if let Ok(root) = std::env::var("MKLROOT") {
+        println!("cargo:rustc-link-search=native={}/lib", root);
+        println!("cargo:rustc-link-search=native={}/lib/intel64", root);
+    }
+
+    println!("cargo:rustc-link-lib=dylib=mkl_intel_lp64");
+    println!("cargo:rustc-link-lib=dylib=mkl_intel_thread");
+    println!("cargo:rustc-link-lib=dylib=mkl_core");
+    println!("cargo:rustc-link-lib=dylib=iomp5");
+
+    if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=m");
+        println!("cargo:rustc-link-lib=dl");
     }
 }

--- a/strided-einsum2/src/backend.rs
+++ b/strided-einsum2/src/backend.rs
@@ -95,21 +95,18 @@ impl<T: crate::ScalarBase> Backend<T> for NaiveBackend {
 
 /// The active GEMM backend, selected by Cargo features.
 ///
-/// - `faer` (without blas/blas-inject) -> `FaerBackend`
-/// - `blas` or `blas-inject` (without faer) -> `BlasBackend`
+/// - `blas` or `blas-inject` -> `BlasBackend`
+/// - `faer` without BLAS -> `FaerBackend`
 /// - no backend feature -> `NaiveBackend`
 /// - invalid combos -> `NaiveBackend` (placeholder; `compile_error!` fires first)
-#[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
-pub type ActiveBackend = FaerBackend;
-
-#[cfg(all(
-    not(feature = "faer"),
-    any(
-        all(feature = "blas", not(feature = "blas-inject")),
-        all(feature = "blas-inject", not(feature = "blas"))
-    )
+#[cfg(any(
+    all(feature = "blas", not(feature = "blas-inject")),
+    all(feature = "blas-inject", not(feature = "blas"))
 ))]
 pub type ActiveBackend = BlasBackend;
+
+#[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
+pub type ActiveBackend = FaerBackend;
 
 #[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
 pub type ActiveBackend = NaiveBackend;
@@ -118,8 +115,5 @@ pub type ActiveBackend = NaiveBackend;
 ///
 /// The crate emits `compile_error!` for these combinations (in `lib.rs`), so this
 /// alias only suppresses cascading type-resolution errors.
-#[cfg(any(
-    all(feature = "faer", any(feature = "blas", feature = "blas-inject")),
-    all(feature = "blas", feature = "blas-inject")
-))]
+#[cfg(all(feature = "blas", feature = "blas-inject"))]
 pub type ActiveBackend = NaiveBackend;

--- a/strided-einsum2/src/bgemm_blas.rs
+++ b/strided-einsum2/src/bgemm_blas.rs
@@ -7,7 +7,7 @@
 use crate::backend::{Backend, BlasBackend};
 use crate::contiguous::{ContiguousOperand, ContiguousOperandMut};
 use crate::util::{try_fuse_group, MultiIndex};
-use crate::Scalar;
+use crate::ScalarBase;
 
 #[cfg(all(feature = "blas-inject", not(feature = "blas")))]
 mod inject_fallback {
@@ -191,7 +191,7 @@ mod inject_fallback {
 
 /// Type-level dispatch trait for CBLAS GEMM.
 ///
-/// Implemented for `f64` (via `cblas_dgemm`) and `Complex64` (via `cblas_zgemm`).
+/// Implemented for `f32`/`f64` and `Complex32`/`Complex64`.
 /// The `trans_a` and `trans_b` parameters accept `cblas_sys::CBLAS_TRANSPOSE` values.
 pub trait BlasGemm: Sized {
     /// Call the appropriate CBLAS GEMM routine.
@@ -219,6 +219,43 @@ pub trait BlasGemm: Sized {
         c: *mut Self,
         ldc: i32,
     );
+}
+
+impl BlasGemm for f32 {
+    unsafe fn gemm(
+        trans_a: cblas_sys::CBLAS_TRANSPOSE,
+        trans_b: cblas_sys::CBLAS_TRANSPOSE,
+        m: i32,
+        n: i32,
+        k: i32,
+        alpha: f32,
+        a: *const f32,
+        lda: i32,
+        b: *const f32,
+        ldb: i32,
+        beta: f32,
+        c: *mut f32,
+        ldc: i32,
+    ) {
+        unsafe {
+            cblas_sys::cblas_sgemm(
+                cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                trans_a,
+                trans_b,
+                m,
+                n,
+                k,
+                alpha,
+                a,
+                lda,
+                b,
+                ldb,
+                beta,
+                c,
+                ldc,
+            );
+        }
+    }
 }
 
 impl BlasGemm for f64 {
@@ -252,6 +289,43 @@ impl BlasGemm for f64 {
                 ldb,
                 beta,
                 c,
+                ldc,
+            );
+        }
+    }
+}
+
+impl BlasGemm for num_complex::Complex32 {
+    unsafe fn gemm(
+        trans_a: cblas_sys::CBLAS_TRANSPOSE,
+        trans_b: cblas_sys::CBLAS_TRANSPOSE,
+        m: i32,
+        n: i32,
+        k: i32,
+        alpha: num_complex::Complex32,
+        a: *const num_complex::Complex32,
+        lda: i32,
+        b: *const num_complex::Complex32,
+        ldb: i32,
+        beta: num_complex::Complex32,
+        c: *mut num_complex::Complex32,
+        ldc: i32,
+    ) {
+        unsafe {
+            cblas_sys::cblas_cgemm(
+                cblas_sys::CBLAS_LAYOUT::CblasColMajor,
+                trans_a,
+                trans_b,
+                m,
+                n,
+                k,
+                (&alpha) as *const _ as *const _,
+                a as *const _ as *const _,
+                lda,
+                b as *const _ as *const _,
+                ldb,
+                (&beta) as *const _ as *const _,
+                c as *mut _ as *mut _,
                 ldc,
             );
         }
@@ -358,7 +432,7 @@ fn operand_layout(
 ///
 /// CBLAS handles `beta` internally, so no pre-scaling loop is needed
 /// (unlike the faer backend which requires explicit pre-scaling for beta not in {0, 1}).
-pub(crate) fn bgemm_contiguous_into<T: Scalar + BlasGemm>(
+pub(crate) fn bgemm_contiguous_into<T: ScalarBase + strided_view::ElementOpApply + BlasGemm>(
     c: &mut ContiguousOperandMut<T>,
     a: &ContiguousOperand<T>,
     b: &ContiguousOperand<T>,
@@ -465,7 +539,7 @@ pub(crate) fn bgemm_contiguous_into<T: Scalar + BlasGemm>(
 
 impl<T> Backend<T> for BlasBackend
 where
-    T: Scalar + BlasGemm,
+    T: ScalarBase + strided_view::ElementOpApply + BlasGemm,
 {
     const MATERIALIZES_CONJ: bool = true;
     const REQUIRES_UNIT_STRIDE: bool = true;

--- a/strided-einsum2/src/bgemm_faer.rs
+++ b/strided-einsum2/src/bgemm_faer.rs
@@ -375,7 +375,7 @@ use crate::backend::{Backend, FaerBackend};
 
 impl<T> Backend<T> for FaerBackend
 where
-    T: crate::Scalar + ComplexField,
+    T: crate::ScalarBase + strided_view::ElementOpApply + ComplexField,
 {
     const MATERIALIZES_CONJ: bool = false;
     const REQUIRES_UNIT_STRIDE: bool = false;

--- a/strided-einsum2/src/contiguous.rs
+++ b/strided-einsum2/src/contiguous.rs
@@ -695,6 +695,33 @@ mod tests {
     }
 
     #[test]
+    fn test_borrowed_transposed_matrix_no_copy() {
+        let data = vec![0.0f64; 6];
+        let a_t = StridedArray::<f64>::from_parts(data, &[2, 3], &[3, 1], 0).unwrap();
+        let view = a_t.view();
+
+        let op = prepare_input_view(&view, 1, 1, false, UNIT_STRIDE, true, None).unwrap();
+
+        assert!(!op.has_buf());
+        assert_eq!(op.row_stride(), 3);
+        assert_eq!(op.col_stride(), 1);
+    }
+
+    #[test]
+    fn test_borrowed_batched_transposed_matrix_no_copy() {
+        let data = vec![0.0f64; 2 * 3 * 5];
+        let a_t = StridedArray::<f64>::from_parts(data, &[2, 3, 5], &[3, 1, 6], 0).unwrap();
+        let view = a_t.view();
+
+        let op = prepare_input_view(&view, 1, 1, false, UNIT_STRIDE, true, None).unwrap();
+
+        assert!(!op.has_buf());
+        assert_eq!(op.row_stride(), 3);
+        assert_eq!(op.col_stride(), 1);
+        assert_eq!(op.batch_strides(), &[6]);
+    }
+
+    #[test]
     fn test_borrowed_non_contiguous_copies() {
         let data = vec![0.0f64; 100];
         let a = StridedArray::<f64>::from_parts(data, &[2, 3, 4], &[20, 4, 1], 0).unwrap();

--- a/strided-einsum2/src/dot_general.rs
+++ b/strided-einsum2/src/dot_general.rs
@@ -1,0 +1,306 @@
+//! Axis-based general dot product API.
+//!
+//! The dimension-numbering config borrows axis slices so callers can reuse
+//! their existing metadata without allocating a second owned config.
+//!
+//! ```
+//! use strided_einsum2::{dot_general_into, DotGeneralConfig};
+//! use strided_view::StridedArray;
+//!
+//! let a = StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| {
+//!     (idx[0] + 2 * idx[1] + 1) as f64
+//! });
+//! let b = StridedArray::<f64>::from_fn_col_major(&[3, 2], |idx| {
+//!     (idx[0] + 3 * idx[1] + 1) as f64
+//! });
+//! let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+//!
+//! let config = DotGeneralConfig {
+//!     lhs_contracting_dims: &[1],
+//!     rhs_contracting_dims: &[0],
+//!     lhs_batch_dims: &[],
+//!     rhs_batch_dims: &[],
+//! };
+//! dot_general_into(c.view_mut(), &a.view(), &b.view(), &config, 1.0, 0.0).unwrap();
+//! ```
+
+use smallvec::SmallVec;
+use strided_view::{StridedView, StridedViewMut};
+
+use crate::backend::Backend;
+use crate::{einsum2_dispatch, Einsum2Plan, EinsumError, Result, ScalarBase};
+
+/// DotGeneral dimension configuration.
+///
+/// The output shape is `[lhs_free..., rhs_free..., batch...]`, matching
+/// tenferro's batch-trailing col-major convention.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub struct DotGeneralConfig<'a> {
+    pub lhs_contracting_dims: &'a [usize],
+    pub rhs_contracting_dims: &'a [usize],
+    pub lhs_batch_dims: &'a [usize],
+    pub rhs_batch_dims: &'a [usize],
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DotGeneralLabels {
+    pub lhs_labels: SmallVec<[usize; 8]>,
+    pub rhs_labels: SmallVec<[usize; 8]>,
+    pub out_labels: SmallVec<[usize; 8]>,
+}
+
+fn check_no_duplicates(dims: &[usize], label: &str) -> Result<()> {
+    for (i, &dim) in dims.iter().enumerate() {
+        if dims[..i].contains(&dim) {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "{label} contains duplicate dim {dim}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn check_bounds(dims: &[usize], rank: usize, label: &str) -> Result<()> {
+    for &dim in dims {
+        if dim >= rank {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "{label} dim {dim} out of bounds for rank {rank}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn free_dims(rank: usize, contracting: &[usize], batch: &[usize]) -> SmallVec<[usize; 8]> {
+    (0..rank)
+        .filter(|dim| !contracting.contains(dim) && !batch.contains(dim))
+        .collect()
+}
+
+impl DotGeneralConfig<'_> {
+    /// Validate dimension indices for explicit operand ranks.
+    pub fn validate_dims_with_ranks(&self, lhs_rank: usize, rhs_rank: usize) -> Result<()> {
+        check_bounds(&self.lhs_contracting_dims, lhs_rank, "lhs_contracting")?;
+        check_bounds(&self.rhs_contracting_dims, rhs_rank, "rhs_contracting")?;
+        check_bounds(&self.lhs_batch_dims, lhs_rank, "lhs_batch")?;
+        check_bounds(&self.rhs_batch_dims, rhs_rank, "rhs_batch")?;
+        check_no_duplicates(&self.lhs_contracting_dims, "lhs_contracting_dims")?;
+        check_no_duplicates(&self.rhs_contracting_dims, "rhs_contracting_dims")?;
+        check_no_duplicates(&self.lhs_batch_dims, "lhs_batch_dims")?;
+        check_no_duplicates(&self.rhs_batch_dims, "rhs_batch_dims")?;
+
+        for &dim in self.lhs_contracting_dims {
+            if self.lhs_batch_dims.contains(&dim) {
+                return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                    "lhs dim {dim} appears in both contracting and batch dims"
+                )));
+            }
+        }
+        for &dim in self.rhs_contracting_dims {
+            if self.rhs_batch_dims.contains(&dim) {
+                return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                    "rhs dim {dim} appears in both contracting and batch dims"
+                )));
+            }
+        }
+        if self.lhs_contracting_dims.len() != self.rhs_contracting_dims.len() {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "lhs/rhs contracting dim counts differ ({} vs {})",
+                self.lhs_contracting_dims.len(),
+                self.rhs_contracting_dims.len()
+            )));
+        }
+        if self.lhs_batch_dims.len() != self.rhs_batch_dims.len() {
+            return Err(EinsumError::InvalidDotGeneralConfig(format!(
+                "lhs/rhs batch dim counts differ ({} vs {})",
+                self.lhs_batch_dims.len(),
+                self.rhs_batch_dims.len()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Compute the output shape `[lhs_free..., rhs_free..., batch...]`.
+    pub fn expected_output_shape(
+        &self,
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+    ) -> Result<Vec<usize>> {
+        self.validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())?;
+        self.validate_pair_shapes(lhs_shape, rhs_shape)?;
+
+        let lhs_free = free_dims(
+            lhs_shape.len(),
+            &self.lhs_contracting_dims,
+            &self.lhs_batch_dims,
+        );
+        let rhs_free = free_dims(
+            rhs_shape.len(),
+            &self.rhs_contracting_dims,
+            &self.rhs_batch_dims,
+        );
+
+        let mut out =
+            Vec::with_capacity(lhs_free.len() + rhs_free.len() + self.lhs_batch_dims.len());
+        out.extend(lhs_free.iter().map(|&dim| lhs_shape[dim]));
+        out.extend(rhs_free.iter().map(|&dim| rhs_shape[dim]));
+        out.extend(self.lhs_batch_dims.iter().map(|&dim| lhs_shape[dim]));
+        Ok(out)
+    }
+
+    fn validate_pair_shapes(&self, lhs_shape: &[usize], rhs_shape: &[usize]) -> Result<()> {
+        for (&lhs_dim, &rhs_dim) in self.lhs_batch_dims.iter().zip(self.rhs_batch_dims) {
+            if lhs_shape[lhs_dim] != rhs_shape[rhs_dim] {
+                return Err(EinsumError::DimensionMismatch {
+                    axis: format!("batch lhs {lhs_dim} rhs {rhs_dim}"),
+                    dim_a: lhs_shape[lhs_dim],
+                    dim_b: rhs_shape[rhs_dim],
+                });
+            }
+        }
+        for (&lhs_dim, &rhs_dim) in self
+            .lhs_contracting_dims
+            .iter()
+            .zip(self.rhs_contracting_dims)
+        {
+            if lhs_shape[lhs_dim] != rhs_shape[rhs_dim] {
+                return Err(EinsumError::DimensionMismatch {
+                    axis: format!("contract lhs {lhs_dim} rhs {rhs_dim}"),
+                    dim_a: lhs_shape[lhs_dim],
+                    dim_b: rhs_shape[rhs_dim],
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn labels_for_shapes(
+        &self,
+        lhs_shape: &[usize],
+        rhs_shape: &[usize],
+        out_shape: &[usize],
+    ) -> Result<DotGeneralLabels> {
+        self.validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())?;
+        self.validate_pair_shapes(lhs_shape, rhs_shape)?;
+
+        let lhs_free = free_dims(
+            lhs_shape.len(),
+            &self.lhs_contracting_dims,
+            &self.lhs_batch_dims,
+        );
+        let rhs_free = free_dims(
+            rhs_shape.len(),
+            &self.rhs_contracting_dims,
+            &self.rhs_batch_dims,
+        );
+
+        let mut lhs_labels = smallvec::smallvec![usize::MAX; lhs_shape.len()];
+        let mut rhs_labels = smallvec::smallvec![usize::MAX; rhs_shape.len()];
+        let mut next_label = 0usize;
+
+        for (&lhs_dim, &rhs_dim) in self.lhs_batch_dims.iter().zip(self.rhs_batch_dims) {
+            lhs_labels[lhs_dim] = next_label;
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+        for &lhs_dim in &lhs_free {
+            lhs_labels[lhs_dim] = next_label;
+            next_label += 1;
+        }
+        for &rhs_dim in &rhs_free {
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+        for (&lhs_dim, &rhs_dim) in self
+            .lhs_contracting_dims
+            .iter()
+            .zip(self.rhs_contracting_dims)
+        {
+            lhs_labels[lhs_dim] = next_label;
+            rhs_labels[rhs_dim] = next_label;
+            next_label += 1;
+        }
+
+        let expected_out_shape = self.expected_output_shape(lhs_shape, rhs_shape)?;
+        if expected_out_shape.as_slice() != out_shape {
+            return Err(EinsumError::OutputShapeMismatch {
+                expected: expected_out_shape,
+                got: out_shape.to_vec(),
+            });
+        }
+
+        let mut out_labels = SmallVec::<[usize; 8]>::new();
+        out_labels.extend(lhs_free.iter().map(|&dim| lhs_labels[dim]));
+        out_labels.extend(rhs_free.iter().map(|&dim| rhs_labels[dim]));
+        out_labels.extend(self.lhs_batch_dims.iter().map(|&dim| lhs_labels[dim]));
+
+        Ok(DotGeneralLabels {
+            lhs_labels,
+            rhs_labels,
+            out_labels,
+        })
+    }
+}
+
+/// Compute `C = alpha * dot_general(A, B) + beta * C` with an explicit backend.
+pub fn dot_general_with_backend_into<T, B>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig<'_>,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+where
+    T: ScalarBase,
+    B: Backend<T>,
+{
+    let labels = config.labels_for_shapes(a.dims(), b.dims(), c.dims())?;
+    let plan = Einsum2Plan::new(
+        labels.lhs_labels.as_slice(),
+        labels.rhs_labels.as_slice(),
+        labels.out_labels.as_slice(),
+    )?;
+    einsum2_dispatch::<T, B, _>(c, a, b, &plan, alpha, beta, false, false, None)
+}
+
+/// Compute `C = alpha * dot_general(A, B) + beta * C` with the active backend.
+#[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
+pub fn dot_general_into<T: crate::Scalar>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig<'_>,
+    alpha: T,
+    beta: T,
+) -> Result<()>
+where
+    crate::backend::ActiveBackend: Backend<T>,
+{
+    dot_general_with_backend_into::<T, crate::backend::ActiveBackend>(c, a, b, config, alpha, beta)
+}
+
+/// Compute `C = alpha * dot_general(A, B) + beta * C` with the naive fallback.
+#[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
+pub fn dot_general_into<T: crate::Scalar>(
+    c: StridedViewMut<T>,
+    a: &StridedView<T>,
+    b: &StridedView<T>,
+    config: &DotGeneralConfig<'_>,
+    alpha: T,
+    beta: T,
+) -> Result<()> {
+    let labels = config.labels_for_shapes(a.dims(), b.dims(), c.dims())?;
+    crate::einsum2_naive_into(
+        c,
+        a,
+        b,
+        labels.out_labels.as_slice(),
+        labels.lhs_labels.as_slice(),
+        labels.rhs_labels.as_slice(),
+        alpha,
+        beta,
+        |x| x,
+        |x| x,
+    )
+}

--- a/strided-einsum2/src/lib.rs
+++ b/strided-einsum2/src/lib.rs
@@ -21,26 +21,24 @@
 //! ).unwrap();
 //! ```
 
-#[cfg(all(feature = "faer", feature = "blas"))]
-compile_error!("Features `faer` and `blas` are mutually exclusive. Use one or the other.");
-
-#[cfg(all(feature = "faer", feature = "blas-inject"))]
-compile_error!("Features `faer` and `blas-inject` are mutually exclusive.");
-
 #[cfg(all(feature = "blas", feature = "blas-inject"))]
 compile_error!("Features `blas` and `blas-inject` are mutually exclusive.");
+
+#[cfg(any(
+    all(feature = "blas-accelerate", feature = "blas-openblas"),
+    all(feature = "blas-accelerate", feature = "blas-mkl"),
+    all(feature = "blas-openblas", feature = "blas-mkl")
+))]
+compile_error!("Select at most one explicit BLAS provider feature.");
 
 #[cfg(all(feature = "blas-inject", not(feature = "blas")))]
 extern crate cblas_inject as cblas_sys;
 #[cfg(all(feature = "blas", not(feature = "blas-inject")))]
 extern crate cblas_sys;
 
-#[cfg(all(
-    not(feature = "faer"),
-    any(
-        all(feature = "blas", not(feature = "blas-inject")),
-        all(feature = "blas-inject", not(feature = "blas"))
-    )
+#[cfg(any(
+    all(feature = "blas", not(feature = "blas-inject")),
+    all(feature = "blas-inject", not(feature = "blas"))
 ))]
 pub mod bgemm_blas;
 
@@ -51,6 +49,8 @@ pub mod bgemm_faer;
 pub mod bgemm_naive;
 /// GEMM-ready operand types and preparation functions for contiguous data.
 pub mod contiguous;
+/// Axis-based general dot product API.
+pub mod dot_general;
 /// Contraction planning: axis classification and permutation computation.
 pub mod plan;
 /// Trace-axis reduction (summing axes that appear only in one operand).
@@ -68,11 +68,13 @@ use std::hash::Hash;
 use strided_kernel::zip_map2_into;
 #[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
 use strided_view::StridedArray;
-use strided_view::{Adjoint, Conj, ElementOp, ElementOpApply, StridedView, StridedViewMut};
+use strided_view::{Adjoint, Conj, ElementOp, ElementOpApply};
 
 pub use strided_traits::ScalarBase;
+pub use strided_view::{col_major_strides, StridedView, StridedViewMut};
 
 pub use backend::Backend;
+pub use dot_general::{dot_general_into, dot_general_with_backend_into, DotGeneralConfig};
 pub use plan::Einsum2Plan;
 
 /// Trait alias for axis label types.
@@ -85,34 +87,29 @@ impl<T: Clone + Eq + Hash + Debug> AxisId for T {}
 
 /// Trait alias for element types supported by einsum operations.
 ///
-/// When the `faer` feature is enabled, this additionally requires `faer::ComplexField`
+/// When BLAS is enabled, `Scalar` follows the active backend and requires
+/// `BlasGemm`, even if faer is also compiled for explicit backend use.
+#[cfg(any(
+    all(feature = "blas", not(feature = "blas-inject")),
+    all(feature = "blas-inject", not(feature = "blas"))
+))]
+pub trait Scalar: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
+
+#[cfg(any(
+    all(feature = "blas", not(feature = "blas-inject")),
+    all(feature = "blas-inject", not(feature = "blas"))
+))]
+impl<T> Scalar for T where T: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
+
+/// Trait alias for element types supported by the faer active backend.
+///
+/// When only faer is enabled, this additionally requires `faer::ComplexField`
 /// so that the faer GEMM backend can be used.
 #[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
 pub trait Scalar: ScalarBase + ElementOpApply + faer_traits::ComplexField {}
 
 #[cfg(all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))))]
 impl<T> Scalar for T where T: ScalarBase + ElementOpApply + faer_traits::ComplexField {}
-
-/// Trait alias for element types (with `blas` or `blas-inject` feature).
-///
-/// Includes `BlasGemm` so that all `Scalar` types can be dispatched to CBLAS.
-#[cfg(all(
-    not(feature = "faer"),
-    any(
-        all(feature = "blas", not(feature = "blas-inject")),
-        all(feature = "blas-inject", not(feature = "blas"))
-    )
-))]
-pub trait Scalar: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
-
-#[cfg(all(
-    not(feature = "faer"),
-    any(
-        all(feature = "blas", not(feature = "blas-inject")),
-        all(feature = "blas-inject", not(feature = "blas"))
-    )
-))]
-impl<T> Scalar for T where T: ScalarBase + ElementOpApply + bgemm_blas::BlasGemm {}
 
 /// Trait alias for element types (without `faer` or BLAS features).
 #[cfg(not(any(feature = "faer", feature = "blas", feature = "blas-inject")))]
@@ -125,16 +122,10 @@ impl<T> Scalar for T where T: ScalarBase + ElementOpApply {}
 ///
 /// The crate emits `compile_error!` above for these combinations. This trait only
 /// avoids cascading type-resolution errors so users see the intended diagnostics.
-#[cfg(any(
-    all(feature = "faer", any(feature = "blas", feature = "blas-inject")),
-    all(feature = "blas", feature = "blas-inject")
-))]
+#[cfg(all(feature = "blas", feature = "blas-inject"))]
 pub trait Scalar: ScalarBase + ElementOpApply {}
 
-#[cfg(any(
-    all(feature = "faer", any(feature = "blas", feature = "blas-inject")),
-    all(feature = "blas", feature = "blas-inject")
-))]
+#[cfg(all(feature = "blas", feature = "blas-inject"))]
 impl<T> Scalar for T where T: ScalarBase + ElementOpApply {}
 
 /// Errors specific to einsum operations.
@@ -149,6 +140,13 @@ pub enum EinsumError {
         axis: String,
         dim_a: usize,
         dim_b: usize,
+    },
+    #[error("invalid dot-general config: {0}")]
+    InvalidDotGeneralConfig(String),
+    #[error("output shape mismatch: expected {expected:?}, got {got:?}")]
+    OutputShapeMismatch {
+        expected: Vec<usize>,
+        got: Vec<usize>,
     },
     #[error(transparent)]
     Strided(#[from] strided_view::StridedError),
@@ -230,16 +228,7 @@ where
     };
 
     // 4. Dispatch to GEMM
-    #[cfg(any(
-        all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))),
-        all(
-            not(feature = "faer"),
-            any(
-                all(feature = "blas", not(feature = "blas-inject")),
-                all(feature = "blas-inject", not(feature = "blas"))
-            )
-        )
-    ))]
+    #[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
     {
         let conj_fn = make_conj_fn::<T>();
         einsum2_dispatch::<T, backend::ActiveBackend, _>(
@@ -441,22 +430,60 @@ where
 /// When the backend requires conj to be materialized into data (e.g. CBLAS),
 /// returns `Some(conj_apply)`. Otherwise returns `None` (backend handles conj
 /// via transpose flags or similar).
-#[cfg(any(
-    all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))),
-    all(
-        not(feature = "faer"),
-        any(
-            all(feature = "blas", not(feature = "blas-inject")),
-            all(feature = "blas-inject", not(feature = "blas"))
-        )
-    )
-))]
+#[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
 fn make_conj_fn<T: Scalar>() -> Option<fn(T) -> T> {
     if <backend::ActiveBackend as Backend<T>>::MATERIALIZES_CONJ {
         Some(|x| Conj::apply(x))
     } else {
         None
     }
+}
+
+fn scale_or_zero_strided_mut<T: ScalarBase>(c: &mut StridedViewMut<T>, beta: T) {
+    if c.is_empty() {
+        return;
+    }
+
+    let dims = c.dims().to_vec();
+    let strides = c.strides().to_vec();
+    let ptr = c.as_mut_ptr();
+    let zero = T::zero();
+
+    fn visit<T: ScalarBase>(
+        ptr: *mut T,
+        dims: &[usize],
+        strides: &[isize],
+        axis: usize,
+        offset: isize,
+        beta: T,
+        zero: T,
+    ) {
+        if axis == dims.len() {
+            unsafe {
+                let dst = ptr.offset(offset);
+                if beta == zero {
+                    *dst = zero;
+                } else {
+                    *dst = beta * *dst;
+                }
+            }
+            return;
+        }
+
+        for i in 0..dims[axis] {
+            visit(
+                ptr,
+                dims,
+                strides,
+                axis + 1,
+                offset + i as isize * strides[axis],
+                beta,
+                zero,
+            );
+        }
+    }
+
+    visit(ptr, &dims, &strides, 0, 0, beta, zero);
 }
 
 /// Internal GEMM dispatch, generic over backend.
@@ -471,7 +498,7 @@ fn make_conj_fn<T: Scalar>() -> Option<fn(T) -> T> {
 /// `conj_fn` is the materialization function for backends that need conj
 /// applied to data before GEMM. Pass `None` when conj_a/conj_b are both false
 /// or when the backend handles conj natively (via flags).
-fn einsum2_dispatch<T, B, ID>(
+pub(crate) fn einsum2_dispatch<T, B, ID>(
     c: StridedViewMut<T>,
     a: &StridedView<T>,
     b: &StridedView<T>,
@@ -491,6 +518,10 @@ where
     let a_perm = a.permute(&plan.left_perm)?;
     let b_perm = b.permute(&plan.right_perm)?;
     let mut c_perm = c.permute(&plan.c_to_internal_perm)?;
+
+    if c_perm.is_empty() {
+        return Ok(());
+    }
 
     // 2. Fast path: element-wise (all batch, no contraction)
     if plan.sum.is_empty() && plan.lo.is_empty() && plan.ro.is_empty() && beta == T::zero() {
@@ -550,6 +581,10 @@ where
     let sum_dims = &a_perm.dims()[n_lo..n_lo + n_sum];
     let batch_dims = &a_perm.dims()[n_lo + n_sum..];
     let ro_dims = &b_perm.dims()[n_sum..n_sum + n_ro];
+    if sum_dims.iter().any(|&dim| dim == 0) {
+        scale_or_zero_strided_mut(&mut c_perm, beta);
+        return Ok(());
+    }
     let m: usize = lo_dims.iter().product::<usize>().max(1);
     let k: usize = sum_dims.iter().product::<usize>().max(1);
     let n: usize = ro_dims.iter().product::<usize>().max(1);
@@ -571,16 +606,7 @@ where
 /// the behavior is identical.
 ///
 /// `conj_a` and `conj_b` indicate whether to conjugate elements of A/B.
-#[cfg(any(
-    all(feature = "faer", not(any(feature = "blas", feature = "blas-inject"))),
-    all(
-        not(feature = "faer"),
-        any(
-            all(feature = "blas", not(feature = "blas-inject")),
-            all(feature = "blas-inject", not(feature = "blas"))
-        )
-    )
-))]
+#[cfg(any(feature = "faer", feature = "blas", feature = "blas-inject"))]
 pub fn einsum2_into_owned<T: Scalar, ID: AxisId>(
     c: StridedViewMut<T>,
     a: StridedArray<T>,

--- a/strided-einsum2/tests/dot_general.rs
+++ b/strided-einsum2/tests/dot_general.rs
@@ -1,0 +1,245 @@
+use strided_einsum2::{dot_general_into, DotGeneralConfig};
+use strided_view::{col_major_strides, StridedArray};
+
+fn col_major_array(data: Vec<f64>, shape: &[usize]) -> StridedArray<f64> {
+    StridedArray::from_parts(data, shape, &col_major_strides(shape), 0).unwrap()
+}
+
+fn get_col_major(data: &[f64], shape: &[usize], idx: &[usize]) -> f64 {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&i, &dim) in idx.iter().zip(shape) {
+        offset += i * stride;
+        stride *= dim;
+    }
+    data[offset]
+}
+
+fn expected_matmul_col_major(
+    a: &[f64],
+    a_shape: &[usize],
+    b: &[f64],
+    b_shape: &[usize],
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Vec<f64> {
+    let mut out = vec![0.0; m * n];
+    for j in 0..n {
+        for i in 0..m {
+            let mut acc = 0.0;
+            for p in 0..k {
+                acc += get_col_major(a, a_shape, &[i, p]) * get_col_major(b, b_shape, &[p, j]);
+            }
+            out[i + m * j] = acc;
+        }
+    }
+    out
+}
+
+#[test]
+fn dot_general_matmul_matches_col_major_reference() {
+    let a_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let b_data = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
+    let a = col_major_array(a_data.clone(), &[2, 3]);
+    let b = col_major_array(b_data.clone(), &[3, 2]);
+    let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[],
+            rhs_batch_dims: &[],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(
+        c.data(),
+        expected_matmul_col_major(&a_data, &[2, 3], &b_data, &[3, 2], 2, 2, 3).as_slice()
+    );
+}
+
+#[test]
+fn dot_general_batched_matmul_uses_batch_trailing_output_shape() {
+    let a = StridedArray::<f64>::from_fn_col_major(&[2, 3, 2], |idx| {
+        (100 * idx[2] + 10 * idx[1] + idx[0] + 1) as f64
+    });
+    let b = StridedArray::<f64>::from_fn_col_major(&[3, 4, 2], |idx| {
+        (100 * idx[2] + 10 * idx[1] + idx[0] + 1) as f64
+    });
+    let mut c = StridedArray::<f64>::col_major(&[2, 4, 2]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[2],
+            rhs_batch_dims: &[2],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    for batch in 0..2 {
+        for j in 0..4 {
+            for i in 0..2 {
+                let mut expected = 0.0;
+                for p in 0..3 {
+                    expected += a.get(&[i, p, batch]) * b.get(&[p, j, batch]);
+                }
+                assert_eq!(c.get(&[i, j, batch]), expected);
+            }
+        }
+    }
+}
+
+#[test]
+fn dot_general_matches_tenferro_batched_matmul_colmajor_layout() {
+    let batch = 2;
+    let m = 3;
+    let n = 4;
+    let k = 5;
+    let lhs_row_memory = StridedArray::<f64>::from_fn_col_major(&[k, m, batch], |idx| {
+        (1000 * idx[2] + 100 * idx[1] + 10 * idx[0] + 1) as f64
+    });
+    let rhs_row_memory = StridedArray::<f64>::from_fn_col_major(&[n, k, batch], |idx| {
+        (1000 * idx[2] + 100 * idx[1] + 10 * idx[0] + 7) as f64
+    });
+    let mut out = StridedArray::<f64>::col_major(&[n, m, batch]);
+
+    dot_general_into(
+        out.view_mut(),
+        &rhs_row_memory.view(),
+        &lhs_row_memory.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[2],
+            rhs_batch_dims: &[2],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    for b in 0..batch {
+        for i in 0..m {
+            for out_colmajor_n in 0..n {
+                let mut expected = 0.0;
+                for p in 0..k {
+                    expected += lhs_row_memory.get(&[p, i, b])
+                        * rhs_row_memory.get(&[out_colmajor_n, p, b]);
+                }
+                assert_eq!(out.get(&[out_colmajor_n, i, b]), expected);
+            }
+        }
+    }
+}
+
+#[test]
+fn dot_general_accepts_transposed_input_view() {
+    let a = StridedArray::<f64>::from_fn_col_major(&[3, 2], |idx| (idx[0] + 3 * idx[1] + 1) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+    let b = StridedArray::<f64>::from_fn_col_major(&[3, 2], |idx| (idx[0] + 3 * idx[1] + 7) as f64);
+    let mut c = StridedArray::<f64>::col_major(&[2, 2]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a_t,
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[],
+            rhs_batch_dims: &[],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(c.data(), &[50.0, 122.0, 68.0, 167.0]);
+}
+
+#[test]
+fn dot_general_inner_product_returns_rank0_scalar() {
+    let a = col_major_array(vec![1.0, 2.0, 3.0], &[3]);
+    let b = col_major_array(vec![4.0, 5.0, 6.0], &[3]);
+    let mut c = StridedArray::<f64>::col_major(&[]);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[0],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[],
+            rhs_batch_dims: &[],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(c.data(), &[32.0]);
+}
+
+#[test]
+fn dot_general_zero_contracting_dim_zero_fills_output() {
+    let a = col_major_array(Vec::new(), &[2, 0]);
+    let b = col_major_array(Vec::new(), &[0, 3]);
+    let mut c = StridedArray::<f64>::from_fn_col_major(&[2, 3], |_| 5.0);
+
+    dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[],
+            rhs_batch_dims: &[],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap();
+
+    assert_eq!(c.data(), &[0.0; 6]);
+}
+
+#[test]
+fn dot_general_rejects_wrong_output_shape() {
+    let a = StridedArray::<f64>::col_major(&[2, 3]);
+    let b = StridedArray::<f64>::col_major(&[3, 4]);
+    let mut c = StridedArray::<f64>::col_major(&[4, 2]);
+
+    let err = dot_general_into(
+        c.view_mut(),
+        &a.view(),
+        &b.view(),
+        &DotGeneralConfig {
+            lhs_contracting_dims: &[1],
+            rhs_contracting_dims: &[0],
+            lhs_batch_dims: &[],
+            rhs_batch_dims: &[],
+        },
+        1.0,
+        0.0,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("output shape mismatch"));
+}

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -51,3 +51,7 @@ harness = false
 [[bench]]
 name = "outer_product"
 harness = false
+
+[[bench]]
+name = "mul_pytorch_compare"
+harness = false

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -47,3 +47,7 @@ required-features = ["parallel"]
 [[bench]]
 name = "rank25_permute"
 harness = false
+
+[[bench]]
+name = "outer_product"
+harness = false

--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -109,6 +109,15 @@ RAYON_NUM_THREADS=1 cargo bench --bench rank25_permute --manifest-path strided-k
 
 # Rank-25 Julia comparison
 JULIA_NUM_THREADS=1 julia --project=strided-kernel/benches strided-kernel/benches/julia_rank25_compare.jl
+
+# Mul kernel comparison against PyTorch CPU at 1T and 4T.
+# Requires uv; the script uses uv run --with torch --with numpy so PyTorch
+# is installed only in the benchmark environment.
+# The PyTorch runner uses torch.mul(..., out=...) to avoid allocator/autograd overhead.
+# Noncompact batched outer product includes both compact output and a
+# torchlike_output case whose non-contiguous output strides match torch.einsum.
+uv --version
+STRIDED_KERNEL_MUL_BENCH_PROFILE=full bash strided-kernel/benches/run_mul_pytorch_compare.sh 1 4
 ```
 
 ### Single-Threaded Results

--- a/strided-kernel/benches/mul_pytorch_compare.py
+++ b/strided-kernel/benches/mul_pytorch_compare.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""PyTorch reference runner for strided-kernel mul benchmarks.
+
+The timed loop uses torch.mul(..., out=...) so allocator and autograd overheads
+are excluded. Shapes follow the original tenferro-benchmark row-major einsum
+instances, while the Rust runner uses the equivalent strided-kernel column-major
+views.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import statistics
+import sys
+import time
+from collections.abc import Callable
+
+
+DEFAULT_WARMUPS = 3
+DEFAULT_RUNS = 15
+
+ELEMENTWISE = "elementwise"
+OUTER_PRODUCT = "outer_product"
+BATCHED_OUTER_COMPACT = "batched_outer_compact"
+BATCHED_OUTER_NONCOMPACT = "batched_outer_noncompact"
+BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT = "batched_outer_noncompact_torchlike_output"
+BATCHED_OUTER_NONCOMPACT_LHS_SCALAR = "batched_outer_noncompact_lhs_scalar"
+BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP = "batched_outer_noncompact_single_outer_group"
+PERMUTED_ELEMENTWISE = "permuted_elementwise"
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def parse_dtypes(value: str) -> list[str]:
+    dtypes = []
+    for item in value.split(","):
+        item = item.strip()
+        if item in {"f64", "c64", "c128"}:
+            dtypes.append(item)
+        elif item:
+            raise argparse.ArgumentTypeError(f"unknown dtype: {item}")
+    return dtypes or ["f64"]
+
+
+def configure_thread_env(num_threads: int) -> None:
+    value = str(num_threads)
+    xla_multi_thread = "true" if num_threads > 1 else "false"
+    os.environ.update(
+        {
+            "OMP_NUM_THREADS": value,
+            "OMP_THREAD_LIMIT": value,
+            "OMP_DYNAMIC": "FALSE",
+            "RAYON_NUM_THREADS": value,
+            "OPENBLAS_NUM_THREADS": value,
+            "GOTO_NUM_THREADS": value,
+            "MKL_NUM_THREADS": value,
+            "VECLIB_MAXIMUM_THREADS": value,
+            "VECLIB_NUM_THREADS": value,
+            "NUMEXPR_NUM_THREADS": value,
+            "BLIS_NUM_THREADS": value,
+            "XLA_FLAGS": (
+                f"--xla_cpu_multi_thread_eigen={xla_multi_thread} "
+                f"intra_op_parallelism_threads={value}"
+            ),
+        }
+    )
+
+
+def case_specs(profile: str) -> list[tuple[str, tuple[int, ...]]]:
+    if profile == "smoke":
+        return [
+            (ELEMENTWISE, (64,)),
+            (OUTER_PRODUCT, (64,)),
+            (BATCHED_OUTER_COMPACT, (4, 4, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT, (4, 4, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT, (4, 4, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT_LHS_SCALAR, (4, 4, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT, (2, 8, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT, (8, 2, 8, 8)),
+            (BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP, (32, 32, 1, 1)),
+            (PERMUTED_ELEMENTWISE, (6, 3)),
+        ]
+    if profile == "quick":
+        return [
+            (ELEMENTWISE, (1024,)),
+            (OUTER_PRODUCT, (2048,)),
+            (BATCHED_OUTER_COMPACT, (16, 16, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT, (16, 16, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT, (16, 16, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT_LHS_SCALAR, (16, 16, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT, (8, 32, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT, (32, 8, 64, 64)),
+            (BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP, (256, 256, 1, 1)),
+            (PERMUTED_ELEMENTWISE, (12, 3)),
+        ]
+    return [
+        (ELEMENTWISE, (2048,)),
+        (OUTER_PRODUCT, (4096,)),
+        (BATCHED_OUTER_COMPACT, (16, 16, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT, (16, 16, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT, (16, 16, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT_LHS_SCALAR, (16, 16, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT, (8, 32, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT, (32, 8, 64, 64)),
+        (BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP, (1024, 1024, 1, 1)),
+        (PERMUTED_ELEMENTWISE, (16, 3)),
+    ]
+
+
+def benchmark_name(kind: str, dims: tuple[int, ...]) -> str:
+    if kind == ELEMENTWISE:
+        n = dims[0]
+        return f"bin_elementwise_mul_{n}x{n}"
+    if kind == OUTER_PRODUCT:
+        return f"bin_outer_product_{dims[0]}"
+    if kind == PERMUTED_ELEMENTWISE:
+        rank, extent = dims
+        return f"bin_permuted_elementwise_mul_rank{rank}_extent{extent}"
+
+    j, k, o, t = dims
+    if kind == BATCHED_OUTER_COMPACT:
+        return f"bin_batched_outer_product_compact_j{j}_k{k}_o{o}_t{t}"
+    if kind == BATCHED_OUTER_NONCOMPACT:
+        return f"bin_batched_outer_product_noncompact_j{j}_k{k}_o{o}_t{t}"
+    if kind == BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT:
+        return f"bin_batched_outer_product_noncompact_torchlike_output_j{j}_k{k}_o{o}_t{t}"
+    if kind == BATCHED_OUTER_NONCOMPACT_LHS_SCALAR:
+        return f"bin_batched_outer_product_noncompact_lhs_scalar_j{j}_k{k}_o{o}_t{t}"
+    if kind == BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP:
+        return f"bin_batched_outer_product_noncompact_single_outer_group_j{j}_k{k}_o{o}_t{t}"
+    raise ValueError(f"unknown benchmark kind: {kind}")
+
+
+def median_iqr(samples: list[float]) -> tuple[float, float]:
+    ordered = sorted(samples)
+    return statistics.median(ordered), ordered[(3 * len(ordered)) // 4] - ordered[len(ordered) // 4]
+
+
+def bench(fn: Callable[[], object], runs: int, warmups: int) -> tuple[float, float]:
+    for _ in range(warmups):
+        fn()
+    samples = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        value = fn()
+        samples.append((time.perf_counter() - start) * 1000.0)
+        # CPU eager ops are synchronous; this prevents accidental dead-code-like
+        # benchmark changes if the body is later refactored.
+        if hasattr(value, "numel"):
+            value.numel()
+    return median_iqr(samples)
+
+
+def torch_dtype(torch, dtype: str):
+    if dtype == "f64":
+        return torch.float64
+    if dtype == "c64":
+        return torch.complex64
+    if dtype == "c128":
+        return torch.complex128
+    raise ValueError(f"unknown dtype: {dtype}")
+
+
+def randn_tensor(torch, shape: tuple[int, ...], dtype: str):
+    if dtype == "f64":
+        return torch.randn(shape, dtype=torch_dtype(torch, dtype))
+    real_dtype = torch.float32 if dtype == "c64" else torch.float64
+    return torch.randn(shape, dtype=real_dtype) + 1j * torch.randn(shape, dtype=real_dtype)
+
+
+def empty_tensor(torch, shape: tuple[int, ...], dtype: str):
+    return torch.empty(shape, dtype=torch_dtype(torch, dtype))
+
+
+def make_elementwise_case(torch, dtype: str, n: int):
+    lhs = randn_tensor(torch, (n, n), dtype)
+    rhs = randn_tensor(torch, (n, n), dtype)
+    out = empty_tensor(torch, (n, n), dtype)
+    return f"{n}x{n}", lambda: torch.mul(lhs, rhs, out=out)
+
+
+def make_outer_product_case(torch, dtype: str, n: int):
+    lhs = randn_tensor(torch, (n, 1), dtype)
+    rhs = randn_tensor(torch, (1, n), dtype)
+    out = empty_tensor(torch, (n, n), dtype)
+    return f"{n}x{n}", lambda: torch.mul(lhs, rhs, out=out)
+
+
+def make_batched_outer_compact_case(torch, dtype: str, j: int, k: int, o: int, t: int):
+    lhs = randn_tensor(torch, (t, k, j), dtype)
+    rhs = randn_tensor(torch, (t, o), dtype)
+    out = empty_tensor(torch, (t, o, k, j), dtype)
+    lhs_view = lhs[:, None, :, :]
+    rhs_view = rhs[:, :, None, None]
+    return f"j={j};k={k};o={o};t={t}", lambda: torch.mul(lhs_view, rhs_view, out=out)
+
+
+def make_batched_outer_noncompact_case(torch, dtype: str, j: int, k: int, o: int, t: int):
+    lhs = randn_tensor(torch, (t, j, k), dtype)
+    rhs = randn_tensor(torch, (t, o), dtype)
+    out = empty_tensor(torch, (t, o, k, j), dtype)
+    lhs_view = lhs[:, None, :, :].permute(0, 1, 3, 2)
+    rhs_view = rhs[:, :, None, None]
+    return f"j={j};k={k};o={o};t={t}", lambda: torch.mul(lhs_view, rhs_view, out=out)
+
+
+def make_batched_outer_noncompact_torchlike_output_case(torch, dtype: str, j: int, k: int, o: int, t: int):
+    lhs = randn_tensor(torch, (t, j, k), dtype)
+    rhs = randn_tensor(torch, (t, o), dtype)
+    out = torch.empty_strided((t, o, k, j), (o * k * j, k * j, 1, k), dtype=torch_dtype(torch, dtype))
+    lhs_view = lhs[:, None, :, :].permute(0, 1, 3, 2)
+    rhs_view = rhs[:, :, None, None]
+    return f"j={j};k={k};o={o};t={t}", lambda: torch.mul(lhs_view, rhs_view, out=out)
+
+
+def make_batched_outer_noncompact_lhs_scalar_case(torch, dtype: str, j: int, k: int, o: int, t: int):
+    lhs = randn_tensor(torch, (t, o), dtype)
+    rhs = randn_tensor(torch, (t, j, k), dtype)
+    out = empty_tensor(torch, (t, o, k, j), dtype)
+    lhs_view = lhs[:, :, None, None]
+    rhs_view = rhs[:, None, :, :].permute(0, 1, 3, 2)
+    return f"j={j};k={k};o={o};t={t}", lambda: torch.mul(lhs_view, rhs_view, out=out)
+
+
+def permuted_elementwise_axes(rank: int) -> tuple[int, ...]:
+    if rank == 16:
+        return (7, 4, 10, 5, 12, 2, 9, 13, 1, 3, 6, 15, 14, 11, 8, 0)
+    return tuple(reversed(range(rank)))
+
+
+def make_permuted_elementwise_case(torch, dtype: str, rank: int, extent: int):
+    shape = (extent,) * rank
+    lhs = randn_tensor(torch, shape, dtype)
+    rhs_base = randn_tensor(torch, shape, dtype)
+    rhs = rhs_base.permute(permuted_elementwise_axes(rank))
+    out = empty_tensor(torch, shape, dtype)
+    return f"rank={rank};extent={extent}", lambda: torch.mul(lhs, rhs, out=out)
+
+
+def make_case(torch, dtype: str, kind: str, dims: tuple[int, ...]):
+    if kind == ELEMENTWISE:
+        return make_elementwise_case(torch, dtype, dims[0])
+    if kind == OUTER_PRODUCT:
+        return make_outer_product_case(torch, dtype, dims[0])
+    if kind == BATCHED_OUTER_COMPACT:
+        return make_batched_outer_compact_case(torch, dtype, *dims)
+    if kind == BATCHED_OUTER_NONCOMPACT:
+        return make_batched_outer_noncompact_case(torch, dtype, *dims)
+    if kind == BATCHED_OUTER_NONCOMPACT_TORCHLIKE_OUTPUT:
+        return make_batched_outer_noncompact_torchlike_output_case(torch, dtype, *dims)
+    if kind == BATCHED_OUTER_NONCOMPACT_LHS_SCALAR:
+        return make_batched_outer_noncompact_lhs_scalar_case(torch, dtype, *dims)
+    if kind == BATCHED_OUTER_NONCOMPACT_SINGLE_OUTER_GROUP:
+        return make_batched_outer_noncompact_case(torch, dtype, *dims)
+    if kind == PERMUTED_ELEMENTWISE:
+        return make_permuted_elementwise_case(torch, dtype, *dims)
+    raise ValueError(f"unknown benchmark kind: {kind}")
+
+
+def shape_label(kind: str, dims: tuple[int, ...]) -> str:
+    if kind in {ELEMENTWISE, OUTER_PRODUCT}:
+        return f"{dims[0]}x{dims[0]}"
+    if kind == PERMUTED_ELEMENTWISE:
+        rank, extent = dims
+        return f"rank={rank};extent={extent}"
+    j, k, o, t = dims
+    return f"j={j};k={k};o={o};t={t}"
+
+
+def emit_error_rows(writer: csv.DictWriter, args: argparse.Namespace, status: str) -> None:
+    for dtype in parse_dtypes(args.dtypes):
+        for kind, dims in case_specs(args.profile):
+            writer.writerow(
+                {
+                    "suite": "mul",
+                    "benchmark": benchmark_name(kind, dims),
+                    "dtype": dtype,
+                    "threads": args.num_threads,
+                    "shape": shape_label(kind, dims),
+                    "backend": "pytorch-cpu",
+                    "median_ms": "",
+                    "iqr_ms": "",
+                    "status": status,
+                }
+            )
+
+
+def run(args: argparse.Namespace, writer: csv.DictWriter) -> None:
+    try:
+        import torch
+    except Exception as exc:
+        emit_error_rows(writer, args, f"error: {exc}")
+        return
+
+    torch.manual_seed(0)
+    torch.set_num_threads(args.num_threads)
+    torch.set_num_interop_threads(args.num_threads)
+
+    for dtype in parse_dtypes(args.dtypes):
+        for kind, dims in case_specs(args.profile):
+            try:
+                shape, fn = make_case(torch, dtype, kind, dims)
+                median_ms, iqr_ms = bench(fn, args.runs, args.warmups)
+                status = "ok"
+                median = f"{median_ms:.6f}"
+                iqr = f"{iqr_ms:.6f}"
+            except Exception as exc:
+                shape = ""
+                status = f"error: {exc}"
+                median = ""
+                iqr = ""
+
+            writer.writerow(
+                {
+                    "suite": "mul",
+                    "benchmark": benchmark_name(kind, dims),
+                    "dtype": dtype,
+                    "threads": args.num_threads,
+                    "shape": shape,
+                    "backend": "pytorch-cpu",
+                    "median_ms": median,
+                    "iqr_ms": iqr,
+                    "status": status,
+                }
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-threads", type=positive_int, default=int(os.environ.get("OMP_NUM_THREADS", "1")))
+    parser.add_argument("--profile", choices=["smoke", "quick", "full"], default=os.environ.get("STRIDED_KERNEL_MUL_BENCH_PROFILE", "full"))
+    parser.add_argument("--runs", type=positive_int, default=int(os.environ.get("STRIDED_KERNEL_MUL_BENCH_RUNS", DEFAULT_RUNS)))
+    parser.add_argument("--warmups", type=int, default=int(os.environ.get("STRIDED_KERNEL_MUL_BENCH_WARMUPS", DEFAULT_WARMUPS)))
+    parser.add_argument("--dtypes", default=os.environ.get("STRIDED_KERNEL_MUL_BENCH_DTYPES", "f64"))
+    parser.add_argument("--output", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.warmups < 0:
+        raise SystemExit("--warmups must be non-negative")
+    configure_thread_env(args.num_threads)
+
+    fieldnames = [
+        "suite",
+        "benchmark",
+        "dtype",
+        "threads",
+        "shape",
+        "backend",
+        "median_ms",
+        "iqr_ms",
+        "status",
+    ]
+    if args.output:
+        file_exists = os.path.exists(args.output) and os.path.getsize(args.output) > 0
+        with open(args.output, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, lineterminator="\n")
+            if not file_exists:
+                writer.writeheader()
+            run(args, writer)
+    else:
+        writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        run(args, writer)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/strided-kernel/benches/mul_pytorch_compare.rs
+++ b/strided-kernel/benches/mul_pytorch_compare.rs
@@ -1,0 +1,525 @@
+use std::env;
+use std::hint::black_box;
+use std::ops::Mul;
+use std::time::{Duration, Instant};
+
+use strided_kernel::MaybeSendSync;
+use strided_kernel::{
+    batched_outer_product_into, broadcast_mul_into, mul_into, StridedArray, StridedViewMut,
+};
+
+const DEFAULT_WARMUPS: usize = 3;
+const DEFAULT_RUNS: usize = 15;
+
+#[derive(Clone, Copy)]
+enum BenchCase {
+    Elementwise {
+        n: usize,
+    },
+    OuterProduct {
+        n: usize,
+    },
+    BatchedOuterCompact {
+        j: usize,
+        k: usize,
+        o: usize,
+        t: usize,
+    },
+    BatchedOuterNoncompact {
+        j: usize,
+        k: usize,
+        o: usize,
+        t: usize,
+    },
+    BatchedOuterNoncompactTorchlikeOutput {
+        j: usize,
+        k: usize,
+        o: usize,
+        t: usize,
+    },
+    BatchedOuterNoncompactLhsScalar {
+        j: usize,
+        k: usize,
+        o: usize,
+        t: usize,
+    },
+    BatchedOuterNoncompactSingleOuterGroup {
+        j: usize,
+        k: usize,
+        o: usize,
+        t: usize,
+    },
+    PermutedElementwise {
+        rank: usize,
+        extent: usize,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum BenchDType {
+    F64,
+    C64,
+    C128,
+}
+
+impl BenchDType {
+    fn label(self) -> &'static str {
+        match self {
+            Self::F64 => "f64",
+            Self::C64 => "c64",
+            Self::C128 => "c128",
+        }
+    }
+}
+
+impl BenchCase {
+    fn benchmark(self) -> String {
+        match self {
+            Self::Elementwise { n } => format!("bin_elementwise_mul_{n}x{n}"),
+            Self::OuterProduct { n } => format!("bin_outer_product_{n}"),
+            Self::BatchedOuterCompact { j, k, o, t } => {
+                format!("bin_batched_outer_product_compact_j{j}_k{k}_o{o}_t{t}")
+            }
+            Self::BatchedOuterNoncompact { j, k, o, t } => {
+                format!("bin_batched_outer_product_noncompact_j{j}_k{k}_o{o}_t{t}")
+            }
+            Self::BatchedOuterNoncompactTorchlikeOutput { j, k, o, t } => {
+                format!("bin_batched_outer_product_noncompact_torchlike_output_j{j}_k{k}_o{o}_t{t}")
+            }
+            Self::BatchedOuterNoncompactLhsScalar { j, k, o, t } => {
+                format!("bin_batched_outer_product_noncompact_lhs_scalar_j{j}_k{k}_o{o}_t{t}")
+            }
+            Self::BatchedOuterNoncompactSingleOuterGroup { j, k, o, t } => {
+                format!(
+                    "bin_batched_outer_product_noncompact_single_outer_group_j{j}_k{k}_o{o}_t{t}"
+                )
+            }
+            Self::PermutedElementwise { rank, extent } => {
+                format!("bin_permuted_elementwise_mul_rank{rank}_extent{extent}")
+            }
+        }
+    }
+
+    fn shape_label(self) -> String {
+        match self {
+            Self::Elementwise { n } => format!("{n}x{n}"),
+            Self::OuterProduct { n } => format!("{n}x{n}"),
+            Self::BatchedOuterCompact { j, k, o, t }
+            | Self::BatchedOuterNoncompact { j, k, o, t }
+            | Self::BatchedOuterNoncompactTorchlikeOutput { j, k, o, t }
+            | Self::BatchedOuterNoncompactLhsScalar { j, k, o, t }
+            | Self::BatchedOuterNoncompactSingleOuterGroup { j, k, o, t } => {
+                format!("j={j};k={k};o={o};t={t}")
+            }
+            Self::PermutedElementwise { rank, extent } => {
+                format!("rank={rank};extent={extent}")
+            }
+        }
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(default)
+}
+
+fn profile_cases() -> Vec<BenchCase> {
+    match env::var("STRIDED_KERNEL_MUL_BENCH_PROFILE")
+        .unwrap_or_else(|_| "full".to_string())
+        .as_str()
+    {
+        "smoke" => vec![
+            BenchCase::Elementwise { n: 64 },
+            BenchCase::OuterProduct { n: 64 },
+            BenchCase::BatchedOuterCompact {
+                j: 4,
+                k: 4,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 4,
+                k: 4,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompactTorchlikeOutput {
+                j: 4,
+                k: 4,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompactLhsScalar {
+                j: 4,
+                k: 4,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 2,
+                k: 8,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 8,
+                k: 2,
+                o: 8,
+                t: 8,
+            },
+            BenchCase::BatchedOuterNoncompactSingleOuterGroup {
+                j: 32,
+                k: 32,
+                o: 1,
+                t: 1,
+            },
+            BenchCase::PermutedElementwise { rank: 6, extent: 3 },
+        ],
+        "quick" => vec![
+            BenchCase::Elementwise { n: 1024 },
+            BenchCase::OuterProduct { n: 2048 },
+            BenchCase::BatchedOuterCompact {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactTorchlikeOutput {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactLhsScalar {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 8,
+                k: 32,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 32,
+                k: 8,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactSingleOuterGroup {
+                j: 256,
+                k: 256,
+                o: 1,
+                t: 1,
+            },
+            BenchCase::PermutedElementwise {
+                rank: 12,
+                extent: 3,
+            },
+        ],
+        _ => vec![
+            BenchCase::Elementwise { n: 2048 },
+            BenchCase::OuterProduct { n: 4096 },
+            BenchCase::BatchedOuterCompact {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactTorchlikeOutput {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactLhsScalar {
+                j: 16,
+                k: 16,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 8,
+                k: 32,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompact {
+                j: 32,
+                k: 8,
+                o: 64,
+                t: 64,
+            },
+            BenchCase::BatchedOuterNoncompactSingleOuterGroup {
+                j: 1024,
+                k: 1024,
+                o: 1,
+                t: 1,
+            },
+            BenchCase::PermutedElementwise {
+                rank: 16,
+                extent: 3,
+            },
+        ],
+    }
+}
+
+fn profile_dtypes() -> Vec<BenchDType> {
+    let dtypes: Vec<_> = env::var("STRIDED_KERNEL_MUL_BENCH_DTYPES")
+        .unwrap_or_else(|_| "f64".to_string())
+        .split(',')
+        .filter_map(|value| match value.trim() {
+            "f64" => Some(BenchDType::F64),
+            "c64" => Some(BenchDType::C64),
+            "c128" => Some(BenchDType::C128),
+            _ => None,
+        })
+        .collect();
+
+    if dtypes.is_empty() {
+        vec![BenchDType::F64]
+    } else {
+        dtypes
+    }
+}
+
+fn fill_value(indices: &[usize], salt: usize) -> f64 {
+    let mut acc = salt.wrapping_mul(1_099);
+    for (axis, &idx) in indices.iter().enumerate() {
+        acc = acc.wrapping_add((axis + 1).wrapping_mul(1_003).wrapping_mul(idx + 1));
+    }
+    ((acc % 1024) as f64 - 512.0) / 512.0
+}
+
+trait BenchScalar: Copy + Default + MaybeSendSync + Mul<Output = Self> + 'static {
+    fn from_indices(indices: &[usize], salt: usize) -> Self;
+}
+
+impl BenchScalar for f64 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        fill_value(indices, salt)
+    }
+}
+
+impl BenchScalar for num_complex::Complex32 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        Self::new(
+            fill_value(indices, salt) as f32,
+            fill_value(indices, salt + 17) as f32,
+        )
+    }
+}
+
+impl BenchScalar for num_complex::Complex64 {
+    fn from_indices(indices: &[usize], salt: usize) -> Self {
+        Self::new(fill_value(indices, salt), fill_value(indices, salt + 17))
+    }
+}
+
+fn make_col_major<T: BenchScalar>(dims: &[usize], salt: usize) -> StridedArray<T> {
+    StridedArray::<T>::from_fn_col_major(dims, |idx| T::from_indices(idx, salt))
+}
+
+fn duration_stats(mut durations: Vec<Duration>) -> (f64, f64) {
+    durations.sort_unstable();
+    let median = durations[durations.len() / 2];
+    let q1 = durations[durations.len() / 4];
+    let q3 = durations[3 * durations.len() / 4];
+    (
+        median.as_secs_f64() * 1e3,
+        q3.saturating_sub(q1).as_secs_f64() * 1e3,
+    )
+}
+
+fn measure(mut f: impl FnMut()) -> (f64, f64) {
+    let warmups = env_usize("STRIDED_KERNEL_MUL_BENCH_WARMUPS", DEFAULT_WARMUPS);
+    let runs = env_usize("STRIDED_KERNEL_MUL_BENCH_RUNS", DEFAULT_RUNS);
+    for _ in 0..warmups {
+        f();
+    }
+
+    let mut durations = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let start = Instant::now();
+        f();
+        durations.push(start.elapsed());
+    }
+    duration_stats(durations)
+}
+
+fn run_elementwise<T: BenchScalar>(n: usize) -> (f64, f64) {
+    let lhs = make_col_major::<T>(&[n, n], 1);
+    let rhs = make_col_major::<T>(&[n, n], 2);
+    let mut out = StridedArray::<T>::col_major(&[n, n]);
+    measure(|| {
+        mul_into(&mut out.view_mut(), &lhs.view(), &rhs.view()).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_outer_product<T: BenchScalar>(n: usize) -> (f64, f64) {
+    let lhs = make_col_major::<T>(&[n], 3);
+    let rhs = make_col_major::<T>(&[n], 4);
+    let mut out = StridedArray::<T>::col_major(&[n, n]);
+    measure(|| {
+        broadcast_mul_into(&mut out.view_mut(), &lhs.view(), &[0], &rhs.view(), &[1]).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_batched_outer_compact<T: BenchScalar>(j: usize, k: usize, o: usize, t: usize) -> (f64, f64) {
+    let lhs = make_col_major::<T>(&[j, k, t], 5);
+    let rhs = make_col_major::<T>(&[o, t], 6);
+    let mut out = StridedArray::<T>::col_major(&[j, k, o, t]);
+    measure(|| {
+        batched_outer_product_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), 2, 1).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_batched_outer_noncompact<T: BenchScalar>(
+    j: usize,
+    k: usize,
+    o: usize,
+    t: usize,
+) -> (f64, f64) {
+    let lhs_base = make_col_major::<T>(&[k, j, t], 7);
+    let lhs = lhs_base.view().permute(&[1, 0, 2]).unwrap();
+    let rhs = make_col_major::<T>(&[o, t], 8);
+    let mut out = StridedArray::<T>::col_major(&[j, k, o, t]);
+    measure(|| {
+        batched_outer_product_into(&mut out.view_mut(), &lhs, &rhs.view(), 2, 1).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_batched_outer_noncompact_torchlike_output<T: BenchScalar>(
+    j: usize,
+    k: usize,
+    o: usize,
+    t: usize,
+) -> (f64, f64) {
+    let lhs_base = make_col_major::<T>(&[k, j, t], 17);
+    let lhs = lhs_base.view().permute(&[1, 0, 2]).unwrap();
+    let rhs = make_col_major::<T>(&[o, t], 18);
+    let mut out = StridedArray::<T>::col_major(&[j, k, o, t]);
+    let out_strides = [j as isize, 1, (j * k) as isize, (j * k * o) as isize];
+    let mut out_view = StridedViewMut::new(out.data_mut(), &[j, k, o, t], &out_strides, 0).unwrap();
+    measure(|| {
+        batched_outer_product_into(&mut out_view, &lhs, &rhs.view(), 2, 1).unwrap();
+        black_box(out_view.as_mut_ptr());
+    })
+}
+
+fn run_batched_outer_noncompact_lhs_scalar<T: BenchScalar>(
+    j: usize,
+    k: usize,
+    o: usize,
+    t: usize,
+) -> (f64, f64) {
+    let lhs = make_col_major::<T>(&[o, t], 9);
+    let rhs_base = make_col_major::<T>(&[k, j, t], 10);
+    let rhs = rhs_base.view().permute(&[1, 0, 2]).unwrap();
+    let mut out = StridedArray::<T>::col_major(&[j, k, o, t]);
+    measure(|| {
+        // Keep this as broadcast_mul_into: the case intentionally fixes operand
+        // order so the scalar-on-lhs branch is benchmarked.
+        broadcast_mul_into(&mut out.view_mut(), &lhs.view(), &[2, 3], &rhs, &[0, 1, 3]).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn permuted_elementwise_axes(rank: usize) -> Vec<usize> {
+    if rank == 16 {
+        vec![7, 4, 10, 5, 12, 2, 9, 13, 1, 3, 6, 15, 14, 11, 8, 0]
+    } else {
+        (0..rank).rev().collect()
+    }
+}
+
+fn run_permuted_elementwise<T: BenchScalar>(rank: usize, extent: usize) -> (f64, f64) {
+    let dims = vec![extent; rank];
+    let rhs_base = make_col_major::<T>(&dims, 11);
+    let rhs_perm = permuted_elementwise_axes(rank);
+    let lhs = make_col_major::<T>(&dims, 12);
+    let rhs = rhs_base.view().permute(&rhs_perm).unwrap();
+    let mut out = StridedArray::<T>::col_major(&dims);
+    measure(|| {
+        mul_into(&mut out.view_mut(), &lhs.view(), &rhs).unwrap();
+        black_box(out.data().as_ptr());
+    })
+}
+
+fn run_case_typed<T: BenchScalar>(case: BenchCase) -> (f64, f64) {
+    match case {
+        BenchCase::Elementwise { n } => run_elementwise::<T>(n),
+        BenchCase::OuterProduct { n } => run_outer_product::<T>(n),
+        BenchCase::BatchedOuterCompact { j, k, o, t } => run_batched_outer_compact::<T>(j, k, o, t),
+        BenchCase::BatchedOuterNoncompact { j, k, o, t } => {
+            run_batched_outer_noncompact::<T>(j, k, o, t)
+        }
+        BenchCase::BatchedOuterNoncompactTorchlikeOutput { j, k, o, t } => {
+            run_batched_outer_noncompact_torchlike_output::<T>(j, k, o, t)
+        }
+        BenchCase::BatchedOuterNoncompactLhsScalar { j, k, o, t } => {
+            run_batched_outer_noncompact_lhs_scalar::<T>(j, k, o, t)
+        }
+        BenchCase::BatchedOuterNoncompactSingleOuterGroup { j, k, o, t } => {
+            run_batched_outer_noncompact::<T>(j, k, o, t)
+        }
+        BenchCase::PermutedElementwise { rank, extent } => {
+            run_permuted_elementwise::<T>(rank, extent)
+        }
+    }
+}
+
+fn run_case_for_dtype(dtype: BenchDType, case: BenchCase) -> (f64, f64) {
+    match dtype {
+        BenchDType::F64 => run_case_typed::<f64>(case),
+        BenchDType::C64 => run_case_typed::<num_complex::Complex32>(case),
+        BenchDType::C128 => run_case_typed::<num_complex::Complex64>(case),
+    }
+}
+
+fn threads_label() -> String {
+    env::var("RAYON_NUM_THREADS")
+        .or_else(|_| env::var("OMP_NUM_THREADS"))
+        .unwrap_or_else(|_| "unset".to_string())
+}
+
+fn main() {
+    println!("suite,benchmark,dtype,threads,shape,backend,median_ms,iqr_ms,status");
+    let threads = threads_label();
+    for dtype in profile_dtypes() {
+        for case in profile_cases() {
+            let (median_ms, iqr_ms) = run_case_for_dtype(dtype, case);
+            println!(
+                "mul,{},{},{},{},{},{:.6},{:.6},ok",
+                case.benchmark(),
+                dtype.label(),
+                threads,
+                case.shape_label(),
+                "strided-kernel",
+                median_ms,
+                iqr_ms
+            );
+        }
+    }
+}

--- a/strided-kernel/benches/outer_product.rs
+++ b/strided-kernel/benches/outer_product.rs
@@ -1,0 +1,218 @@
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+use strided_kernel::{
+    batched_outer_product_into_seq, zip_map2_into, Identity, StridedArray, StridedView,
+    StridedViewMut,
+};
+
+fn mean(durations: &[Duration]) -> Duration {
+    let total_nanos: u128 = durations.iter().map(|d| d.as_nanos()).sum();
+    Duration::from_nanos((total_nanos / durations.len() as u128) as u64)
+}
+
+fn bench_n(label: &str, warmup_iters: usize, iters: usize, mut f: impl FnMut()) -> Duration {
+    for _ in 0..warmup_iters {
+        f();
+    }
+
+    let mut samples = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        f();
+        samples.push(t0.elapsed());
+    }
+
+    let avg = mean(&samples);
+    println!("{label}: {:.3} ms", avg.as_secs_f64() * 1e3);
+    avg
+}
+
+fn make_random_col_major(dims: &[usize], seed: u64) -> StridedArray<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    StridedArray::<f64>::from_fn_col_major(dims, |_| rng.gen::<f64>())
+}
+
+fn main() {
+    let j = 16usize;
+    let k = 16usize;
+    let o = 64usize;
+    let t = 64usize;
+
+    println!("Rust runner: benches/outer_product.rs");
+    println!("Case: C[j,k,o,t] = A[k,j,t] * B[o,t], column-major logical output");
+    println!();
+
+    let lhs_compact = make_random_col_major(&[j, k, t], 1);
+    let lhs_noncompact_base = make_random_col_major(&[k, j, t], 2);
+    let lhs_noncompact = lhs_noncompact_base.view().permute(&[1, 0, 2]).unwrap();
+    let rhs = make_random_col_major(&[o, t], 3);
+    let mut out = StridedArray::<f64>::col_major(&[j, k, o, t]);
+    let mut out_torchlike = StridedArray::<f64>::col_major(&[j, k, o, t]);
+    let torchlike_out_strides = [j as isize, 1, (j * k) as isize, (j * k * o) as isize];
+
+    println!("lhs compact strides: {:?}", lhs_compact.view().strides());
+    println!("lhs noncompact strides: {:?}", lhs_noncompact.strides());
+    println!("rhs strides: {:?}", rhs.view().strides());
+    println!("out strides: {:?}", out.view().strides());
+    println!();
+
+    bench_n("batched_outer compact", 20, 100, || {
+        batched_outer_product_into_seq(&mut out.view_mut(), &lhs_compact.view(), &rhs.view(), 2, 1)
+            .unwrap();
+        black_box(out.data().as_ptr());
+    });
+
+    bench_n("batched_outer noncompact", 20, 100, || {
+        batched_outer_product_into_seq(&mut out.view_mut(), &lhs_noncompact, &rhs.view(), 2, 1)
+            .unwrap();
+        black_box(out.data().as_ptr());
+    });
+
+    bench_n("batched_outer noncompact torchlike output", 20, 100, || {
+        let mut out_view = StridedViewMut::new(
+            out_torchlike.data_mut(),
+            &[j, k, o, t],
+            &torchlike_out_strides,
+            0,
+        )
+        .unwrap();
+        batched_outer_product_into_seq(&mut out_view, &lhs_noncompact, &rhs.view(), 2, 1).unwrap();
+        black_box(out_torchlike.data().as_ptr());
+    });
+
+    let lhs_ptr = lhs_noncompact.ptr();
+    let rhs_view = rhs.view();
+    let rhs_ptr = rhs_view.ptr();
+    let out_ptr = out.data_mut().as_mut_ptr();
+    let out_torchlike_ptr = out_torchlike.data_mut().as_mut_ptr();
+    let lhs_row_offsets: Vec<isize> = (0..j * k)
+        .map(|row| ((row % j) * j + (row / j)) as isize)
+        .collect();
+    let mut lhs_values = Vec::with_capacity(j * k);
+    bench_n("manual packed lhs noncompact", 20, 100, || {
+        for batch in 0..t {
+            lhs_values.clear();
+            let lhs_batch = (batch * j * k) as isize;
+            for &row_offset in &lhs_row_offsets {
+                unsafe {
+                    lhs_values.push(*lhs_ptr.offset(lhs_batch + row_offset));
+                }
+            }
+            for col in 0..o {
+                let rhs_value = unsafe { *rhs_ptr.offset((batch * o + col) as isize) };
+                let dst_base = batch * j * k * o + col * j * k;
+                for row in 0..j * k {
+                    unsafe {
+                        *out_ptr.add(dst_base + row) = lhs_values[row] * rhs_value;
+                    }
+                }
+            }
+        }
+        black_box(out_ptr);
+    });
+
+    bench_n("manual torchlike output", 20, 100, || {
+        for batch in 0..t {
+            let lhs_batch = batch * j * k;
+            let rhs_batch = batch * o;
+            let dst_batch = batch * j * k * o;
+            for col in 0..o {
+                let rhs_value = unsafe { *rhs_ptr.add(rhs_batch + col) };
+                let dst_col = dst_batch + col * j * k;
+                for row_j in 0..j {
+                    let lhs_row = lhs_batch + row_j * j;
+                    let dst_row = dst_col + row_j * j;
+                    for row_k in 0..k {
+                        unsafe {
+                            *out_torchlike_ptr.add(dst_row + row_k) =
+                                *lhs_ptr.add(lhs_row + row_k) * rhs_value;
+                        }
+                    }
+                }
+            }
+        }
+        black_box(out_torchlike_ptr);
+    });
+
+    bench_n("manual torchlike output flat row", 20, 100, || {
+        let rows = j * k;
+        for batch in 0..t {
+            let lhs_batch = batch * rows;
+            let rhs_batch = batch * o;
+            let dst_batch = batch * rows * o;
+            for col in 0..o {
+                let rhs_value = unsafe { *rhs_ptr.add(rhs_batch + col) };
+                let dst_col = dst_batch + col * rows;
+                for row in 0..rows {
+                    unsafe {
+                        *out_torchlike_ptr.add(dst_col + row) =
+                            *lhs_ptr.add(lhs_batch + row) * rhs_value;
+                    }
+                }
+            }
+        }
+        black_box(out_torchlike_ptr);
+    });
+
+    bench_n("manual torchlike output slices", 20, 100, || {
+        let rows = j * k;
+        let lhs_data = lhs_noncompact_base.data();
+        let rhs_data = rhs.data();
+        let dst_data = out_torchlike.data_mut();
+        for batch in 0..t {
+            let lhs_slice = &lhs_data[batch * rows..(batch + 1) * rows];
+            let rhs_batch = batch * o;
+            let dst_batch = batch * rows * o;
+            for col in 0..o {
+                let rhs_value = rhs_data[rhs_batch + col];
+                let dst_col = dst_batch + col * rows;
+                let dst_slice = &mut dst_data[dst_col..dst_col + rows];
+                for (d, &x) in dst_slice.iter_mut().zip(lhs_slice.iter()) {
+                    *d = x * rhs_value;
+                }
+            }
+        }
+        black_box(out_torchlike.data().as_ptr());
+    });
+
+    let lhs_broadcast_seed: StridedView<'_, f64, Identity> = StridedView::new(
+        lhs_noncompact_base.data(),
+        &[j, k, 1, t],
+        &[j as isize, 1, 0, (j * k) as isize],
+        0,
+    )
+    .unwrap();
+    let lhs_broadcast = lhs_broadcast_seed.broadcast(&[j, k, o, t]).unwrap();
+    let rhs_broadcast_seed: StridedView<'_, f64, Identity> =
+        StridedView::new(rhs.data(), &[1, 1, o, t], &[0, 0, 1, o as isize], 0).unwrap();
+    let rhs_broadcast = rhs_broadcast_seed.broadcast(&[j, k, o, t]).unwrap();
+
+    bench_n("zip_map2 broadcast noncompact", 20, 100, || {
+        zip_map2_into(
+            &mut out.view_mut(),
+            &lhs_broadcast,
+            &rhs_broadcast,
+            |x, y| x * y,
+        )
+        .unwrap();
+        black_box(out.data().as_ptr());
+    });
+
+    bench_n(
+        "zip_map2 broadcast noncompact torchlike output",
+        20,
+        100,
+        || {
+            let mut out_view = StridedViewMut::new(
+                out_torchlike.data_mut(),
+                &[j, k, o, t],
+                &torchlike_out_strides,
+                0,
+            )
+            .unwrap();
+            zip_map2_into(&mut out_view, &lhs_broadcast, &rhs_broadcast, |x, y| x * y).unwrap();
+            black_box(out_torchlike.data().as_ptr());
+        },
+    );
+}

--- a/strided-kernel/benches/outer_product.rs
+++ b/strided-kernel/benches/outer_product.rs
@@ -2,8 +2,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 use strided_kernel::{
-    batched_outer_product_into_seq, zip_map2_into, Identity, StridedArray, StridedView,
-    StridedViewMut,
+    batched_outer_product_into, zip_map2_into, Identity, StridedArray, StridedView, StridedViewMut,
 };
 
 fn mean(durations: &[Duration]) -> Duration {
@@ -58,13 +57,13 @@ fn main() {
     println!();
 
     bench_n("batched_outer compact", 20, 100, || {
-        batched_outer_product_into_seq(&mut out.view_mut(), &lhs_compact.view(), &rhs.view(), 2, 1)
+        batched_outer_product_into(&mut out.view_mut(), &lhs_compact.view(), &rhs.view(), 2, 1)
             .unwrap();
         black_box(out.data().as_ptr());
     });
 
     bench_n("batched_outer noncompact", 20, 100, || {
-        batched_outer_product_into_seq(&mut out.view_mut(), &lhs_noncompact, &rhs.view(), 2, 1)
+        batched_outer_product_into(&mut out.view_mut(), &lhs_noncompact, &rhs.view(), 2, 1)
             .unwrap();
         black_box(out.data().as_ptr());
     });
@@ -77,7 +76,7 @@ fn main() {
             0,
         )
         .unwrap();
-        batched_outer_product_into_seq(&mut out_view, &lhs_noncompact, &rhs.view(), 2, 1).unwrap();
+        batched_outer_product_into(&mut out_view, &lhs_noncompact, &rhs.view(), 2, 1).unwrap();
         black_box(out_torchlike.data().as_ptr());
     });
 
@@ -174,6 +173,54 @@ fn main() {
             }
         }
         black_box(out_torchlike.data().as_ptr());
+    });
+
+    bench_n("manual colmajor output j-inner", 20, 100, || {
+        let rows = j * k;
+        for batch in 0..t {
+            let lhs_batch = batch * rows;
+            let rhs_batch = batch * o;
+            let dst_batch = batch * rows * o;
+            for col in 0..o {
+                let rhs_value = unsafe { *rhs_ptr.add(rhs_batch + col) };
+                let dst_col = dst_batch + col * rows;
+                for row_k in 0..k {
+                    let lhs_k = lhs_batch + row_k;
+                    let dst_k = dst_col + row_k * j;
+                    for row_j in 0..j {
+                        unsafe {
+                            *out_ptr.add(dst_k + row_j) =
+                                *lhs_ptr.add(lhs_k + row_j * k) * rhs_value;
+                        }
+                    }
+                }
+            }
+        }
+        black_box(out_ptr);
+    });
+
+    bench_n("manual colmajor output k-inner", 20, 100, || {
+        let rows = j * k;
+        for batch in 0..t {
+            let lhs_batch = batch * rows;
+            let rhs_batch = batch * o;
+            let dst_batch = batch * rows * o;
+            for col in 0..o {
+                let rhs_value = unsafe { *rhs_ptr.add(rhs_batch + col) };
+                let dst_col = dst_batch + col * rows;
+                for row_j in 0..j {
+                    let lhs_j = lhs_batch + row_j * k;
+                    let dst_j = dst_col + row_j;
+                    for row_k in 0..k {
+                        unsafe {
+                            *out_ptr.add(dst_j + row_k * j) =
+                                *lhs_ptr.add(lhs_j + row_k) * rhs_value;
+                        }
+                    }
+                }
+            }
+        }
+        black_box(out_ptr);
     });
 
     let lhs_broadcast_seed: StridedView<'_, f64, Identity> = StridedView::new(

--- a/strided-kernel/benches/run_mul_pytorch_compare.sh
+++ b/strided-kernel/benches/run_mul_pytorch_compare.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THREAD_COUNTS=("$@")
+if (( ${#THREAD_COUNTS[@]} == 0 )); then
+    THREAD_COUNTS=(1 4)
+fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CRATE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$CRATE_DIR/.." && pwd)"
+PROFILE="${STRIDED_KERNEL_MUL_BENCH_PROFILE:-full}"
+RUNS="${STRIDED_KERNEL_MUL_BENCH_RUNS:-15}"
+WARMUPS="${STRIDED_KERNEL_MUL_BENCH_WARMUPS:-3}"
+DTYPES="${STRIDED_KERNEL_MUL_BENCH_DTYPES:-f64}"
+THREAD_LABEL="$(IFS=_; echo "${THREAD_COUNTS[*]}")"
+DTYPE_LABEL="${DTYPES//,/_}"
+OUT="${STRIDED_KERNEL_MUL_BENCH_OUTPUT:-$CRATE_DIR/target/mul_pytorch_compare_t${THREAD_LABEL}_${PROFILE}_${DTYPE_LABEL}.csv}"
+
+export STRIDED_KERNEL_MUL_BENCH_PROFILE="$PROFILE"
+export STRIDED_KERNEL_MUL_BENCH_RUNS="$RUNS"
+export STRIDED_KERNEL_MUL_BENCH_WARMUPS="$WARMUPS"
+export STRIDED_KERNEL_MUL_BENCH_DTYPES="$DTYPES"
+
+mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
+
+configure_cpu_thread_env() {
+    local threads="${1:?threads required}"
+    local xla_multi_thread="false"
+    if [[ "$threads" =~ ^[0-9]+$ ]] && (( threads > 1 )); then
+        xla_multi_thread="true"
+    fi
+
+    export OMP_NUM_THREADS="$threads"
+    export OMP_THREAD_LIMIT="$threads"
+    export OMP_DYNAMIC=FALSE
+    export RAYON_NUM_THREADS="$threads"
+    export OPENBLAS_NUM_THREADS="$threads"
+    export GOTO_NUM_THREADS="$threads"
+    export MKL_NUM_THREADS="$threads"
+    export VECLIB_MAXIMUM_THREADS="$threads"
+    export VECLIB_NUM_THREADS="$threads"
+    export NUMEXPR_NUM_THREADS="$threads"
+    export BLIS_NUM_THREADS="$threads"
+    export XLA_FLAGS="--xla_cpu_multi_thread_eigen=${xla_multi_thread} intra_op_parallelism_threads=${threads}"
+}
+
+run_rust() {
+    local threads="${1:?threads required}"
+    local rust_bench_log
+    rust_bench_log="$(mktemp)"
+    cargo bench \
+        --manifest-path "$WORKSPACE_DIR/Cargo.toml" \
+        -p strided-kernel \
+        --bench mul_pytorch_compare \
+        --features parallel \
+        >"$rust_bench_log"
+
+    if [[ -s "$OUT" ]]; then
+        awk '/^mul,/' "$rust_bench_log" >>"$OUT"
+    else
+        awk '/^suite,/ || /^mul,/' "$rust_bench_log" >"$OUT"
+    fi
+    rm -f "$rust_bench_log"
+}
+
+run_pytorch() {
+    local threads="${1:?threads required}"
+    if command -v uv >/dev/null 2>&1; then
+        uv run --with torch --with numpy python "$SCRIPT_DIR/mul_pytorch_compare.py" \
+            --num-threads "$threads" \
+            --profile "$PROFILE" \
+            --runs "$RUNS" \
+            --warmups "$WARMUPS" \
+            --dtypes "$DTYPES" \
+            --output "$OUT"
+    else
+        python3 "$SCRIPT_DIR/mul_pytorch_compare.py" \
+            --num-threads "$threads" \
+            --profile "$PROFILE" \
+            --runs "$RUNS" \
+            --warmups "$WARMUPS" \
+            --dtypes "$DTYPES" \
+            --output "$OUT"
+    fi
+}
+
+for num_threads in "${THREAD_COUNTS[@]}"; do
+    configure_cpu_thread_env "$num_threads"
+    run_rust "$num_threads"
+    run_pytorch "$num_threads"
+done
+
+echo "mul comparison results saved to: $OUT"

--- a/strided-kernel/src/fuse.rs
+++ b/strided-kernel/src/fuse.rs
@@ -48,8 +48,14 @@ pub fn fuse_dims(dims: &[usize], all_strides: &[&[isize]]) -> Vec<usize> {
     for i in (1..n).rev() {
         let mut can_merge = true;
 
-        // Check all arrays for contiguity
+        // Check all arrays for contiguity. An operand broadcast across both
+        // axes has stride 0 for both axes and does not prevent fusing the
+        // iteration space.
         for strides in all_strides {
+            if strides[i - 1] == 0 && strides[i] == 0 {
+                continue;
+            }
+
             // s[i] should equal dims[i-1] * s[i-1] for fusion
             let expected = result[i - 1] as isize * strides[i - 1];
             if strides[i] != expected {
@@ -100,17 +106,9 @@ pub fn compress_dims(dims: &[usize], all_strides: &[Vec<isize>]) -> (Vec<usize>,
 /// Compute the "importance" of each dimension for loop ordering.
 ///
 /// This encodes stride order information into importance scores that determine
-/// the optimal iteration order. The output array's strides are weighted 2x.
-///
-/// # Julia equivalent
-/// ```julia
-/// g = 8 * sizeof(Int) - leading_zeros(M + 1)  # ceil(log2(M+2))
-/// importance = 2 .* (1 .<< (g .* (N .- indexorder(strides[1]))))
-/// for k in 2:M
-///     importance = importance .+ (1 .<< (g .* (N .- indexorder(strides[k]))))
-/// end
-/// importance = importance .* (dims .> 1)
-/// ```
+/// the optimal iteration order. Zero-stride broadcast axes do not contribute to
+/// importance, and the output array gets strong weight so contiguous stores
+/// remain in the inner loop.
 ///
 /// # Arguments
 /// * `dims` - The dimensions
@@ -136,18 +134,27 @@ pub fn compute_importance(
 
     let mut importance = vec![0u64; n];
 
-    // First array (output) is weighted 2x
+    let output_weight = 1u64 << (g + 1);
+
+    // First array (output) gets a strong weight. For elementwise kernels the
+    // store stream determines whether the inner loop can be emitted as a
+    // contiguous vector loop, so a broadcasted input's local stride should not
+    // break a contiguous output group.
     for i in 0..n {
-        let shift = g * (n - index_orders[0][i]) as u64;
-        importance[i] = 2 * (1u64 << shift);
+        if all_strides[0][i] != 0 {
+            let shift = g * (n - index_orders[0][i]) as u64;
+            importance[i] = output_weight * (1u64 << shift);
+        }
     }
 
     // Add contributions from remaining arrays
     #[allow(clippy::needless_range_loop)]
     for k in 1..m {
         for i in 0..n {
-            let shift = g * (n - index_orders[k][i]) as u64;
-            importance[i] += 1u64 << shift;
+            if all_strides[k][i] != 0 {
+                let shift = g * (n - index_orders[k][i]) as u64;
+                importance[i] += 1u64 << shift;
+            }
         }
     }
 
@@ -215,6 +222,19 @@ mod tests {
 
         let fused = fuse_dims(&dims, &all_strides);
         assert_eq!(fused, vec![12, 1]);
+    }
+
+    #[test]
+    fn test_fuse_dims_allows_broadcast_operand_across_fused_axes() {
+        let dims = [16usize, 16, 64, 64];
+        let out = [1isize, 16, 256, 16_384];
+        let lhs = [1isize, 16, 0, 256];
+        let rhs = [0isize, 0, 1, 64];
+        let all_strides: Vec<&[isize]> = vec![&out, &lhs, &rhs];
+
+        let fused = fuse_dims(&dims, &all_strides);
+
+        assert_eq!(fused, vec![256, 1, 64, 64]);
     }
 
     #[test]
@@ -290,7 +310,8 @@ mod tests {
 
     #[test]
     fn test_compute_importance_with_zero_stride() {
-        // Zero stride (broadcast) gets index_order = 1
+        // Zero stride (broadcast) still gets index_order = 1 for compatibility,
+        // but it does not contribute to ordering importance.
         let dims = [4usize, 5];
         let strides1 = [0isize, 1]; // First dim is broadcast
         let all_strides: Vec<&[isize]> = vec![&strides1];
@@ -303,9 +324,8 @@ mod tests {
         let index_orders = vec![order1];
         let importance = compute_importance(&dims, &all_strides, &index_orders);
 
-        // Both dimensions have same index_order, so same importance
-        // (before size-1 filtering)
-        assert_eq!(importance[0], importance[1]);
+        assert_eq!(importance[0], 0);
+        assert!(importance[1] > 0);
     }
 
     #[test]
@@ -327,8 +347,8 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_importance_output_2x_weight() {
-        // Output (first array) is weighted 2x
+    fn test_compute_importance_output_weight() {
+        // Output (first array) is strongly weighted
         // With same strides, dimension with smaller stride in output wins
         let dims = [4usize, 5];
         let out_strides = [1isize, 4]; // Column-major output
@@ -341,7 +361,7 @@ mod tests {
 
         let importance = compute_importance(&dims, &all_strides, &index_orders);
 
-        // Output has 2x weight, so dimension 0 (smaller stride in output) wins
+        // Output weighting makes dimension 0 (smaller stride in output) win.
         assert!(importance[0] > importance[1]);
     }
 

--- a/strided-kernel/src/kernel.rs
+++ b/strided-kernel/src/kernel.rs
@@ -608,15 +608,15 @@ pub(crate) fn total_len(dims: &[usize]) -> usize {
 /// Whether the sequential contiguous fast path should be used.
 ///
 /// When the `parallel` feature is enabled and the total element count exceeds
-/// the threading threshold, we must *not* take the contiguous fast path so that
-/// the parallel kernel path can be reached.  Julia has no separate contiguous
-/// fast path -- everything flows through fuse -> order -> block -> threaded ->
-/// kernel, so skipping it here matches Julia's branching.
+/// the threading threshold, we normally must *not* take the contiguous fast path
+/// so that the parallel kernel path can be reached. If the active Rayon pool has
+/// only one worker, however, there is no threaded path to reach and the
+/// sequential slice loop is the right kernel.
 #[inline]
 pub(crate) fn use_sequential_fast_path(total: usize) -> bool {
     #[cfg(feature = "parallel")]
     {
-        total <= crate::threading::MINTHREADLENGTH
+        total <= crate::threading::MINTHREADLENGTH || rayon::current_num_threads() <= 1
     }
     #[cfg(not(feature = "parallel"))]
     {
@@ -827,6 +827,22 @@ mod tests {
         assert_eq!(fused_strides.len(), 1);
         assert_eq!(fused_strides[0], vec![1]);
         assert_eq!(plan.block.len(), 1);
+    }
+
+    #[test]
+    fn test_build_plan_fused_keeps_broadcast_compact_inner_loop() {
+        let dims = [16usize, 16, 64, 64];
+        let out = [1isize, 16, 256, 16_384];
+        let lhs = [1isize, 16, 0, 256];
+        let rhs = [0isize, 0, 1, 64];
+        let strides_list: Vec<&[isize]> = vec![&out, &lhs, &rhs];
+
+        let (fused_dims, fused_strides, _) = build_plan_fused(&dims, &strides_list, Some(0), 8);
+
+        assert_eq!(fused_dims[0], 256);
+        assert_eq!(fused_strides[0][0], 1);
+        assert_eq!(fused_strides[1][0], 1);
+        assert_eq!(fused_strides[2][0], 0);
     }
 
     #[test]

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -84,14 +84,14 @@ pub use strided_view::{
 // ============================================================================
 // Map operations
 // ============================================================================
-pub use map_view::{map_into, zip_map2_into, zip_map3_into, zip_map4_into};
+pub use map_view::{
+    broadcast_mul_into, map_into, mul_into, zip_map2_into, zip_map3_into, zip_map4_into,
+};
 
 // ============================================================================
 // Outer-product operations
 // ============================================================================
-pub use outer_product::{batched_outer_product_into, batched_outer_product_into_seq};
-#[cfg(feature = "parallel")]
-pub use outer_product::{batched_outer_product_into_auto, batched_outer_product_into_par};
+pub use outer_product::batched_outer_product_into;
 
 // ============================================================================
 // High-level operations

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -68,6 +68,7 @@ pub use maybe_sync::{MaybeSend, MaybeSendSync, MaybeSync};
 // View-based operation modules
 mod map_view;
 mod ops_view;
+mod outer_product;
 mod reduce_view;
 
 // ============================================================================
@@ -84,6 +85,13 @@ pub use strided_view::{
 // Map operations
 // ============================================================================
 pub use map_view::{map_into, zip_map2_into, zip_map3_into, zip_map4_into};
+
+// ============================================================================
+// Outer-product operations
+// ============================================================================
+pub use outer_product::{batched_outer_product_into, batched_outer_product_into_seq};
+#[cfg(feature = "parallel")]
+pub use outer_product::{batched_outer_product_into_auto, batched_outer_product_into_par};
 
 // ============================================================================
 // High-level operations

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -1547,6 +1547,197 @@ pub fn zip_map4_into<
     )
 }
 
+#[cfg(test)]
+mod scalar_branch_tests {
+    use super::*;
+    use crate::StridedArray;
+    use strided_view::Identity;
+
+    #[test]
+    fn test_inner_loop_map2_stride_specializations() {
+        let a = [2.0, 3.0, 5.0, 7.0, 11.0, 13.0];
+        let b = [17.0, 19.0, 23.0, 29.0, 31.0, 37.0];
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                1,
+                b.as_ptr(),
+                1,
+                3,
+                &|x, y| x + y,
+            );
+        }
+        assert_eq!(out, [19.0, 22.0, 28.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                1,
+                b.as_ptr(),
+                0,
+                3,
+                &|x, y| x * y,
+            );
+        }
+        assert_eq!(out, [34.0, 51.0, 85.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                0,
+                b.as_ptr(),
+                1,
+                3,
+                &|x, y| x * y,
+            );
+        }
+        assert_eq!(out, [34.0, 38.0, 46.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                0,
+                b.as_ptr(),
+                0,
+                3,
+                &|x, y| x + y,
+            );
+        }
+        assert_eq!(out, [19.0, 19.0, 19.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                2,
+                b.as_ptr(),
+                0,
+                3,
+                &|x, y| x + y,
+            );
+        }
+        assert_eq!(out, [19.0, 22.0, 28.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_map2::<f64, f64, f64, Identity, Identity>(
+                out.as_mut_ptr(),
+                1,
+                a.as_ptr(),
+                0,
+                b.as_ptr(),
+                2,
+                3,
+                &|x, y| x + y,
+            );
+        }
+        assert_eq!(out, [19.0, 25.0, 33.0]);
+    }
+
+    #[test]
+    fn test_inner_loop_mul2_stride_specializations() {
+        let a = [2.0, 3.0, 5.0, 7.0, 11.0, 13.0];
+        let b = [17.0, 19.0, 23.0, 29.0, 31.0, 37.0];
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_mul2::<f64, f64, f64>(out.as_mut_ptr(), 1, a.as_ptr(), 1, b.as_ptr(), 1, 3);
+        }
+        assert_eq!(out, [34.0, 57.0, 115.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_mul2::<f64, f64, f64>(out.as_mut_ptr(), 1, a.as_ptr(), 0, b.as_ptr(), 1, 3);
+        }
+        assert_eq!(out, [34.0, 38.0, 46.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_mul2::<f64, f64, f64>(out.as_mut_ptr(), 1, a.as_ptr(), 0, b.as_ptr(), 0, 3);
+        }
+        assert_eq!(out, [34.0, 34.0, 34.0]);
+
+        let mut out = [0.0; 3];
+        unsafe {
+            inner_loop_mul2::<f64, f64, f64>(out.as_mut_ptr(), 1, a.as_ptr(), 0, b.as_ptr(), 2, 3);
+        }
+        assert_eq!(out, [34.0, 46.0, 62.0]);
+    }
+
+    #[test]
+    fn test_broadcast_mul_into_error_branches_and_non_identity_ops() {
+        let lhs = StridedArray::<f64>::row_major(&[2, 3]);
+        let rhs = StridedArray::<f64>::row_major(&[2, 3]);
+        let mut out = StridedArray::<f64>::row_major(&[2, 3]);
+
+        let err = broadcast_mul_into(&mut out.view_mut(), &lhs.view(), &[0], &rhs.view(), &[0, 1])
+            .unwrap_err();
+        assert!(matches!(err, StridedError::RankMismatch(2, 1)));
+
+        let err = broadcast_mul_into(
+            &mut out.view_mut(),
+            &lhs.view(),
+            &[0, 3],
+            &rhs.view(),
+            &[0, 1],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            StridedError::InvalidAxis { axis: 3, rank: 2 }
+        ));
+
+        let err = broadcast_mul_into(
+            &mut out.view_mut(),
+            &lhs.view(),
+            &[0, 0],
+            &rhs.view(),
+            &[0, 1],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            StridedError::InvalidAxis { axis: 0, rank: 2 }
+        ));
+
+        let rhs_bad = StridedArray::<f64>::row_major(&[2, 4]);
+        let err = broadcast_mul_into(
+            &mut out.view_mut(),
+            &lhs.view(),
+            &[0, 1],
+            &rhs_bad.view(),
+            &[0, 1],
+        )
+        .unwrap_err();
+        assert!(matches!(err, StridedError::ShapeMismatch(_, _)));
+
+        let lhs_conj = lhs.view().conj();
+        broadcast_mul_into(
+            &mut out.view_mut(),
+            &lhs_conj,
+            &[0, 1],
+            &rhs.view(),
+            &[0, 1],
+        )
+        .unwrap();
+    }
+}
+
 #[cfg(all(test, feature = "parallel"))]
 mod tests {
     use super::*;

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -9,13 +9,21 @@ use crate::kernel::{
 use crate::maybe_sync::{MaybeSendSync, MaybeSync};
 use crate::simd;
 use crate::view::{StridedView, StridedViewMut};
-use crate::Result;
+use crate::{Result, StridedError};
+use std::ops::Mul;
 use strided_view::ElementOp;
 
 #[cfg(feature = "parallel")]
 use crate::fuse::compute_costs;
 #[cfg(feature = "parallel")]
 use crate::threading::{for_each_inner_block_with_offsets, mapreduce_threaded, MINTHREADLENGTH};
+#[cfg(feature = "parallel")]
+use smallvec::SmallVec;
+
+#[cfg(feature = "parallel")]
+type AxisVec<T> = SmallVec<[T; 8]>;
+#[cfg(not(feature = "parallel"))]
+type AxisVec<T> = Vec<T>;
 
 // ============================================================================
 // Stride-specialized inner loop helpers
@@ -102,6 +110,26 @@ unsafe fn inner_loop_map2<D: Copy, A: Copy, B: Copy, OpA: ElementOp<A>, OpB: Ele
                 *d = f(a, b);
             }
         });
+    } else if ds == 1 && b_s == 0 {
+        let b = OpB::apply(*bp);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        let mut ap = ap;
+        simd::dispatch_if_large(len, || {
+            for d in dst.iter_mut() {
+                *d = f(OpA::apply(*ap), b);
+                ap = ap.offset(a_s);
+            }
+        });
+    } else if ds == 1 && a_s == 0 {
+        let a = OpA::apply(*ap);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        let mut bp = bp;
+        simd::dispatch_if_large(len, || {
+            for d in dst.iter_mut() {
+                *d = f(a, OpB::apply(*bp));
+                bp = bp.offset(b_s);
+            }
+        });
     } else {
         let mut dp = dp;
         let mut ap = ap;
@@ -113,6 +141,550 @@ unsafe fn inner_loop_map2<D: Copy, A: Copy, B: Copy, OpA: ElementOp<A>, OpB: Ele
             bp = bp.offset(b_s);
         }
     }
+}
+
+/// Binary multiplication inner loop for identity element ops.
+#[inline(always)]
+unsafe fn inner_loop_mul2<
+    D: Copy + 'static,
+    A: Copy + Mul<B, Output = D> + 'static,
+    B: Copy + 'static,
+>(
+    dp: *mut D,
+    ds: isize,
+    ap: *const A,
+    a_s: isize,
+    bp: *const B,
+    b_s: isize,
+    len: usize,
+) {
+    if ds == 1 && a_s == 1 && b_s == 1 {
+        let src_a = std::slice::from_raw_parts(ap, len);
+        let src_b = std::slice::from_raw_parts(bp, len);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        if len >= 64 && simd::try_mul_contiguous(dst, src_a, src_b) {
+            return;
+        }
+        for i in 0..len {
+            dst[i] = src_a[i] * src_b[i];
+        }
+    } else if ds == 1 && a_s == 1 && b_s == 0 {
+        let src_a = std::slice::from_raw_parts(ap, len);
+        let b = *bp;
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        for i in 0..len {
+            dst[i] = src_a[i] * b;
+        }
+    } else if ds == 1 && a_s == 0 && b_s == 1 {
+        let a = *ap;
+        let src_b = std::slice::from_raw_parts(bp, len);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        for i in 0..len {
+            dst[i] = a * src_b[i];
+        }
+    } else if ds == 1 && a_s == 0 && b_s == 0 {
+        let a = *ap;
+        let b = *bp;
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        for d in dst.iter_mut() {
+            *d = a * b;
+        }
+    } else if ds == 1 && b_s == 0 {
+        let b = *bp;
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        let mut ap = ap;
+        for d in dst.iter_mut() {
+            *d = *ap * b;
+            ap = ap.offset(a_s);
+        }
+    } else if ds == 1 && a_s == 0 {
+        let a = *ap;
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        let mut bp = bp;
+        for d in dst.iter_mut() {
+            *d = a * *bp;
+            bp = bp.offset(b_s);
+        }
+    } else {
+        let mut dp = dp;
+        let mut ap = ap;
+        let mut bp = bp;
+        for _ in 0..len {
+            *dp = *ap * *bp;
+            dp = dp.offset(ds);
+            ap = ap.offset(a_s);
+            bp = bp.offset(b_s);
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ContiguousMulRangePlan {
+    axis_order: AxisVec<usize>,
+    inner_len: usize,
+    inner_axis_count: usize,
+    row_len: usize,
+    outer_axis_start: usize,
+    fast_axis: usize,
+    a_fast_stride: isize,
+    b_fast_stride: isize,
+    a_row_stride: isize,
+    b_row_stride: isize,
+}
+
+#[cfg(feature = "parallel")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TransposedScalarTileKind {
+    RhsScalar,
+    LhsScalar,
+}
+
+#[cfg(feature = "parallel")]
+fn transposed_scalar_tile_kind(plan: &ContiguousMulRangePlan) -> Option<TransposedScalarTileKind> {
+    let row_len = isize::try_from(plan.row_len).ok()?;
+    if plan.a_fast_stride == row_len
+        && plan.a_row_stride == 1
+        && plan.b_fast_stride == 0
+        && plan.b_row_stride == 0
+    {
+        return Some(TransposedScalarTileKind::RhsScalar);
+    }
+
+    if plan.b_fast_stride == row_len
+        && plan.b_row_stride == 1
+        && plan.a_fast_stride == 0
+        && plan.a_row_stride == 0
+    {
+        return Some(TransposedScalarTileKind::LhsScalar);
+    }
+
+    None
+}
+
+#[cfg(feature = "parallel")]
+fn compact_axis_order(dims: &[usize], strides: &[isize]) -> Option<AxisVec<usize>> {
+    if dims.len() != strides.len() {
+        return None;
+    }
+
+    let mut active = AxisVec::<usize>::new();
+    let mut inactive = AxisVec::<usize>::new();
+    for (axis, (&dim, &stride)) in dims.iter().zip(strides.iter()).enumerate() {
+        if stride < 0 {
+            return None;
+        }
+        if dim > 1 {
+            active.push(axis);
+        } else {
+            inactive.push(axis);
+        }
+    }
+
+    active.sort_by(|&lhs, &rhs| strides[lhs].cmp(&strides[rhs]).then_with(|| lhs.cmp(&rhs)));
+
+    let mut expected = 1isize;
+    for &axis in &active {
+        if strides[axis] != expected {
+            return None;
+        }
+        expected = expected.saturating_mul(dims[axis] as isize);
+    }
+
+    active.extend(inactive);
+    Some(active)
+}
+
+#[cfg(feature = "parallel")]
+fn can_fuse_contiguous_range_axis(dim: usize, prev_stride: isize, next_stride: isize) -> bool {
+    dim <= 1 || (prev_stride == 0 && next_stride == 0) || next_stride == prev_stride * dim as isize
+}
+
+#[cfg(feature = "parallel")]
+fn contiguous_mul_range_plan(
+    dims: &[usize],
+    dst_strides: &[isize],
+    a_strides: &[isize],
+    b_strides: &[isize],
+) -> Option<ContiguousMulRangePlan> {
+    let axis_order = compact_axis_order(dims, dst_strides)?;
+    if dims.is_empty() {
+        return Some(ContiguousMulRangePlan {
+            axis_order,
+            inner_len: 1,
+            inner_axis_count: 0,
+            row_len: 1,
+            outer_axis_start: 0,
+            fast_axis: 0,
+            a_fast_stride: 0,
+            b_fast_stride: 0,
+            a_row_stride: 0,
+            b_row_stride: 0,
+        });
+    }
+
+    let first_pos = axis_order
+        .iter()
+        .position(|&axis| dims[axis] > 1)
+        .unwrap_or(0);
+    let first_axis = axis_order[first_pos];
+    let mut inner_len = dims[first_axis].max(1);
+    let mut inner_axis_count = first_pos + 1;
+    let mut prev_axis = first_axis;
+
+    for &axis in axis_order.iter().skip(first_pos + 1) {
+        if can_fuse_contiguous_range_axis(
+            dims[prev_axis],
+            dst_strides[prev_axis],
+            dst_strides[axis],
+        ) && can_fuse_contiguous_range_axis(
+            dims[prev_axis],
+            a_strides[prev_axis],
+            a_strides[axis],
+        ) && can_fuse_contiguous_range_axis(
+            dims[prev_axis],
+            b_strides[prev_axis],
+            b_strides[axis],
+        ) {
+            inner_len = inner_len.checked_mul(dims[axis].max(1))?;
+            inner_axis_count += 1;
+            prev_axis = axis;
+        } else {
+            break;
+        }
+    }
+
+    let row = axis_order
+        .iter()
+        .enumerate()
+        .skip(inner_axis_count)
+        .find(|&(_, &axis)| dims[axis] > 1);
+    let (row_len, outer_axis_start, a_row_stride, b_row_stride) =
+        if let Some((row_pos, &row_axis)) = row {
+            (
+                dims[row_axis],
+                row_pos + 1,
+                a_strides[row_axis],
+                b_strides[row_axis],
+            )
+        } else {
+            (1, axis_order.len(), 0, 0)
+        };
+
+    Some(ContiguousMulRangePlan {
+        axis_order,
+        inner_len,
+        inner_axis_count,
+        row_len,
+        outer_axis_start,
+        fast_axis: first_axis,
+        a_fast_stride: a_strides[first_axis],
+        b_fast_stride: b_strides[first_axis],
+        a_row_stride,
+        b_row_stride,
+    })
+}
+
+#[cfg(feature = "parallel")]
+struct ContiguousMulOuterCursor<'a> {
+    dims: &'a [usize],
+    a_strides: &'a [isize],
+    b_strides: &'a [isize],
+    axes: SmallVec<[usize; 8]>,
+    coords: SmallVec<[usize; 8]>,
+    a_offset: isize,
+    b_offset: isize,
+}
+
+#[cfg(feature = "parallel")]
+impl<'a> ContiguousMulOuterCursor<'a> {
+    fn new(
+        dims: &'a [usize],
+        a_strides: &'a [isize],
+        b_strides: &'a [isize],
+        plan: &ContiguousMulRangePlan,
+        outer_group: usize,
+    ) -> Self {
+        let axes: SmallVec<[usize; 8]> = plan
+            .axis_order
+            .iter()
+            .skip(plan.outer_axis_start)
+            .copied()
+            .collect();
+        let mut coords = SmallVec::<[usize; 8]>::with_capacity(axes.len());
+        let mut rem = outer_group;
+        let mut a_offset = 0isize;
+        let mut b_offset = 0isize;
+
+        for &axis in &axes {
+            let dim = dims[axis].max(1);
+            let coord = rem % dim;
+            rem /= dim;
+            coords.push(coord);
+            a_offset += coord as isize * a_strides[axis];
+            b_offset += coord as isize * b_strides[axis];
+        }
+
+        Self {
+            dims,
+            a_strides,
+            b_strides,
+            axes,
+            coords,
+            a_offset,
+            b_offset,
+        }
+    }
+
+    fn advance(&mut self) {
+        for (i, &axis) in self.axes.iter().enumerate() {
+            let dim = self.dims[axis].max(1);
+            if dim <= 1 {
+                continue;
+            }
+
+            self.coords[i] += 1;
+            self.a_offset += self.a_strides[axis];
+            self.b_offset += self.b_strides[axis];
+
+            if self.coords[i] < dim {
+                break;
+            }
+
+            self.coords[i] = 0;
+            self.a_offset -= dim as isize * self.a_strides[axis];
+            self.b_offset -= dim as isize * self.b_strides[axis];
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[inline(always)]
+unsafe fn run_contiguous_mul_row_block<
+    D: Copy + 'static,
+    A: Copy + Mul<B, Output = D> + 'static,
+    B: Copy + 'static,
+>(
+    dst_ptr: *mut D,
+    a_ptr: *const A,
+    b_ptr: *const B,
+    plan: &ContiguousMulRangePlan,
+    base_index: usize,
+    total: usize,
+    base_a_offset: isize,
+    base_b_offset: isize,
+) {
+    let inner_len = plan.inner_len.max(1);
+    let row_len = plan.row_len.max(1);
+    let block_len = inner_len.saturating_mul(row_len);
+
+    if total.saturating_sub(base_index) >= block_len {
+        match transposed_scalar_tile_kind(plan) {
+            Some(TransposedScalarTileKind::RhsScalar) => {
+                if simd::try_mul_transposed_scalar_rhs_2d::<D, A, B>(
+                    dst_ptr.add(base_index),
+                    a_ptr.offset(base_a_offset),
+                    b_ptr.offset(base_b_offset),
+                    inner_len,
+                    row_len,
+                    plan.a_fast_stride,
+                    plan.a_row_stride,
+                ) {
+                    return;
+                }
+            }
+            Some(TransposedScalarTileKind::LhsScalar) => {
+                if simd::try_mul_transposed_scalar_lhs_2d::<D, A, B>(
+                    dst_ptr.add(base_index),
+                    a_ptr.offset(base_a_offset),
+                    b_ptr.offset(base_b_offset),
+                    inner_len,
+                    row_len,
+                    plan.b_fast_stride,
+                    plan.b_row_stride,
+                ) {
+                    return;
+                }
+            }
+            None => {}
+        }
+    }
+
+    let mut index = base_index;
+    let mut a_offset = base_a_offset;
+    let mut b_offset = base_b_offset;
+
+    for _ in 0..row_len {
+        if index >= total {
+            break;
+        }
+        let len = inner_len.min(total - index);
+        inner_loop_mul2::<D, A, B>(
+            dst_ptr.add(index),
+            1,
+            a_ptr.offset(a_offset),
+            plan.a_fast_stride,
+            b_ptr.offset(b_offset),
+            plan.b_fast_stride,
+            len,
+        );
+        index += inner_len;
+        a_offset += plan.a_row_stride;
+        b_offset += plan.b_row_stride;
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn strided_offset_for_contiguous_linear_index(
+    dims: &[usize],
+    strides: &[isize],
+    axis_order: &[usize],
+    mut index: usize,
+) -> isize {
+    let mut offset = 0isize;
+    for &axis in axis_order {
+        let dim = dims[axis];
+        if dim == 0 {
+            return 0;
+        }
+        let coord = index % dim;
+        index /= dim;
+        offset += coord as isize * strides[axis];
+    }
+    offset
+}
+
+#[cfg(feature = "parallel")]
+fn try_contiguous_range_mul<
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + MaybeSendSync + Mul<B, Output = D> + 'static,
+    B: Copy + MaybeSendSync + 'static,
+>(
+    dst_ptr: *mut D,
+    dims: &[usize],
+    dst_strides: &[isize],
+    a_ptr: *const A,
+    a_strides: &[isize],
+    b_ptr: *const B,
+    b_strides: &[isize],
+) -> bool {
+    let total = total_len(dims);
+    if total == 0 {
+        return true;
+    }
+    if total <= MINTHREADLENGTH {
+        return false;
+    }
+
+    let Some(plan) = contiguous_mul_range_plan(dims, dst_strides, a_strides, b_strides) else {
+        return false;
+    };
+
+    let inner_len = plan.inner_len.max(1);
+    let row_len = plan.row_len.max(1);
+    let block_len = inner_len.saturating_mul(row_len).max(1);
+    let outer_groups = total.div_ceil(block_len);
+    let nthreads = rayon::current_num_threads();
+
+    if nthreads <= 1 {
+        let mut cursor = ContiguousMulOuterCursor::new(dims, a_strides, b_strides, &plan, 0);
+        for group in 0..outer_groups {
+            let index = group * block_len;
+            unsafe {
+                run_contiguous_mul_row_block::<D, A, B>(
+                    dst_ptr,
+                    a_ptr,
+                    b_ptr,
+                    &plan,
+                    index,
+                    total,
+                    cursor.a_offset,
+                    cursor.b_offset,
+                );
+            }
+            cursor.advance();
+        }
+        return true;
+    }
+
+    use crate::threading::SendPtr;
+    use rayon::prelude::*;
+
+    let dst = SendPtr(dst_ptr);
+    let a = SendPtr(a_ptr as *mut A);
+    let b = SendPtr(b_ptr as *mut B);
+
+    if outer_groups < nthreads {
+        let chunk_len = total.div_ceil(nthreads);
+        let nchunks = total.div_ceil(chunk_len);
+
+        (0..nchunks).into_par_iter().for_each(|chunk| {
+            let start = chunk * chunk_len;
+            let end = (start + chunk_len).min(total);
+            let mut index = start;
+
+            while index < end {
+                let in_inner = index % inner_len;
+                let len = (inner_len - in_inner).min(end - index);
+                let a_offset = strided_offset_for_contiguous_linear_index(
+                    dims,
+                    a_strides,
+                    &plan.axis_order,
+                    index,
+                );
+                let b_offset = strided_offset_for_contiguous_linear_index(
+                    dims,
+                    b_strides,
+                    &plan.axis_order,
+                    index,
+                );
+
+                unsafe {
+                    inner_loop_mul2::<D, A, B>(
+                        dst.as_ptr().add(index),
+                        1,
+                        a.as_const().offset(a_offset),
+                        plan.a_fast_stride,
+                        b.as_const().offset(b_offset),
+                        plan.b_fast_stride,
+                        len,
+                    );
+                }
+                index += len;
+            }
+        });
+
+        return true;
+    }
+
+    let groups_per_chunk = outer_groups.div_ceil(nthreads);
+    let nchunks = outer_groups.div_ceil(groups_per_chunk);
+
+    (0..nchunks).into_par_iter().for_each(|chunk| {
+        let group_start = chunk * groups_per_chunk;
+        let group_end = (group_start + groups_per_chunk).min(outer_groups);
+        let mut cursor =
+            ContiguousMulOuterCursor::new(dims, a_strides, b_strides, &plan, group_start);
+
+        for group in group_start..group_end {
+            let index = group * block_len;
+            unsafe {
+                run_contiguous_mul_row_block::<D, A, B>(
+                    dst.as_ptr(),
+                    a.as_const(),
+                    b.as_const(),
+                    &plan,
+                    index,
+                    total,
+                    cursor.a_offset,
+                    cursor.b_offset,
+                );
+            }
+            cursor.advance();
+        }
+    });
+
+    true
 }
 
 /// Ternary inner loop: `dest[i] = f(a[i], b[i], c[i])`.
@@ -273,7 +845,7 @@ pub fn map_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut A);
@@ -383,7 +955,7 @@ pub fn zip_map2_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -443,6 +1015,248 @@ pub fn zip_map2_into<
             Ok(())
         },
     )
+}
+
+fn mul_identity_into_raw<
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + MaybeSendSync + Mul<B, Output = D> + 'static,
+    B: Copy + MaybeSendSync + 'static,
+>(
+    dest: &mut StridedViewMut<D>,
+    a_ptr: *const A,
+    a_strides: &[isize],
+    b_ptr: *const B,
+    b_strides: &[isize],
+) -> Result<()> {
+    let dst_ptr = dest.as_mut_ptr();
+    let dst_dims = dest.dims();
+    let dst_strides = dest.strides();
+    debug_assert_eq!(dst_dims.len(), a_strides.len());
+    debug_assert_eq!(dst_dims.len(), b_strides.len());
+
+    if sequential_contiguous_layout(dst_dims, &[dst_strides, a_strides, b_strides]).is_some() {
+        let len = total_len(dst_dims);
+        let dst = unsafe { std::slice::from_raw_parts_mut(dst_ptr, len) };
+        let sa = unsafe { std::slice::from_raw_parts(a_ptr, len) };
+        let sb = unsafe { std::slice::from_raw_parts(b_ptr, len) };
+        if simd::try_mul_contiguous(dst, sa, sb) {
+            return Ok(());
+        }
+        for i in 0..len {
+            dst[i] = sa[i] * sb[i];
+        }
+        return Ok(());
+    }
+
+    let strides_list: [&[isize]; 3] = [dst_strides, a_strides, b_strides];
+    let elem_size = std::mem::size_of::<D>()
+        .max(std::mem::size_of::<A>())
+        .max(std::mem::size_of::<B>());
+    let total = total_len(dst_dims);
+
+    #[cfg(feature = "parallel")]
+    {
+        if try_contiguous_range_mul(
+            dst_ptr,
+            dst_dims,
+            dst_strides,
+            a_ptr,
+            a_strides,
+            b_ptr,
+            b_strides,
+        ) {
+            return Ok(());
+        }
+    }
+
+    let (fused_dims, ordered_strides, plan) = if total <= SMALL_TENSOR_THRESHOLD {
+        build_plan_fused_small(dst_dims, &strides_list)
+    } else {
+        build_plan_fused(dst_dims, &strides_list, Some(0), elem_size)
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        let total: usize = fused_dims.iter().product();
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+            use crate::threading::SendPtr;
+            let dst_send = SendPtr(dst_ptr);
+            let a_send = SendPtr(a_ptr as *mut A);
+            let b_send = SendPtr(b_ptr as *mut B);
+
+            let costs = compute_costs(&ordered_strides);
+            let initial_offsets = vec![0isize; strides_list.len()];
+            let nthreads = rayon::current_num_threads();
+
+            return mapreduce_threaded(
+                &fused_dims,
+                &plan.block,
+                &ordered_strides,
+                &initial_offsets,
+                &costs,
+                nthreads,
+                0,
+                1,
+                &|dims, blocks, strides_list, offsets| {
+                    for_each_inner_block_with_offsets(
+                        dims,
+                        blocks,
+                        strides_list,
+                        offsets,
+                        |offsets, len, strides| {
+                            let dp = unsafe { dst_send.as_ptr().offset(offsets[0]) };
+                            let ap = unsafe { a_send.as_const().offset(offsets[1]) };
+                            let bp = unsafe { b_send.as_const().offset(offsets[2]) };
+                            unsafe {
+                                inner_loop_mul2::<D, A, B>(
+                                    dp, strides[0], ap, strides[1], bp, strides[2], len,
+                                )
+                            };
+                            Ok(())
+                        },
+                    )
+                },
+            );
+        }
+    }
+
+    let initial_offsets = vec![0isize; ordered_strides.len()];
+    for_each_inner_block_preordered(
+        &fused_dims,
+        &plan.block,
+        &ordered_strides,
+        &initial_offsets,
+        |offsets, len, strides| {
+            let dp = unsafe { dst_ptr.offset(offsets[0]) };
+            let ap = unsafe { a_ptr.offset(offsets[1]) };
+            let bp = unsafe { b_ptr.offset(offsets[2]) };
+            unsafe {
+                inner_loop_mul2::<D, A, B>(dp, strides[0], ap, strides[1], bp, strides[2], len)
+            };
+            Ok(())
+        },
+    )
+}
+
+fn mul_identity_into<
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + Mul<B, Output = D> + MaybeSendSync + 'static,
+    B: Copy + MaybeSendSync + 'static,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dest: &mut StridedViewMut<D>,
+    a: &StridedView<A, OpA>,
+    b: &StridedView<B, OpB>,
+) -> Result<()> {
+    ensure_same_shape(dest.dims(), a.dims())?;
+    ensure_same_shape(dest.dims(), b.dims())?;
+    mul_identity_into_raw(dest, a.ptr(), a.strides(), b.ptr(), b.strides())
+}
+
+/// Element-wise multiplication: `dest[i] = a[i] * b[i]`.
+///
+/// All views must have the same shape. Broadcast operands should be represented
+/// as stride-0 views before calling this function.
+pub fn mul_into<
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + Mul<B, Output = D> + MaybeSendSync + 'static,
+    B: Copy + MaybeSendSync + 'static,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dest: &mut StridedViewMut<D>,
+    a: &StridedView<A, OpA>,
+    b: &StridedView<B, OpB>,
+) -> Result<()> {
+    if OpA::IS_IDENTITY && OpB::IS_IDENTITY {
+        return mul_identity_into(dest, a, b);
+    }
+
+    zip_map2_into(dest, a, b, |x, y| x * y)
+}
+
+fn broadcast_strides_for_axes(
+    source_dims: &[usize],
+    source_strides: &[isize],
+    target_dims: &[usize],
+    axes: &[usize],
+) -> Result<AxisVec<isize>> {
+    if source_dims.len() != axes.len() {
+        return Err(StridedError::RankMismatch(source_dims.len(), axes.len()));
+    }
+    debug_assert_eq!(source_dims.len(), source_strides.len());
+
+    let mut seen = AxisVec::<bool>::new();
+    seen.resize(target_dims.len(), false);
+    let mut strides = AxisVec::<isize>::new();
+    strides.resize(target_dims.len(), 0);
+    for (src_axis, &dst_axis) in axes.iter().enumerate() {
+        if dst_axis >= target_dims.len() {
+            return Err(StridedError::InvalidAxis {
+                axis: dst_axis,
+                rank: target_dims.len(),
+            });
+        }
+        if seen[dst_axis] {
+            return Err(StridedError::InvalidAxis {
+                axis: dst_axis,
+                rank: target_dims.len(),
+            });
+        }
+        seen[dst_axis] = true;
+
+        let source_dim = source_dims[src_axis];
+        let target_dim = target_dims[dst_axis];
+        if source_dim != target_dim && source_dim != 1 {
+            return Err(StridedError::ShapeMismatch(
+                source_dims.to_vec(),
+                target_dims.to_vec(),
+            ));
+        }
+        if source_dim == target_dim {
+            strides[dst_axis] = source_strides[src_axis];
+        }
+    }
+
+    Ok(strides)
+}
+
+fn broadcast_view_with_strides<'a, T, Op: ElementOp<T>>(
+    view: &StridedView<'a, T, Op>,
+    target_dims: &[usize],
+    strides: &[isize],
+) -> StridedView<'a, T, Op> {
+    unsafe { StridedView::new_unchecked(view.data(), target_dims, strides, view.offset()) }
+}
+
+/// Broadcasted element-wise multiplication: `dest[i] = a[i] * b[i]`.
+///
+/// `a_axes` and `b_axes` map each source axis to an axis of `dest`. Output axes
+/// not referenced by a source operand are treated as stride-0 broadcast axes.
+pub fn broadcast_mul_into<
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + Mul<B, Output = D> + MaybeSendSync + 'static,
+    B: Copy + MaybeSendSync + 'static,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dest: &mut StridedViewMut<D>,
+    a: &StridedView<A, OpA>,
+    a_axes: &[usize],
+    b: &StridedView<B, OpB>,
+    b_axes: &[usize],
+) -> Result<()> {
+    let a_strides = broadcast_strides_for_axes(a.dims(), a.strides(), dest.dims(), a_axes)?;
+    let b_strides = broadcast_strides_for_axes(b.dims(), b.strides(), dest.dims(), b_axes)?;
+
+    if OpA::IS_IDENTITY && OpB::IS_IDENTITY {
+        return mul_identity_into_raw(dest, a.ptr(), &a_strides, b.ptr(), &b_strides);
+    }
+
+    let a = broadcast_view_with_strides(a, dest.dims(), &a_strides);
+    let b = broadcast_view_with_strides(b, dest.dims(), &b_strides);
+    mul_into(dest, &a, &b)
 }
 
 /// Ternary element-wise operation: `dest[i] = f(a[i], b[i], c[i])`.
@@ -509,7 +1323,7 @@ pub fn zip_map3_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -663,7 +1477,7 @@ pub fn zip_map4_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -731,4 +1545,218 @@ pub fn zip_map4_into<
             Ok(())
         },
     )
+}
+
+#[cfg(all(test, feature = "parallel"))]
+mod tests {
+    use super::*;
+
+    fn compact_strides_for_axis_order<const N: usize>(
+        dims: [usize; N],
+        axis_order: [usize; N],
+    ) -> [isize; N] {
+        let mut strides = [0isize; N];
+        let mut stride = 1isize;
+        for &axis in &axis_order {
+            strides[axis] = stride;
+            stride *= dims[axis] as isize;
+        }
+        strides
+    }
+
+    #[test]
+    fn test_contiguous_mul_range_plan_pure_outer() {
+        let dims = [7usize, 11];
+        let dst = [1isize, 7];
+        let lhs = [1isize, 0];
+        let rhs = [0isize, 1];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(plan.inner_len, 7);
+        assert_eq!(plan.row_len, 11);
+        assert_eq!(plan.fast_axis, 0);
+        assert_eq!(plan.a_fast_stride, 1);
+        assert_eq!(plan.b_fast_stride, 0);
+        assert_eq!(plan.a_row_stride, 0);
+        assert_eq!(plan.b_row_stride, 1);
+    }
+
+    #[test]
+    fn test_compact_axis_order_accepts_all_rank4_axis_permutations() {
+        fn visit(dims: [usize; 4], axes: &mut [usize; 4], pos: usize, count: &mut usize) {
+            if pos == axes.len() {
+                let dst = compact_strides_for_axis_order(dims, *axes);
+                let axis_order = compact_axis_order(&dims, &dst).unwrap();
+                assert_eq!(&axis_order[..], &axes[..]);
+                *count += 1;
+                return;
+            }
+
+            for i in pos..axes.len() {
+                axes.swap(pos, i);
+                visit(dims, axes, pos + 1, count);
+                axes.swap(pos, i);
+            }
+        }
+
+        let dims = [2usize, 3, 5, 7];
+        let mut axes = [0usize, 1, 2, 3];
+        let mut count = 0usize;
+        visit(dims, &mut axes, 0, &mut count);
+
+        assert_eq!(count, 24);
+    }
+
+    #[test]
+    fn test_compact_axis_order_rejects_strided_layout_with_holes() {
+        let dims = [2usize, 3, 5];
+        let strides = [1isize, 4, 2];
+
+        assert_eq!(compact_axis_order(&dims, &strides), None);
+    }
+
+    #[test]
+    fn test_contiguous_mul_range_plan_uses_permuted_compact_output_for_unrelated_shape() {
+        let dims = [2usize, 3, 5, 7, 11];
+        let dst = compact_strides_for_axis_order(dims, [2usize, 0, 4, 1, 3]);
+        let lhs = [5isize, 0, 1, 0, 10];
+        let rhs = [0isize, 1, 0, 3, 0];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(&plan.axis_order[..], &[2, 0, 4, 1, 3]);
+        assert_eq!(plan.inner_len, 110);
+        assert_eq!(plan.row_len, 3);
+        assert_eq!(plan.fast_axis, 2);
+        assert_eq!(plan.a_fast_stride, 1);
+        assert_eq!(plan.b_fast_stride, 0);
+        assert_eq!(plan.a_row_stride, 0);
+        assert_eq!(plan.b_row_stride, 1);
+        assert_eq!(transposed_scalar_tile_kind(&plan), None);
+    }
+
+    #[test]
+    fn test_contiguous_mul_range_plan_compact_batched_outer() {
+        let dims = [3usize, 5, 7, 11];
+        let dst = [1isize, 3, 15, 105];
+        let lhs = [1isize, 3, 0, 15];
+        let rhs = [0isize, 0, 1, 7];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(plan.inner_len, 15);
+        assert_eq!(plan.row_len, 7);
+        assert_eq!(plan.fast_axis, 0);
+        assert_eq!(plan.a_fast_stride, 1);
+        assert_eq!(plan.b_fast_stride, 0);
+        assert_eq!(plan.a_row_stride, 0);
+        assert_eq!(plan.b_row_stride, 1);
+    }
+
+    #[test]
+    fn test_contiguous_mul_range_plan_noncompact_batched_outer() {
+        let dims = [5usize, 5, 7, 11];
+        let dst = [1isize, 5, 25, 175];
+        let lhs = [5isize, 1, 0, 25];
+        let rhs = [0isize, 0, 1, 7];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(plan.inner_len, 5);
+        assert_eq!(plan.row_len, 5);
+        assert_eq!(plan.fast_axis, 0);
+        assert_eq!(plan.a_fast_stride, 5);
+        assert_eq!(plan.b_fast_stride, 0);
+        assert_eq!(plan.a_row_stride, 1);
+        assert_eq!(plan.b_row_stride, 0);
+    }
+
+    #[test]
+    fn test_contiguous_mul_range_plan_noncompact_row_major_output() {
+        let dims = [5usize, 5, 7, 11];
+        let dst = [5isize, 1, 25, 175];
+        let lhs = [5isize, 1, 0, 25];
+        let rhs = [0isize, 0, 1, 7];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(plan.inner_len, 25);
+        assert_eq!(plan.row_len, 7);
+        assert_eq!(plan.fast_axis, 1);
+        assert_eq!(plan.a_fast_stride, 1);
+        assert_eq!(plan.b_fast_stride, 0);
+        assert_eq!(plan.a_row_stride, 0);
+        assert_eq!(plan.b_row_stride, 1);
+        assert_eq!(transposed_scalar_tile_kind(&plan), None);
+    }
+
+    #[test]
+    fn test_broadcast_strides_for_axes_batched_outer() {
+        let target_dims = [3usize, 5, 7, 11];
+        let lhs_dims = [3usize, 5, 11];
+        let lhs_strides = [3isize, 1, 15];
+        let rhs_dims = [7usize, 11];
+        let rhs_strides = [1isize, 7];
+
+        let lhs =
+            broadcast_strides_for_axes(&lhs_dims, &lhs_strides, &target_dims, &[0, 1, 3]).unwrap();
+        let rhs =
+            broadcast_strides_for_axes(&rhs_dims, &rhs_strides, &target_dims, &[2, 3]).unwrap();
+
+        assert_eq!(&lhs[..], &[3, 1, 0, 15]);
+        assert_eq!(&rhs[..], &[0, 0, 1, 7]);
+    }
+
+    #[test]
+    fn test_broadcast_strides_for_axes_uses_zero_stride_for_size_one_source_dim() {
+        let target_dims = [8usize, 4];
+        let source_dims = [1usize, 4];
+        let source_strides = [1isize, 1];
+
+        let strides =
+            broadcast_strides_for_axes(&source_dims, &source_strides, &target_dims, &[0, 1])
+                .unwrap();
+
+        assert_eq!(&strides[..], &[0, 1]);
+    }
+
+    #[test]
+    fn test_transposed_scalar_tile_kind_detects_noncompact_rhs_scalar() {
+        let dims = [5usize, 5, 7, 11];
+        let dst = [1isize, 5, 25, 175];
+        let lhs = [5isize, 1, 0, 25];
+        let rhs = [0isize, 0, 1, 7];
+
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+
+        assert_eq!(
+            transposed_scalar_tile_kind(&plan),
+            Some(TransposedScalarTileKind::RhsScalar)
+        );
+    }
+
+    #[test]
+    fn test_contiguous_mul_outer_cursor_matches_linear_offsets() {
+        let dims = [16usize, 16, 64, 64];
+        let dst = [1isize, 16, 256, 16_384];
+        let lhs = [16isize, 1, 0, 256];
+        let rhs = [0isize, 0, 1, 64];
+        let plan = contiguous_mul_range_plan(&dims, &dst, &lhs, &rhs).unwrap();
+        let mut cursor = ContiguousMulOuterCursor::new(&dims, &lhs, &rhs, &plan, 13);
+        let block_len = plan.inner_len * plan.row_len;
+
+        for group in 13..80 {
+            let index = group * block_len;
+            assert_eq!(
+                cursor.a_offset,
+                strided_offset_for_contiguous_linear_index(&dims, &lhs, &plan.axis_order, index)
+            );
+            assert_eq!(
+                cursor.b_offset,
+                strided_offset_for_contiguous_linear_index(&dims, &rhs, &plan.axis_order, index)
+            );
+            cursor.advance();
+        }
+    }
 }

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -75,6 +75,33 @@ unsafe fn inner_loop_map2<D: Copy, A: Copy, B: Copy, OpA: ElementOp<A>, OpB: Ele
                 dst[i] = f(OpA::apply(src_a[i]), OpB::apply(src_b[i]));
             }
         });
+    } else if ds == 1 && a_s == 1 && b_s == 0 {
+        let src_a = std::slice::from_raw_parts(ap, len);
+        let b = OpB::apply(*bp);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        simd::dispatch_if_large(len, || {
+            for i in 0..len {
+                dst[i] = f(OpA::apply(src_a[i]), b);
+            }
+        });
+    } else if ds == 1 && a_s == 0 && b_s == 1 {
+        let a = OpA::apply(*ap);
+        let src_b = std::slice::from_raw_parts(bp, len);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        simd::dispatch_if_large(len, || {
+            for i in 0..len {
+                dst[i] = f(a, OpB::apply(src_b[i]));
+            }
+        });
+    } else if ds == 1 && a_s == 0 && b_s == 0 {
+        let a = OpA::apply(*ap);
+        let b = OpB::apply(*bp);
+        let dst = std::slice::from_raw_parts_mut(dp, len);
+        simd::dispatch_if_large(len, || {
+            for d in dst.iter_mut() {
+                *d = f(a, b);
+            }
+        });
     } else {
         let mut dp = dp;
         let mut ap = ap;

--- a/strided-kernel/src/ops_view.rs
+++ b/strided-kernel/src/ops_view.rs
@@ -289,7 +289,7 @@ pub fn add<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
@@ -391,7 +391,7 @@ pub fn mul<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
@@ -496,7 +496,7 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
@@ -610,7 +610,7 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
             let b_send = SendPtr(b_ptr as *mut B);

--- a/strided-kernel/src/order.rs
+++ b/strided-kernel/src/order.rs
@@ -1,36 +1,30 @@
-//! Loop ordering algorithm ported from Strided.jl
+//! Loop ordering algorithm derived from Strided.jl
 //!
 //! This module computes the optimal dimension iteration order using
-//! the index_order + importance bit-packing algorithm from Julia.
+//! an index_order + importance bit-packing algorithm.
 
 use crate::fuse::{compute_importance, sort_by_importance};
 use strided_view::auxiliary::index_order;
 
 /// Compute the optimal iteration order for dimensions.
 ///
-/// This implementation follows Julia's `_mapreduce_order!` algorithm:
+/// This implementation follows Julia's `_mapreduce_order!` structure:
 /// 1. Compute `index_order` for each array's strides
-/// 2. Compute importance scores using bit-packing with output weighted 2x
+/// 2. Compute importance scores using bit-packing, with strong output locality
+///    preference and zero-stride broadcast axes ignored for ordering
 /// 3. Sort dimensions by importance (descending)
 ///
 /// # Arguments
 /// * `dims` - The dimensions of the arrays
 /// * `strides_list` - Slice of stride arrays, one per array
-/// * `dest_index` - Index of the destination array (weighted 2x, typically 0)
+/// * `dest_index` - Index of the destination array (strongly weighted, typically 0)
 ///
 /// # Returns
 /// Permutation of dimension indices in optimal iteration order
 ///
-/// # Julia equivalent
-/// ```julia
-/// g = 8 * sizeof(Int) - leading_zeros(M + 1)
-/// importance = 2 .* (1 .<< (g .* (N .- indexorder(strides[1]))))
-/// for k in 2:M
-///     importance = importance .+ (1 .<< (g .* (N .- indexorder(strides[k]))))
-/// end
-/// importance = importance .* (dims .> 1)
-/// p = sortperm(importance; rev=true)
-/// ```
+/// The baseline comes from Strided.jl. This version differs by ignoring
+/// zero-stride broadcast axes for ordering and giving the destination a
+/// stronger weight so contiguous stores stay in the inner loop.
 pub(crate) fn compute_order(
     dims: &[usize],
     strides_list: &[&[isize]],
@@ -51,7 +45,7 @@ pub(crate) fn compute_order(
         index_orders.push(index_order(strides));
     }
 
-    // Reorder so destination array is first (gets 2x weight)
+    // Reorder so destination array is first (gets strong store-locality weight)
     let reordered_strides: Vec<&[isize]>;
     let reordered_orders: Vec<Vec<usize>>;
 
@@ -171,20 +165,14 @@ mod tests {
 
     #[test]
     fn test_compute_order_with_zero_stride_broadcast() {
-        // Zero stride indicates broadcasting
-        // Julia: zero strides get index_order = 1 (highest priority for iteration)
+        // Zero stride indicates broadcasting and should not pull an axis inward.
         let dims = [4usize, 5, 3];
         let strides = [0isize, 1, 5]; // First dim is broadcast (stride 0)
         let strides_list: Vec<&[isize]> = vec![&strides];
 
         let order = compute_order(&dims, &strides_list, Some(0));
 
-        // With index_order: [1, 1, 2] for strides [0, 1, 5]
-        // importance for dim 0: shift = g * (3 - 1) = high
-        // importance for dim 1: shift = g * (3 - 1) = high (same as dim 0)
-        // importance for dim 2: shift = g * (3 - 2) = lower
-        // So dim 2 (largest stride) should be last
-        assert_eq!(order[2], 2);
+        assert_eq!(order, vec![1, 2, 0]);
     }
 
     #[test]
@@ -211,10 +199,10 @@ mod tests {
 
         let order = compute_order(&dims, &strides_list, Some(0));
 
-        // Output is weighted 2x, so its stride order dominates
+        // Output is strongly weighted, so its stride order dominates
         // Output index_order: [4, 3, 2, 1] (60 > 20 > 5 > 1)
         // Input index_order: [1, 2, 3, 4] (1 < 2 < 6 < 24)
-        // With output 2x weight, dimension 3 (stride 1 in output) should be first
+        // With output weighting, dimension 3 (stride 1 in output) should be first
         assert_eq!(order[0], 3);
     }
 }

--- a/strided-kernel/src/outer_product.rs
+++ b/strided-kernel/src/outer_product.rs
@@ -1,0 +1,511 @@
+//! Outer-product kernels on dynamic-rank strided views.
+
+use std::ops::Mul;
+
+use crate::view::{StridedView, StridedViewMut};
+use crate::{ElementOp, Result, StridedError};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BatchedOuterShape {
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+    batch_ndim: usize,
+    rows: usize,
+    cols: usize,
+    batches: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CompactBatchedOuter {
+    dst_row_stride: isize,
+    dst_col_stride: isize,
+    dst_batch_stride: isize,
+    lhs_row_stride: isize,
+    lhs_batch_stride: isize,
+    rhs_col_stride: isize,
+    rhs_batch_stride: isize,
+}
+
+/// Compute `dest[lhs_free..., rhs_free..., batch...] =
+/// lhs[lhs_free..., batch...] * rhs[rhs_free..., batch...]`.
+///
+/// The dimension groups are determined by `lhs_free_ndim` and `rhs_free_ndim`.
+/// A pure outer product has zero batch dimensions.
+pub fn batched_outer_product_into<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+) -> Result<()>
+where
+    T: Copy + Mul<Output = T>,
+    OpA: ElementOp<T>,
+    OpB: ElementOp<T>,
+{
+    batched_outer_product_into_seq(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
+}
+
+/// Sequential batched outer-product kernel.
+pub fn batched_outer_product_into_seq<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+) -> Result<()>
+where
+    T: Copy + Mul<Output = T>,
+    OpA: ElementOp<T>,
+    OpB: ElementOp<T>,
+{
+    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
+    if let Some(compact) = compact_batched_outer(dest, lhs, rhs, &shape) {
+        unsafe {
+            execute_compact_seq(dest, lhs, rhs, &shape, &compact);
+        }
+    } else {
+        unsafe {
+            execute_strided_seq(dest, lhs, rhs, &shape)?;
+        }
+    }
+    Ok(())
+}
+
+/// Parallel batched outer-product kernel using Rayon.
+#[cfg(feature = "parallel")]
+pub fn batched_outer_product_into_par<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+) -> Result<()>
+where
+    T: Copy + Send + Sync + Mul<Output = T>,
+    OpA: ElementOp<T> + Send + Sync,
+    OpB: ElementOp<T> + Send + Sync,
+{
+    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
+    if let Some(compact) = compact_batched_outer(dest, lhs, rhs, &shape) {
+        unsafe {
+            execute_compact_par(dest, lhs, rhs, &shape, &compact);
+        }
+    } else {
+        unsafe {
+            execute_strided_par(dest, lhs, rhs, &shape)?;
+        }
+    }
+    Ok(())
+}
+
+/// Choose the sequential or Rayon implementation by output element count.
+#[cfg(feature = "parallel")]
+pub fn batched_outer_product_into_auto<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+    min_parallel_elements: usize,
+) -> Result<()>
+where
+    T: Copy + Send + Sync + Mul<Output = T>,
+    OpA: ElementOp<T> + Send + Sync,
+    OpB: ElementOp<T> + Send + Sync,
+{
+    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
+    let total = checked_mul3(shape.rows, shape.cols, shape.batches)?;
+    if total >= min_parallel_elements && rayon::current_num_threads() > 1 {
+        batched_outer_product_into_par(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
+    } else {
+        batched_outer_product_into_seq(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
+    }
+}
+
+fn validate_batched_outer_shape<T, OpA, OpB>(
+    dest: &StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    lhs_free_ndim: usize,
+    rhs_free_ndim: usize,
+) -> Result<BatchedOuterShape> {
+    if lhs_free_ndim > lhs.ndim() {
+        return Err(StridedError::RankMismatch(lhs_free_ndim, lhs.ndim()));
+    }
+    if rhs_free_ndim > rhs.ndim() {
+        return Err(StridedError::RankMismatch(rhs_free_ndim, rhs.ndim()));
+    }
+
+    let lhs_batch_ndim = lhs.ndim() - lhs_free_ndim;
+    let rhs_batch_ndim = rhs.ndim() - rhs_free_ndim;
+    if lhs_batch_ndim != rhs_batch_ndim {
+        return Err(StridedError::RankMismatch(lhs_batch_ndim, rhs_batch_ndim));
+    }
+    let expected_dest_rank = lhs_free_ndim + rhs_free_ndim + lhs_batch_ndim;
+    if dest.ndim() != expected_dest_rank {
+        return Err(StridedError::RankMismatch(dest.ndim(), expected_dest_rank));
+    }
+
+    ensure_dims(&dest.dims()[..lhs_free_ndim], &lhs.dims()[..lhs_free_ndim])?;
+    ensure_dims(
+        &dest.dims()[lhs_free_ndim..lhs_free_ndim + rhs_free_ndim],
+        &rhs.dims()[..rhs_free_ndim],
+    )?;
+    ensure_dims(
+        &dest.dims()[lhs_free_ndim + rhs_free_ndim..],
+        &lhs.dims()[lhs_free_ndim..],
+    )?;
+    ensure_dims(
+        &dest.dims()[lhs_free_ndim + rhs_free_ndim..],
+        &rhs.dims()[rhs_free_ndim..],
+    )?;
+
+    Ok(BatchedOuterShape {
+        lhs_free_ndim,
+        rhs_free_ndim,
+        batch_ndim: lhs_batch_ndim,
+        rows: product(&lhs.dims()[..lhs_free_ndim])?,
+        cols: product(&rhs.dims()[..rhs_free_ndim])?,
+        batches: product(&lhs.dims()[lhs_free_ndim..])?,
+    })
+}
+
+fn ensure_dims(a: &[usize], b: &[usize]) -> Result<()> {
+    if a != b {
+        return Err(StridedError::ShapeMismatch(a.to_vec(), b.to_vec()));
+    }
+    Ok(())
+}
+
+fn product(dims: &[usize]) -> Result<usize> {
+    dims.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim).ok_or(StridedError::OffsetOverflow)
+    })
+}
+
+#[cfg(feature = "parallel")]
+fn checked_mul3(a: usize, b: usize, c: usize) -> Result<usize> {
+    a.checked_mul(b)
+        .and_then(|x| x.checked_mul(c))
+        .ok_or(StridedError::OffsetOverflow)
+}
+
+fn compact_batched_outer<T, OpA, OpB>(
+    dest: &StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    shape: &BatchedOuterShape,
+) -> Option<CompactBatchedOuter> {
+    Some(CompactBatchedOuter {
+        dst_row_stride: compact_group_stride(dest.dims(), dest.strides(), 0, shape.lhs_free_ndim)?,
+        dst_col_stride: compact_group_stride(
+            dest.dims(),
+            dest.strides(),
+            shape.lhs_free_ndim,
+            shape.lhs_free_ndim + shape.rhs_free_ndim,
+        )?,
+        dst_batch_stride: compact_group_stride(
+            dest.dims(),
+            dest.strides(),
+            shape.lhs_free_ndim + shape.rhs_free_ndim,
+            dest.ndim(),
+        )?,
+        lhs_row_stride: compact_group_stride(lhs.dims(), lhs.strides(), 0, shape.lhs_free_ndim)?,
+        lhs_batch_stride: compact_group_stride(
+            lhs.dims(),
+            lhs.strides(),
+            shape.lhs_free_ndim,
+            lhs.ndim(),
+        )?,
+        rhs_col_stride: compact_group_stride(rhs.dims(), rhs.strides(), 0, shape.rhs_free_ndim)?,
+        rhs_batch_stride: compact_group_stride(
+            rhs.dims(),
+            rhs.strides(),
+            shape.rhs_free_ndim,
+            rhs.ndim(),
+        )?,
+    })
+}
+
+fn compact_group_stride(
+    dims: &[usize],
+    strides: &[isize],
+    start: usize,
+    end: usize,
+) -> Option<isize> {
+    let mut base = None;
+    let mut expected = 0isize;
+    for axis in start..end {
+        if dims[axis] <= 1 {
+            continue;
+        }
+        if let Some(_) = base {
+            if strides[axis] != expected {
+                return None;
+            }
+        } else {
+            base = Some(strides[axis]);
+            expected = strides[axis];
+        }
+        expected = expected.checked_mul(dims[axis] as isize)?;
+    }
+    Some(base.unwrap_or(0))
+}
+
+unsafe fn execute_compact_seq<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    shape: &BatchedOuterShape,
+    compact: &CompactBatchedOuter,
+) where
+    T: Copy + Mul<Output = T>,
+    OpA: ElementOp<T>,
+    OpB: ElementOp<T>,
+{
+    let dst = dest.as_mut_ptr();
+    let lhs_ptr = lhs.ptr();
+    let rhs_ptr = rhs.ptr();
+    for batch in 0..shape.batches {
+        let batch = batch as isize;
+        let dst_batch = batch * compact.dst_batch_stride;
+        let lhs_batch = batch * compact.lhs_batch_stride;
+        let rhs_batch = batch * compact.rhs_batch_stride;
+        for col in 0..shape.cols {
+            let col = col as isize;
+            let rhs_value = OpB::apply(*rhs_ptr.offset(rhs_batch + col * compact.rhs_col_stride));
+            let dst_col = dst_batch + col * compact.dst_col_stride;
+            for row in 0..shape.rows {
+                let row = row as isize;
+                let lhs_value =
+                    OpA::apply(*lhs_ptr.offset(lhs_batch + row * compact.lhs_row_stride));
+                *dst.offset(dst_col + row * compact.dst_row_stride) = lhs_value * rhs_value;
+            }
+        }
+    }
+}
+
+unsafe fn execute_strided_seq<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    shape: &BatchedOuterShape,
+) -> Result<()>
+where
+    T: Copy + Mul<Output = T>,
+    OpA: ElementOp<T>,
+    OpB: ElementOp<T>,
+{
+    let offsets = StridedOuterOffsets::new(dest, lhs, rhs, shape)?;
+    let dst = dest.as_mut_ptr();
+    let lhs_ptr = lhs.ptr();
+    let rhs_ptr = rhs.ptr();
+    for batch in 0..shape.batches {
+        for col in 0..shape.cols {
+            let rhs_value =
+                OpB::apply(*rhs_ptr.offset(offsets.rhs_batch[batch] + offsets.rhs_col[col]));
+            for row in 0..shape.rows {
+                let lhs_value =
+                    OpA::apply(*lhs_ptr.offset(offsets.lhs_batch[batch] + offsets.lhs_row[row]));
+                *dst.offset(
+                    offsets.dst_batch[batch] + offsets.dst_col[col] + offsets.dst_row[row],
+                ) = lhs_value * rhs_value;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "parallel")]
+unsafe fn execute_compact_par<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    shape: &BatchedOuterShape,
+    compact: &CompactBatchedOuter,
+) where
+    T: Copy + Send + Sync + Mul<Output = T>,
+    OpA: ElementOp<T> + Send + Sync,
+    OpB: ElementOp<T> + Send + Sync,
+{
+    use rayon::prelude::*;
+
+    let dst = SendPtr(dest.as_mut_ptr());
+    let lhs_ptr = SendPtr(lhs.ptr() as *mut T);
+    let rhs_ptr = SendPtr(rhs.ptr() as *mut T);
+    let cols = shape.cols;
+    let rows = shape.rows;
+    (0..shape.batches * shape.cols)
+        .into_par_iter()
+        .for_each(|bc| {
+            let batch = (bc / cols) as isize;
+            let col = (bc % cols) as isize;
+            let dst_batch = batch * compact.dst_batch_stride;
+            let lhs_batch = batch * compact.lhs_batch_stride;
+            let rhs_batch = batch * compact.rhs_batch_stride;
+            let rhs_value = unsafe {
+                OpB::apply(
+                    *rhs_ptr
+                        .as_const()
+                        .offset(rhs_batch + col * compact.rhs_col_stride),
+                )
+            };
+            let dst_col = dst_batch + col * compact.dst_col_stride;
+            for row in 0..rows {
+                let row = row as isize;
+                let lhs_value = unsafe {
+                    OpA::apply(
+                        *lhs_ptr
+                            .as_const()
+                            .offset(lhs_batch + row * compact.lhs_row_stride),
+                    )
+                };
+                unsafe {
+                    *dst.as_ptr().offset(dst_col + row * compact.dst_row_stride) =
+                        lhs_value * rhs_value;
+                }
+            }
+        });
+}
+
+#[cfg(feature = "parallel")]
+unsafe fn execute_strided_par<T, OpA, OpB>(
+    dest: &mut StridedViewMut<T>,
+    lhs: &StridedView<T, OpA>,
+    rhs: &StridedView<T, OpB>,
+    shape: &BatchedOuterShape,
+) -> Result<()>
+where
+    T: Copy + Send + Sync + Mul<Output = T>,
+    OpA: ElementOp<T> + Send + Sync,
+    OpB: ElementOp<T> + Send + Sync,
+{
+    use rayon::prelude::*;
+
+    let offsets = StridedOuterOffsets::new(dest, lhs, rhs, shape)?;
+    let dst = SendPtr(dest.as_mut_ptr());
+    let lhs_ptr = SendPtr(lhs.ptr() as *mut T);
+    let rhs_ptr = SendPtr(rhs.ptr() as *mut T);
+    let cols = shape.cols;
+    let rows = shape.rows;
+    (0..shape.batches * shape.cols)
+        .into_par_iter()
+        .for_each(|bc| {
+            let batch = bc / cols;
+            let col = bc % cols;
+            let rhs_value = unsafe {
+                OpB::apply(
+                    *rhs_ptr
+                        .as_const()
+                        .offset(offsets.rhs_batch[batch] + offsets.rhs_col[col]),
+                )
+            };
+            for row in 0..rows {
+                let lhs_value = unsafe {
+                    OpA::apply(
+                        *lhs_ptr
+                            .as_const()
+                            .offset(offsets.lhs_batch[batch] + offsets.lhs_row[row]),
+                    )
+                };
+                unsafe {
+                    *dst.as_ptr().offset(
+                        offsets.dst_batch[batch] + offsets.dst_col[col] + offsets.dst_row[row],
+                    ) = lhs_value * rhs_value;
+                }
+            }
+        });
+    Ok(())
+}
+
+struct StridedOuterOffsets {
+    dst_row: Vec<isize>,
+    dst_col: Vec<isize>,
+    dst_batch: Vec<isize>,
+    lhs_row: Vec<isize>,
+    lhs_batch: Vec<isize>,
+    rhs_col: Vec<isize>,
+    rhs_batch: Vec<isize>,
+}
+
+impl StridedOuterOffsets {
+    fn new<T, OpA, OpB>(
+        dest: &StridedViewMut<T>,
+        lhs: &StridedView<T, OpA>,
+        rhs: &StridedView<T, OpB>,
+        shape: &BatchedOuterShape,
+    ) -> Result<Self> {
+        Ok(Self {
+            dst_row: group_offsets(dest.dims(), dest.strides(), 0, shape.lhs_free_ndim)?,
+            dst_col: group_offsets(
+                dest.dims(),
+                dest.strides(),
+                shape.lhs_free_ndim,
+                shape.lhs_free_ndim + shape.rhs_free_ndim,
+            )?,
+            dst_batch: group_offsets(
+                dest.dims(),
+                dest.strides(),
+                shape.lhs_free_ndim + shape.rhs_free_ndim,
+                dest.ndim(),
+            )?,
+            lhs_row: group_offsets(lhs.dims(), lhs.strides(), 0, shape.lhs_free_ndim)?,
+            lhs_batch: group_offsets(lhs.dims(), lhs.strides(), shape.lhs_free_ndim, lhs.ndim())?,
+            rhs_col: group_offsets(rhs.dims(), rhs.strides(), 0, shape.rhs_free_ndim)?,
+            rhs_batch: group_offsets(rhs.dims(), rhs.strides(), shape.rhs_free_ndim, rhs.ndim())?,
+        })
+    }
+}
+
+fn group_offsets(
+    dims: &[usize],
+    strides: &[isize],
+    start: usize,
+    end: usize,
+) -> Result<Vec<isize>> {
+    let group_dims = &dims[start..end];
+    let group_strides = &strides[start..end];
+    let total = product(group_dims)?;
+    let mut offsets = Vec::with_capacity(total);
+    if group_dims.is_empty() {
+        offsets.push(0);
+        return Ok(offsets);
+    }
+    for mut linear in 0..total {
+        let mut offset = 0isize;
+        for (&dim, &stride) in group_dims.iter().zip(group_strides.iter()) {
+            let idx = linear % dim;
+            linear /= dim;
+            offset = offset
+                .checked_add(
+                    (idx as isize)
+                        .checked_mul(stride)
+                        .ok_or(StridedError::OffsetOverflow)?,
+                )
+                .ok_or(StridedError::OffsetOverflow)?;
+        }
+        offsets.push(offset);
+    }
+    Ok(offsets)
+}
+
+#[cfg(feature = "parallel")]
+#[derive(Clone, Copy)]
+struct SendPtr<T>(*mut T);
+
+#[cfg(feature = "parallel")]
+unsafe impl<T> Send for SendPtr<T> {}
+#[cfg(feature = "parallel")]
+unsafe impl<T> Sync for SendPtr<T> {}
+
+#[cfg(feature = "parallel")]
+impl<T> SendPtr<T> {
+    fn as_ptr(self) -> *mut T {
+        self.0
+    }
+
+    fn as_const(self) -> *const T {
+        self.0 as *const T
+    }
+}

--- a/strided-kernel/src/outer_product.rs
+++ b/strided-kernel/src/outer_product.rs
@@ -1,135 +1,63 @@
-//! Outer-product kernels on dynamic-rank strided views.
+//! Semantic outer-product API on dynamic-rank strided views.
 
 use std::ops::Mul;
 
+#[cfg(feature = "parallel")]
+use smallvec::SmallVec;
+
+use crate::map_view::broadcast_mul_into;
+use crate::maybe_sync::MaybeSendSync;
 use crate::view::{StridedView, StridedViewMut};
 use crate::{ElementOp, Result, StridedError};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct BatchedOuterShape {
-    lhs_free_ndim: usize,
-    rhs_free_ndim: usize,
-    batch_ndim: usize,
-    rows: usize,
-    cols: usize,
-    batches: usize,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct CompactBatchedOuter {
-    dst_row_stride: isize,
-    dst_col_stride: isize,
-    dst_batch_stride: isize,
-    lhs_row_stride: isize,
-    lhs_batch_stride: isize,
-    rhs_col_stride: isize,
-    rhs_batch_stride: isize,
-}
+#[cfg(feature = "parallel")]
+type AxisVec<T> = SmallVec<[T; 8]>;
+#[cfg(not(feature = "parallel"))]
+type AxisVec<T> = Vec<T>;
 
 /// Compute `dest[lhs_free..., rhs_free..., batch...] =
 /// lhs[lhs_free..., batch...] * rhs[rhs_free..., batch...]`.
 ///
-/// The dimension groups are determined by `lhs_free_ndim` and `rhs_free_ndim`.
-/// A pure outer product has zero batch dimensions.
-pub fn batched_outer_product_into<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
+/// This is a semantic convenience wrapper over [`broadcast_mul_into`]. The
+/// broadcast/mul planner owns kernel selection, so explicit outer-product calls
+/// and equivalent broadcasted multiplication use the same implementation path.
+pub fn batched_outer_product_into<D, A, B, OpA, OpB>(
+    dest: &mut StridedViewMut<D>,
+    lhs: &StridedView<A, OpA>,
+    rhs: &StridedView<B, OpB>,
     lhs_free_ndim: usize,
     rhs_free_ndim: usize,
 ) -> Result<()>
 where
-    T: Copy + Mul<Output = T>,
-    OpA: ElementOp<T>,
-    OpB: ElementOp<T>,
+    D: Copy + MaybeSendSync + 'static,
+    A: Copy + MaybeSendSync + Mul<B, Output = D> + 'static,
+    B: Copy + MaybeSendSync + 'static,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
 {
-    batched_outer_product_into_seq(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
+    validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
+
+    let batch_ndim = lhs.ndim() - lhs_free_ndim;
+    let mut lhs_axes = AxisVec::<usize>::with_capacity(lhs.ndim());
+    let mut rhs_axes = AxisVec::<usize>::with_capacity(rhs.ndim());
+
+    lhs_axes.extend(0..lhs_free_ndim);
+    rhs_axes.extend(lhs_free_ndim..lhs_free_ndim + rhs_free_ndim);
+
+    let batch_axis_start = lhs_free_ndim + rhs_free_ndim;
+    lhs_axes.extend(batch_axis_start..batch_axis_start + batch_ndim);
+    rhs_axes.extend(batch_axis_start..batch_axis_start + batch_ndim);
+
+    broadcast_mul_into(dest, lhs, &lhs_axes, rhs, &rhs_axes)
 }
 
-/// Sequential batched outer-product kernel.
-pub fn batched_outer_product_into_seq<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
+fn validate_batched_outer_shape<D, A, OpA, B, OpB>(
+    dest: &StridedViewMut<D>,
+    lhs: &StridedView<A, OpA>,
+    rhs: &StridedView<B, OpB>,
     lhs_free_ndim: usize,
     rhs_free_ndim: usize,
-) -> Result<()>
-where
-    T: Copy + Mul<Output = T>,
-    OpA: ElementOp<T>,
-    OpB: ElementOp<T>,
-{
-    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
-    if let Some(compact) = compact_batched_outer(dest, lhs, rhs, &shape) {
-        unsafe {
-            execute_compact_seq(dest, lhs, rhs, &shape, &compact);
-        }
-    } else {
-        unsafe {
-            execute_strided_seq(dest, lhs, rhs, &shape)?;
-        }
-    }
-    Ok(())
-}
-
-/// Parallel batched outer-product kernel using Rayon.
-#[cfg(feature = "parallel")]
-pub fn batched_outer_product_into_par<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    lhs_free_ndim: usize,
-    rhs_free_ndim: usize,
-) -> Result<()>
-where
-    T: Copy + Send + Sync + Mul<Output = T>,
-    OpA: ElementOp<T> + Send + Sync,
-    OpB: ElementOp<T> + Send + Sync,
-{
-    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
-    if let Some(compact) = compact_batched_outer(dest, lhs, rhs, &shape) {
-        unsafe {
-            execute_compact_par(dest, lhs, rhs, &shape, &compact);
-        }
-    } else {
-        unsafe {
-            execute_strided_par(dest, lhs, rhs, &shape)?;
-        }
-    }
-    Ok(())
-}
-
-/// Choose the sequential or Rayon implementation by output element count.
-#[cfg(feature = "parallel")]
-pub fn batched_outer_product_into_auto<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    lhs_free_ndim: usize,
-    rhs_free_ndim: usize,
-    min_parallel_elements: usize,
-) -> Result<()>
-where
-    T: Copy + Send + Sync + Mul<Output = T>,
-    OpA: ElementOp<T> + Send + Sync,
-    OpB: ElementOp<T> + Send + Sync,
-{
-    let shape = validate_batched_outer_shape(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)?;
-    let total = checked_mul3(shape.rows, shape.cols, shape.batches)?;
-    if total >= min_parallel_elements && rayon::current_num_threads() > 1 {
-        batched_outer_product_into_par(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
-    } else {
-        batched_outer_product_into_seq(dest, lhs, rhs, lhs_free_ndim, rhs_free_ndim)
-    }
-}
-
-fn validate_batched_outer_shape<T, OpA, OpB>(
-    dest: &StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    lhs_free_ndim: usize,
-    rhs_free_ndim: usize,
-) -> Result<BatchedOuterShape> {
+) -> Result<()> {
     if lhs_free_ndim > lhs.ndim() {
         return Err(StridedError::RankMismatch(lhs_free_ndim, lhs.ndim()));
     }
@@ -142,6 +70,7 @@ fn validate_batched_outer_shape<T, OpA, OpB>(
     if lhs_batch_ndim != rhs_batch_ndim {
         return Err(StridedError::RankMismatch(lhs_batch_ndim, rhs_batch_ndim));
     }
+
     let expected_dest_rank = lhs_free_ndim + rhs_free_ndim + lhs_batch_ndim;
     if dest.ndim() != expected_dest_rank {
         return Err(StridedError::RankMismatch(dest.ndim(), expected_dest_rank));
@@ -161,351 +90,16 @@ fn validate_batched_outer_shape<T, OpA, OpB>(
         &rhs.dims()[rhs_free_ndim..],
     )?;
 
-    Ok(BatchedOuterShape {
-        lhs_free_ndim,
-        rhs_free_ndim,
-        batch_ndim: lhs_batch_ndim,
-        rows: product(&lhs.dims()[..lhs_free_ndim])?,
-        cols: product(&rhs.dims()[..rhs_free_ndim])?,
-        batches: product(&lhs.dims()[lhs_free_ndim..])?,
-    })
-}
-
-fn ensure_dims(a: &[usize], b: &[usize]) -> Result<()> {
-    if a != b {
-        return Err(StridedError::ShapeMismatch(a.to_vec(), b.to_vec()));
-    }
     Ok(())
 }
 
-fn product(dims: &[usize]) -> Result<usize> {
-    dims.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim).ok_or(StridedError::OffsetOverflow)
-    })
-}
-
-#[cfg(feature = "parallel")]
-fn checked_mul3(a: usize, b: usize, c: usize) -> Result<usize> {
-    a.checked_mul(b)
-        .and_then(|x| x.checked_mul(c))
-        .ok_or(StridedError::OffsetOverflow)
-}
-
-fn compact_batched_outer<T, OpA, OpB>(
-    dest: &StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    shape: &BatchedOuterShape,
-) -> Option<CompactBatchedOuter> {
-    Some(CompactBatchedOuter {
-        dst_row_stride: compact_group_stride(dest.dims(), dest.strides(), 0, shape.lhs_free_ndim)?,
-        dst_col_stride: compact_group_stride(
-            dest.dims(),
-            dest.strides(),
-            shape.lhs_free_ndim,
-            shape.lhs_free_ndim + shape.rhs_free_ndim,
-        )?,
-        dst_batch_stride: compact_group_stride(
-            dest.dims(),
-            dest.strides(),
-            shape.lhs_free_ndim + shape.rhs_free_ndim,
-            dest.ndim(),
-        )?,
-        lhs_row_stride: compact_group_stride(lhs.dims(), lhs.strides(), 0, shape.lhs_free_ndim)?,
-        lhs_batch_stride: compact_group_stride(
-            lhs.dims(),
-            lhs.strides(),
-            shape.lhs_free_ndim,
-            lhs.ndim(),
-        )?,
-        rhs_col_stride: compact_group_stride(rhs.dims(), rhs.strides(), 0, shape.rhs_free_ndim)?,
-        rhs_batch_stride: compact_group_stride(
-            rhs.dims(),
-            rhs.strides(),
-            shape.rhs_free_ndim,
-            rhs.ndim(),
-        )?,
-    })
-}
-
-fn compact_group_stride(
-    dims: &[usize],
-    strides: &[isize],
-    start: usize,
-    end: usize,
-) -> Option<isize> {
-    let mut base = None;
-    let mut expected = 0isize;
-    for axis in start..end {
-        if dims[axis] <= 1 {
-            continue;
-        }
-        if let Some(_) = base {
-            if strides[axis] != expected {
-                return None;
-            }
-        } else {
-            base = Some(strides[axis]);
-            expected = strides[axis];
-        }
-        expected = expected.checked_mul(dims[axis] as isize)?;
-    }
-    Some(base.unwrap_or(0))
-}
-
-unsafe fn execute_compact_seq<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    shape: &BatchedOuterShape,
-    compact: &CompactBatchedOuter,
-) where
-    T: Copy + Mul<Output = T>,
-    OpA: ElementOp<T>,
-    OpB: ElementOp<T>,
-{
-    let dst = dest.as_mut_ptr();
-    let lhs_ptr = lhs.ptr();
-    let rhs_ptr = rhs.ptr();
-    for batch in 0..shape.batches {
-        let batch = batch as isize;
-        let dst_batch = batch * compact.dst_batch_stride;
-        let lhs_batch = batch * compact.lhs_batch_stride;
-        let rhs_batch = batch * compact.rhs_batch_stride;
-        for col in 0..shape.cols {
-            let col = col as isize;
-            let rhs_value = OpB::apply(*rhs_ptr.offset(rhs_batch + col * compact.rhs_col_stride));
-            let dst_col = dst_batch + col * compact.dst_col_stride;
-            for row in 0..shape.rows {
-                let row = row as isize;
-                let lhs_value =
-                    OpA::apply(*lhs_ptr.offset(lhs_batch + row * compact.lhs_row_stride));
-                *dst.offset(dst_col + row * compact.dst_row_stride) = lhs_value * rhs_value;
-            }
-        }
-    }
-}
-
-unsafe fn execute_strided_seq<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    shape: &BatchedOuterShape,
-) -> Result<()>
-where
-    T: Copy + Mul<Output = T>,
-    OpA: ElementOp<T>,
-    OpB: ElementOp<T>,
-{
-    let offsets = StridedOuterOffsets::new(dest, lhs, rhs, shape)?;
-    let dst = dest.as_mut_ptr();
-    let lhs_ptr = lhs.ptr();
-    let rhs_ptr = rhs.ptr();
-    for batch in 0..shape.batches {
-        for col in 0..shape.cols {
-            let rhs_value =
-                OpB::apply(*rhs_ptr.offset(offsets.rhs_batch[batch] + offsets.rhs_col[col]));
-            for row in 0..shape.rows {
-                let lhs_value =
-                    OpA::apply(*lhs_ptr.offset(offsets.lhs_batch[batch] + offsets.lhs_row[row]));
-                *dst.offset(
-                    offsets.dst_batch[batch] + offsets.dst_col[col] + offsets.dst_row[row],
-                ) = lhs_value * rhs_value;
-            }
-        }
-    }
-    Ok(())
-}
-
-#[cfg(feature = "parallel")]
-unsafe fn execute_compact_par<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    shape: &BatchedOuterShape,
-    compact: &CompactBatchedOuter,
-) where
-    T: Copy + Send + Sync + Mul<Output = T>,
-    OpA: ElementOp<T> + Send + Sync,
-    OpB: ElementOp<T> + Send + Sync,
-{
-    use rayon::prelude::*;
-
-    let dst = SendPtr(dest.as_mut_ptr());
-    let lhs_ptr = SendPtr(lhs.ptr() as *mut T);
-    let rhs_ptr = SendPtr(rhs.ptr() as *mut T);
-    let cols = shape.cols;
-    let rows = shape.rows;
-    (0..shape.batches * shape.cols)
-        .into_par_iter()
-        .for_each(|bc| {
-            let batch = (bc / cols) as isize;
-            let col = (bc % cols) as isize;
-            let dst_batch = batch * compact.dst_batch_stride;
-            let lhs_batch = batch * compact.lhs_batch_stride;
-            let rhs_batch = batch * compact.rhs_batch_stride;
-            let rhs_value = unsafe {
-                OpB::apply(
-                    *rhs_ptr
-                        .as_const()
-                        .offset(rhs_batch + col * compact.rhs_col_stride),
-                )
-            };
-            let dst_col = dst_batch + col * compact.dst_col_stride;
-            for row in 0..rows {
-                let row = row as isize;
-                let lhs_value = unsafe {
-                    OpA::apply(
-                        *lhs_ptr
-                            .as_const()
-                            .offset(lhs_batch + row * compact.lhs_row_stride),
-                    )
-                };
-                unsafe {
-                    *dst.as_ptr().offset(dst_col + row * compact.dst_row_stride) =
-                        lhs_value * rhs_value;
-                }
-            }
-        });
-}
-
-#[cfg(feature = "parallel")]
-unsafe fn execute_strided_par<T, OpA, OpB>(
-    dest: &mut StridedViewMut<T>,
-    lhs: &StridedView<T, OpA>,
-    rhs: &StridedView<T, OpB>,
-    shape: &BatchedOuterShape,
-) -> Result<()>
-where
-    T: Copy + Send + Sync + Mul<Output = T>,
-    OpA: ElementOp<T> + Send + Sync,
-    OpB: ElementOp<T> + Send + Sync,
-{
-    use rayon::prelude::*;
-
-    let offsets = StridedOuterOffsets::new(dest, lhs, rhs, shape)?;
-    let dst = SendPtr(dest.as_mut_ptr());
-    let lhs_ptr = SendPtr(lhs.ptr() as *mut T);
-    let rhs_ptr = SendPtr(rhs.ptr() as *mut T);
-    let cols = shape.cols;
-    let rows = shape.rows;
-    (0..shape.batches * shape.cols)
-        .into_par_iter()
-        .for_each(|bc| {
-            let batch = bc / cols;
-            let col = bc % cols;
-            let rhs_value = unsafe {
-                OpB::apply(
-                    *rhs_ptr
-                        .as_const()
-                        .offset(offsets.rhs_batch[batch] + offsets.rhs_col[col]),
-                )
-            };
-            for row in 0..rows {
-                let lhs_value = unsafe {
-                    OpA::apply(
-                        *lhs_ptr
-                            .as_const()
-                            .offset(offsets.lhs_batch[batch] + offsets.lhs_row[row]),
-                    )
-                };
-                unsafe {
-                    *dst.as_ptr().offset(
-                        offsets.dst_batch[batch] + offsets.dst_col[col] + offsets.dst_row[row],
-                    ) = lhs_value * rhs_value;
-                }
-            }
-        });
-    Ok(())
-}
-
-struct StridedOuterOffsets {
-    dst_row: Vec<isize>,
-    dst_col: Vec<isize>,
-    dst_batch: Vec<isize>,
-    lhs_row: Vec<isize>,
-    lhs_batch: Vec<isize>,
-    rhs_col: Vec<isize>,
-    rhs_batch: Vec<isize>,
-}
-
-impl StridedOuterOffsets {
-    fn new<T, OpA, OpB>(
-        dest: &StridedViewMut<T>,
-        lhs: &StridedView<T, OpA>,
-        rhs: &StridedView<T, OpB>,
-        shape: &BatchedOuterShape,
-    ) -> Result<Self> {
-        Ok(Self {
-            dst_row: group_offsets(dest.dims(), dest.strides(), 0, shape.lhs_free_ndim)?,
-            dst_col: group_offsets(
-                dest.dims(),
-                dest.strides(),
-                shape.lhs_free_ndim,
-                shape.lhs_free_ndim + shape.rhs_free_ndim,
-            )?,
-            dst_batch: group_offsets(
-                dest.dims(),
-                dest.strides(),
-                shape.lhs_free_ndim + shape.rhs_free_ndim,
-                dest.ndim(),
-            )?,
-            lhs_row: group_offsets(lhs.dims(), lhs.strides(), 0, shape.lhs_free_ndim)?,
-            lhs_batch: group_offsets(lhs.dims(), lhs.strides(), shape.lhs_free_ndim, lhs.ndim())?,
-            rhs_col: group_offsets(rhs.dims(), rhs.strides(), 0, shape.rhs_free_ndim)?,
-            rhs_batch: group_offsets(rhs.dims(), rhs.strides(), shape.rhs_free_ndim, rhs.ndim())?,
-        })
-    }
-}
-
-fn group_offsets(
-    dims: &[usize],
-    strides: &[isize],
-    start: usize,
-    end: usize,
-) -> Result<Vec<isize>> {
-    let group_dims = &dims[start..end];
-    let group_strides = &strides[start..end];
-    let total = product(group_dims)?;
-    let mut offsets = Vec::with_capacity(total);
-    if group_dims.is_empty() {
-        offsets.push(0);
-        return Ok(offsets);
-    }
-    for mut linear in 0..total {
-        let mut offset = 0isize;
-        for (&dim, &stride) in group_dims.iter().zip(group_strides.iter()) {
-            let idx = linear % dim;
-            linear /= dim;
-            offset = offset
-                .checked_add(
-                    (idx as isize)
-                        .checked_mul(stride)
-                        .ok_or(StridedError::OffsetOverflow)?,
-                )
-                .ok_or(StridedError::OffsetOverflow)?;
-        }
-        offsets.push(offset);
-    }
-    Ok(offsets)
-}
-
-#[cfg(feature = "parallel")]
-#[derive(Clone, Copy)]
-struct SendPtr<T>(*mut T);
-
-#[cfg(feature = "parallel")]
-unsafe impl<T> Send for SendPtr<T> {}
-#[cfg(feature = "parallel")]
-unsafe impl<T> Sync for SendPtr<T> {}
-
-#[cfg(feature = "parallel")]
-impl<T> SendPtr<T> {
-    fn as_ptr(self) -> *mut T {
-        self.0
-    }
-
-    fn as_const(self) -> *const T {
-        self.0 as *const T
+fn ensure_dims(actual: &[usize], expected: &[usize]) -> Result<()> {
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(StridedError::ShapeMismatch(
+            actual.to_vec(),
+            expected.to_vec(),
+        ))
     }
 }

--- a/strided-kernel/src/reduce_view.rs
+++ b/strided-kernel/src/reduce_view.rs
@@ -52,7 +52,10 @@ where
     #[cfg(feature = "parallel")]
     {
         let total = total_len(src_dims);
-        if total > MINTHREADLENGTH && same_contiguous_layout(src_dims, &[src_strides]).is_some() {
+        if total > MINTHREADLENGTH
+            && rayon::current_num_threads() > 1
+            && same_contiguous_layout(src_dims, &[src_strides]).is_some()
+        {
             let src_slice = unsafe { std::slice::from_raw_parts(src_ptr, total) };
             use rayon::prelude::*;
             let nthreads = rayon::current_num_threads();
@@ -81,7 +84,7 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH {
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let nthreads = rayon::current_num_threads();
             // False sharing avoidance: space output slots by cache line size
             let spacing = (64 / std::mem::size_of::<U>()).max(1);

--- a/strided-kernel/src/simd.rs
+++ b/strided-kernel/src/simd.rs
@@ -21,6 +21,484 @@ pub(crate) fn dispatch_if_large<R>(len: usize, f: impl FnOnce() -> R) -> R {
     }
 }
 
+#[cfg(feature = "simd")]
+#[inline(always)]
+unsafe fn cast_slice<T, U>(src: &[T]) -> &[U] {
+    debug_assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
+    unsafe { std::slice::from_raw_parts(src.as_ptr().cast::<U>(), src.len()) }
+}
+
+#[cfg(feature = "simd")]
+#[inline(always)]
+unsafe fn cast_slice_mut<T, U>(src: &mut [T]) -> &mut [U] {
+    debug_assert_eq!(std::mem::size_of::<T>(), std::mem::size_of::<U>());
+    unsafe { std::slice::from_raw_parts_mut(src.as_mut_ptr().cast::<U>(), src.len()) }
+}
+
+#[cfg(feature = "simd")]
+macro_rules! impl_simd_mul_partial {
+    (
+        $mul_into:ident,
+        $ty:ty,
+        $lanes:ident,
+        $load:ident,
+        $store:ident,
+        $mul:ident
+    ) => {
+        fn $mul_into(dst: &mut [$ty], a: &[$ty], b: &[$ty]) {
+            struct Mul<'a> {
+                dst: &'a mut [$ty],
+                a: &'a [$ty],
+                b: &'a [$ty],
+            }
+
+            impl<'a> pulp::WithSimd for Mul<'a> {
+                type Output = ();
+
+                #[inline(always)]
+                fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+                    debug_assert_eq!(self.dst.len(), self.a.len());
+                    debug_assert_eq!(self.dst.len(), self.b.len());
+
+                    let lanes = S::$lanes;
+                    let mut i = 0usize;
+                    while i + lanes <= self.dst.len() {
+                        let va = simd.$load(&self.a[i..i + lanes]);
+                        let vb = simd.$load(&self.b[i..i + lanes]);
+                        simd.$store(&mut self.dst[i..i + lanes], simd.$mul(va, vb));
+                        i += lanes;
+                    }
+                    if i < self.dst.len() {
+                        let va = simd.$load(&self.a[i..]);
+                        let vb = simd.$load(&self.b[i..]);
+                        simd.$store(&mut self.dst[i..], simd.$mul(va, vb));
+                    }
+                }
+            }
+
+            pulp::Arch::new().dispatch(Mul { dst, a, b });
+        }
+    };
+}
+
+#[cfg(feature = "simd")]
+macro_rules! impl_simd_mul_body_tail {
+    (
+        $mul_into:ident,
+        $ty:ty,
+        $as_simd:ident,
+        $as_mut_simd:ident,
+        $load:ident,
+        $store:ident,
+        $mul:ident
+    ) => {
+        fn $mul_into(dst: &mut [$ty], a: &[$ty], b: &[$ty]) {
+            struct Mul<'a> {
+                dst: &'a mut [$ty],
+                a: &'a [$ty],
+                b: &'a [$ty],
+            }
+
+            impl<'a> pulp::WithSimd for Mul<'a> {
+                type Output = ();
+
+                #[inline(always)]
+                fn with_simd<S: pulp::Simd>(self, simd: S) -> Self::Output {
+                    debug_assert_eq!(self.dst.len(), self.a.len());
+                    debug_assert_eq!(self.dst.len(), self.b.len());
+
+                    let (dst_head, dst_tail) = S::$as_mut_simd(self.dst);
+                    let (a_head, a_tail) = S::$as_simd(self.a);
+                    let (b_head, b_tail) = S::$as_simd(self.b);
+                    debug_assert_eq!(dst_head.len(), a_head.len());
+                    debug_assert_eq!(dst_head.len(), b_head.len());
+                    debug_assert_eq!(dst_tail.len(), a_tail.len());
+                    debug_assert_eq!(dst_tail.len(), b_tail.len());
+
+                    for i in 0..dst_head.len() {
+                        dst_head[i] = simd.$mul(a_head[i], b_head[i]);
+                    }
+                    if !dst_tail.is_empty() {
+                        let va = simd.$load(a_tail);
+                        let vb = simd.$load(b_tail);
+                        simd.$store(dst_tail, simd.$mul(va, vb));
+                    }
+                }
+            }
+
+            pulp::Arch::new().dispatch(Mul { dst, a, b });
+        }
+    };
+}
+
+#[cfg(feature = "simd")]
+impl_simd_mul_partial!(
+    simd_mul_f32_into,
+    f32,
+    F32_LANES,
+    partial_load_f32s,
+    partial_store_f32s,
+    mul_f32s
+);
+
+#[cfg(feature = "simd")]
+impl_simd_mul_partial!(
+    simd_mul_f64_into,
+    f64,
+    F64_LANES,
+    partial_load_f64s,
+    partial_store_f64s,
+    mul_f64s
+);
+
+#[cfg(feature = "simd")]
+impl_simd_mul_body_tail!(
+    simd_mul_c32_into,
+    num_complex::Complex32,
+    as_simd_c32s,
+    as_mut_simd_c32s,
+    partial_load_c32s,
+    partial_store_c32s,
+    mul_e_c32s
+);
+
+#[cfg(feature = "simd")]
+impl_simd_mul_body_tail!(
+    simd_mul_c64_into,
+    num_complex::Complex64,
+    as_simd_c64s,
+    as_mut_simd_c64s,
+    partial_load_c64s,
+    partial_store_c64s,
+    mul_e_c64s
+);
+
+#[cfg(feature = "simd")]
+#[inline]
+pub(crate) fn try_mul_contiguous<D: 'static, A: 'static, B: 'static>(
+    dst: &mut [D],
+    a: &[A],
+    b: &[B],
+) -> bool {
+    use std::any::TypeId;
+
+    macro_rules! try_same_type {
+        ($ty:ty, $mul_into:ident) => {
+            if TypeId::of::<D>() == TypeId::of::<$ty>()
+                && TypeId::of::<A>() == TypeId::of::<$ty>()
+                && TypeId::of::<B>() == TypeId::of::<$ty>()
+            {
+                unsafe { $mul_into(cast_slice_mut(dst), cast_slice(a), cast_slice(b)) };
+                return true;
+            }
+        };
+    }
+
+    try_same_type!(f64, simd_mul_f64_into);
+    try_same_type!(f32, simd_mul_f32_into);
+    try_same_type!(num_complex::Complex64, simd_mul_c64_into);
+    try_same_type!(num_complex::Complex32, simd_mul_c32_into);
+
+    false
+}
+
+#[cfg(not(feature = "simd"))]
+#[inline]
+pub(crate) fn try_mul_contiguous<D: 'static, A: 'static, B: 'static>(
+    _dst: &mut [D],
+    _a: &[A],
+    _b: &[B],
+) -> bool {
+    false
+}
+
+#[cfg(feature = "parallel")]
+const TRANSPOSE_TILE: usize = 8;
+
+#[cfg(feature = "parallel")]
+unsafe fn mul_transposed_scalar_rhs_source_contiguous<T>(
+    dst: *mut T,
+    src: *const T,
+    scalar: T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    let mut inner0 = 0usize;
+
+    while inner0 < inner_len {
+        let inner_count = TRANSPOSE_TILE.min(inner_len - inner0);
+        let mut row0 = 0usize;
+
+        while row0 < row_len {
+            let row_count = TRANSPOSE_TILE.min(row_len - row0);
+
+            for inner in 0..inner_count {
+                let src_base = src.offset((inner0 + inner) as isize * src_fast_stride);
+                for row in 0..row_count {
+                    let row_index = row0 + row;
+                    let src_offset = row_index as isize * src_row_stride;
+                    *dst.add(row_index * inner_len + inner0 + inner) =
+                        *src_base.offset(src_offset) * scalar;
+                }
+            }
+
+            row0 += TRANSPOSE_TILE;
+        }
+
+        inner0 += TRANSPOSE_TILE;
+    }
+}
+
+#[cfg(feature = "parallel")]
+unsafe fn mul_transposed_scalar_rhs_dst_contiguous<T>(
+    dst: *mut T,
+    src: *const T,
+    scalar: T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    for row in 0..row_len {
+        let dst_base = dst.add(row * inner_len);
+        let src_base = src.offset(row as isize * src_row_stride);
+        for inner in 0..inner_len {
+            *dst_base.add(inner) = *src_base.offset(inner as isize * src_fast_stride) * scalar;
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+unsafe fn mul_transposed_scalar_lhs_source_contiguous<T>(
+    dst: *mut T,
+    scalar: T,
+    src: *const T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    let mut inner0 = 0usize;
+
+    while inner0 < inner_len {
+        let inner_count = TRANSPOSE_TILE.min(inner_len - inner0);
+        let mut row0 = 0usize;
+
+        while row0 < row_len {
+            let row_count = TRANSPOSE_TILE.min(row_len - row0);
+
+            for inner in 0..inner_count {
+                let src_base = src.offset((inner0 + inner) as isize * src_fast_stride);
+                for row in 0..row_count {
+                    let row_index = row0 + row;
+                    let src_offset = row_index as isize * src_row_stride;
+                    *dst.add(row_index * inner_len + inner0 + inner) =
+                        scalar * *src_base.offset(src_offset);
+                }
+            }
+
+            row0 += TRANSPOSE_TILE;
+        }
+
+        inner0 += TRANSPOSE_TILE;
+    }
+}
+
+#[cfg(feature = "parallel")]
+unsafe fn mul_transposed_scalar_lhs_dst_contiguous<T>(
+    dst: *mut T,
+    scalar: T,
+    src: *const T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    for row in 0..row_len {
+        let dst_base = dst.add(row * inner_len);
+        let src_base = src.offset(row as isize * src_row_stride);
+        for inner in 0..inner_len {
+            *dst_base.add(inner) = scalar * *src_base.offset(inner as isize * src_fast_stride);
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) unsafe fn mul_transposed_scalar_rhs_2d_typed<T>(
+    dst: *mut T,
+    src: *const T,
+    scalar: T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    if row_len > inner_len {
+        unsafe {
+            mul_transposed_scalar_rhs_source_contiguous(
+                dst,
+                src,
+                scalar,
+                inner_len,
+                row_len,
+                src_fast_stride,
+                src_row_stride,
+            );
+        }
+    } else {
+        unsafe {
+            mul_transposed_scalar_rhs_dst_contiguous(
+                dst,
+                src,
+                scalar,
+                inner_len,
+                row_len,
+                src_fast_stride,
+                src_row_stride,
+            );
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) unsafe fn mul_transposed_scalar_lhs_2d_typed<T>(
+    dst: *mut T,
+    scalar: T,
+    src: *const T,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) where
+    T: Copy + std::ops::Mul<Output = T>,
+{
+    if row_len > inner_len {
+        unsafe {
+            mul_transposed_scalar_lhs_source_contiguous(
+                dst,
+                scalar,
+                src,
+                inner_len,
+                row_len,
+                src_fast_stride,
+                src_row_stride,
+            );
+        }
+    } else {
+        unsafe {
+            mul_transposed_scalar_lhs_dst_contiguous(
+                dst,
+                scalar,
+                src,
+                inner_len,
+                row_len,
+                src_fast_stride,
+                src_row_stride,
+            );
+        }
+    }
+}
+
+#[inline]
+#[cfg(feature = "parallel")]
+pub(crate) unsafe fn try_mul_transposed_scalar_rhs_2d<D: 'static, A: 'static, B: 'static>(
+    dst: *mut D,
+    src: *const A,
+    scalar: *const B,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) -> bool {
+    use std::any::TypeId;
+
+    macro_rules! try_same_type {
+        ($ty:ty) => {
+            if TypeId::of::<D>() == TypeId::of::<$ty>()
+                && TypeId::of::<A>() == TypeId::of::<$ty>()
+                && TypeId::of::<B>() == TypeId::of::<$ty>()
+            {
+                unsafe {
+                    mul_transposed_scalar_rhs_2d_typed(
+                        dst.cast::<$ty>(),
+                        src.cast::<$ty>(),
+                        *scalar.cast::<$ty>(),
+                        inner_len,
+                        row_len,
+                        src_fast_stride,
+                        src_row_stride,
+                    );
+                }
+                return true;
+            }
+        };
+    }
+
+    try_same_type!(f64);
+    try_same_type!(f32);
+    try_same_type!(num_complex::Complex64);
+    try_same_type!(num_complex::Complex32);
+
+    false
+}
+
+#[inline]
+#[cfg(feature = "parallel")]
+pub(crate) unsafe fn try_mul_transposed_scalar_lhs_2d<D: 'static, A: 'static, B: 'static>(
+    dst: *mut D,
+    scalar: *const A,
+    src: *const B,
+    inner_len: usize,
+    row_len: usize,
+    src_fast_stride: isize,
+    src_row_stride: isize,
+) -> bool {
+    use std::any::TypeId;
+
+    macro_rules! try_same_type {
+        ($ty:ty) => {
+            if TypeId::of::<D>() == TypeId::of::<$ty>()
+                && TypeId::of::<A>() == TypeId::of::<$ty>()
+                && TypeId::of::<B>() == TypeId::of::<$ty>()
+            {
+                unsafe {
+                    mul_transposed_scalar_lhs_2d_typed(
+                        dst.cast::<$ty>(),
+                        *scalar.cast::<$ty>(),
+                        src.cast::<$ty>(),
+                        inner_len,
+                        row_len,
+                        src_fast_stride,
+                        src_row_stride,
+                    );
+                }
+                return true;
+            }
+        };
+    }
+
+    try_same_type!(f64);
+    try_same_type!(f32);
+    try_same_type!(num_complex::Complex64);
+    try_same_type!(num_complex::Complex32);
+
+    false
+}
+
 /// Trait for types that may have SIMD-accelerated sum/dot operations.
 ///
 /// Default implementations return `None` (no SIMD available).
@@ -227,6 +705,274 @@ mod simd_impls {
             }
 
             Some(pulp::Arch::new().dispatch(Dot { a, b }))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "simd")]
+    #[test]
+    fn test_try_mul_contiguous_complex64() {
+        let a = vec![
+            num_complex::Complex64::new(1.0, 2.0),
+            num_complex::Complex64::new(-3.0, 4.0),
+            num_complex::Complex64::new(0.5, -0.25),
+        ];
+        let b = vec![
+            num_complex::Complex64::new(5.0, -1.0),
+            num_complex::Complex64::new(2.0, 0.25),
+            num_complex::Complex64::new(-4.0, 3.0),
+        ];
+        let mut dst = vec![num_complex::Complex64::new(0.0, 0.0); a.len()];
+
+        assert!(super::try_mul_contiguous(&mut dst, &a, &b));
+        for i in 0..a.len() {
+            assert_eq!(dst[i], a[i] * b[i]);
+        }
+    }
+
+    #[cfg(feature = "simd")]
+    #[test]
+    fn test_try_mul_contiguous_complex32() {
+        let a = vec![
+            num_complex::Complex32::new(1.0, 2.0),
+            num_complex::Complex32::new(-3.0, 4.0),
+            num_complex::Complex32::new(0.5, -0.25),
+        ];
+        let b = vec![
+            num_complex::Complex32::new(5.0, -1.0),
+            num_complex::Complex32::new(2.0, 0.25),
+            num_complex::Complex32::new(-4.0, 3.0),
+        ];
+        let mut dst = vec![num_complex::Complex32::new(0.0, 0.0); a.len()];
+
+        assert!(super::try_mul_contiguous(&mut dst, &a, &b));
+        for i in 0..a.len() {
+            assert_eq!(dst[i], a[i] * b[i]);
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_rhs_2d_f64_source_contiguous() {
+        let inner_len = 5usize;
+        let row_len = 7usize;
+        let src: Vec<f64> = (0..inner_len * row_len).map(|i| i as f64 + 0.25).collect();
+        let scalar = 2.0f64;
+        let mut dst = vec![0.0f64; inner_len * row_len];
+
+        let used = unsafe {
+            super::try_mul_transposed_scalar_rhs_2d::<f64, f64, f64>(
+                dst.as_mut_ptr(),
+                src.as_ptr(),
+                &scalar,
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    dst[row * inner_len + inner],
+                    src[inner * row_len + row] * scalar
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_lhs_2d_f32_source_contiguous() {
+        let inner_len = 5usize;
+        let row_len = 7usize;
+        let src: Vec<f32> = (0..inner_len * row_len)
+            .map(|i| i as f32 * 0.5 + 1.0)
+            .collect();
+        let scalar = 3.0f32;
+        let mut dst = vec![0.0f32; inner_len * row_len];
+
+        let used = unsafe {
+            super::try_mul_transposed_scalar_lhs_2d::<f32, f32, f32>(
+                dst.as_mut_ptr(),
+                &scalar,
+                src.as_ptr(),
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    dst[row * inner_len + inner],
+                    scalar * src[inner * row_len + row]
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_rhs_2d_handles_short_rows() {
+        let inner_len = 8usize;
+        let row_len = 3usize;
+        let src: Vec<f64> = (0..inner_len * row_len).map(|i| i as f64 + 1.0).collect();
+        let scalar = 2.0f64;
+        let mut dst = vec![0.0f64; inner_len * row_len];
+
+        let used = unsafe {
+            super::try_mul_transposed_scalar_rhs_2d::<f64, f64, f64>(
+                dst.as_mut_ptr(),
+                src.as_ptr(),
+                &scalar,
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    dst[row * inner_len + inner],
+                    src[inner * row_len + row] * scalar
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_2d_handles_small_square_tiles() {
+        let inner_len = 4usize;
+        let row_len = 4usize;
+        let src: Vec<f64> = (0..inner_len * row_len).map(|i| i as f64 + 1.0).collect();
+        let scalar = 2.0f64;
+        let mut rhs_dst = vec![0.0f64; inner_len * row_len];
+        let mut lhs_dst = vec![0.0f64; inner_len * row_len];
+
+        let rhs_used = unsafe {
+            super::try_mul_transposed_scalar_rhs_2d::<f64, f64, f64>(
+                rhs_dst.as_mut_ptr(),
+                src.as_ptr(),
+                &scalar,
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+        let lhs_used = unsafe {
+            super::try_mul_transposed_scalar_lhs_2d::<f64, f64, f64>(
+                lhs_dst.as_mut_ptr(),
+                &scalar,
+                src.as_ptr(),
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(rhs_used);
+        assert!(lhs_used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    rhs_dst[row * inner_len + inner],
+                    src[inner * row_len + row] * scalar
+                );
+                assert_eq!(
+                    lhs_dst[row * inner_len + inner],
+                    scalar * src[inner * row_len + row]
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_rhs_2d_complex64_source_contiguous() {
+        let inner_len = 5usize;
+        let row_len = 7usize;
+        let src: Vec<num_complex::Complex64> = (0..inner_len * row_len)
+            .map(|i| num_complex::Complex64::new(i as f64 + 0.25, i as f64 * -0.5))
+            .collect();
+        let scalar = num_complex::Complex64::new(2.0, -0.25);
+        let mut dst = vec![num_complex::Complex64::new(0.0, 0.0); inner_len * row_len];
+
+        let used = unsafe {
+            super::try_mul_transposed_scalar_rhs_2d::<
+                num_complex::Complex64,
+                num_complex::Complex64,
+                num_complex::Complex64,
+            >(
+                dst.as_mut_ptr(),
+                src.as_ptr(),
+                &scalar,
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    dst[row * inner_len + inner],
+                    src[inner * row_len + row] * scalar
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_transposed_scalar_lhs_2d_complex32_source_contiguous() {
+        let inner_len = 5usize;
+        let row_len = 7usize;
+        let src: Vec<num_complex::Complex32> = (0..inner_len * row_len)
+            .map(|i| num_complex::Complex32::new(i as f32 * 0.5 + 1.0, i as f32 * 0.25))
+            .collect();
+        let scalar = num_complex::Complex32::new(3.0, -0.5);
+        let mut dst = vec![num_complex::Complex32::new(0.0, 0.0); inner_len * row_len];
+
+        let used = unsafe {
+            super::try_mul_transposed_scalar_lhs_2d::<
+                num_complex::Complex32,
+                num_complex::Complex32,
+                num_complex::Complex32,
+            >(
+                dst.as_mut_ptr(),
+                &scalar,
+                src.as_ptr(),
+                inner_len,
+                row_len,
+                row_len as isize,
+                1,
+            )
+        };
+
+        assert!(used);
+        for row in 0..row_len {
+            for inner in 0..inner_len {
+                assert_eq!(
+                    dst[row * inner_len + inner],
+                    scalar * src[inner * row_len + row]
+                );
+            }
         }
     }
 }

--- a/strided-kernel/tests/correctness_view.rs
+++ b/strided-kernel/tests/correctness_view.rs
@@ -1,10 +1,13 @@
 use approx::assert_relative_eq;
 use num_complex::Complex64;
 use strided_kernel::{
-    add, axpy, copy_conj, copy_into, copy_scale, copy_transpose_scale_into, dot, fma, map_into,
-    mul, reduce, reduce_axis, sum, symmetrize_conj_into, symmetrize_into, zip_map2_into,
-    zip_map3_into, zip_map4_into, StridedArray, StridedError,
+    add, axpy, batched_outer_product_into, copy_conj, copy_into, copy_scale,
+    copy_transpose_scale_into, dot, fma, map_into, mul, reduce, reduce_axis, sum,
+    symmetrize_conj_into, symmetrize_into, zip_map2_into, zip_map3_into, zip_map4_into,
+    StridedArray, StridedError,
 };
+#[cfg(feature = "parallel")]
+use strided_kernel::{batched_outer_product_into_auto, batched_outer_product_into_par};
 
 fn make_tensor(rows: usize, cols: usize) -> StridedArray<f64> {
     StridedArray::from_fn_row_major(&[rows, cols], |idx| (idx[0] * cols + idx[1]) as f64)
@@ -43,6 +46,81 @@ fn test_zip_map2_mixed_strides() {
         for j in 0..6 {
             let expected = a.get(&[j, i]) + b.get(&[j, i]);
             assert_relative_eq!(out.get(&[i, j]), expected, epsilon = 1e-10);
+        }
+    }
+}
+
+#[test]
+fn test_batched_outer_product_into_compact() {
+    let lhs =
+        StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
+    let rhs =
+        StridedArray::<f64>::from_fn_col_major(&[4, 3], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let mut out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+
+    batched_outer_product_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), 1, 1).unwrap();
+
+    for j in 0..2 {
+        for o in 0..4 {
+            for t in 0..3 {
+                assert_relative_eq!(
+                    out.get(&[j, o, t]),
+                    lhs.get(&[j, t]) * rhs.get(&[o, t]),
+                    epsilon = 1e-10
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_batched_outer_product_into_noncompact() {
+    let lhs_base =
+        StridedArray::<f64>::from_fn_col_major(&[3, 2], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
+    let rhs_base =
+        StridedArray::<f64>::from_fn_col_major(&[3, 4], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let lhs = lhs_base.view().permute(&[1, 0]).unwrap(); // [j,t] with non-compact j group
+    let rhs = rhs_base.view().permute(&[1, 0]).unwrap(); // [o,t] with non-compact o group
+    let mut out_base = StridedArray::<f64>::col_major(&[3, 4, 2]);
+    let mut out = out_base.view_mut().permute(&[2, 1, 0]).unwrap(); // [j,o,t]
+
+    batched_outer_product_into(&mut out, &lhs, &rhs, 1, 1).unwrap();
+
+    for j in 0..2 {
+        for o in 0..4 {
+            for t in 0..3 {
+                assert_relative_eq!(
+                    out.get(&[j, o, t]),
+                    lhs.get(&[j, t]) * rhs.get(&[o, t]),
+                    epsilon = 1e-10
+                );
+            }
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn test_batched_outer_product_into_parallel_apis() {
+    let lhs =
+        StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
+    let rhs =
+        StridedArray::<f64>::from_fn_col_major(&[4, 3], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let mut par_out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+    let mut auto_out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+
+    batched_outer_product_into_par(&mut par_out.view_mut(), &lhs.view(), &rhs.view(), 1, 1)
+        .unwrap();
+    batched_outer_product_into_auto(&mut auto_out.view_mut(), &lhs.view(), &rhs.view(), 1, 1, 1)
+        .unwrap();
+
+    for j in 0..2 {
+        for o in 0..4 {
+            for t in 0..3 {
+                let expected = lhs.get(&[j, t]) * rhs.get(&[o, t]);
+                assert_relative_eq!(par_out.get(&[j, o, t]), expected, epsilon = 1e-10);
+                assert_relative_eq!(auto_out.get(&[j, o, t]), expected, epsilon = 1e-10);
+            }
         }
     }
 }

--- a/strided-kernel/tests/correctness_view.rs
+++ b/strided-kernel/tests/correctness_view.rs
@@ -1,13 +1,11 @@
 use approx::assert_relative_eq;
 use num_complex::Complex64;
 use strided_kernel::{
-    add, axpy, batched_outer_product_into, copy_conj, copy_into, copy_scale,
-    copy_transpose_scale_into, dot, fma, map_into, mul, reduce, reduce_axis, sum,
+    add, axpy, batched_outer_product_into, broadcast_mul_into, copy_conj, copy_into, copy_scale,
+    copy_transpose_scale_into, dot, fma, map_into, mul, mul_into, reduce, reduce_axis, sum,
     symmetrize_conj_into, symmetrize_into, zip_map2_into, zip_map3_into, zip_map4_into,
     StridedArray, StridedError,
 };
-#[cfg(feature = "parallel")]
-use strided_kernel::{batched_outer_product_into_auto, batched_outer_product_into_par};
 
 fn make_tensor(rows: usize, cols: usize) -> StridedArray<f64> {
     StridedArray::from_fn_row_major(&[rows, cols], |idx| (idx[0] * cols + idx[1]) as f64)
@@ -51,6 +49,151 @@ fn test_zip_map2_mixed_strides() {
 }
 
 #[test]
+fn test_mul_into_contiguous() {
+    let a = make_tensor(4, 5);
+    let b = StridedArray::<f64>::from_fn_row_major(&[4, 5], |idx| (1 + idx[0] + 2 * idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[4, 5]);
+
+    mul_into(&mut out.view_mut(), &a.view(), &b.view()).unwrap();
+
+    for i in 0..4 {
+        for j in 0..5 {
+            assert_relative_eq!(
+                out.get(&[i, j]),
+                a.get(&[i, j]) * b.get(&[i, j]),
+                epsilon = 1e-10
+            );
+        }
+    }
+}
+
+#[test]
+fn test_mul_into_broadcast_stride_zero() {
+    let a = StridedArray::<f64>::from_fn_row_major(&[3, 1], |idx| (1 + idx[0]) as f64);
+    let b = StridedArray::<f64>::from_fn_row_major(&[1, 4], |idx| (10 + idx[1]) as f64);
+    let a_broadcast = a.view().broadcast(&[3, 4]).unwrap();
+    let b_broadcast = b.view().broadcast(&[3, 4]).unwrap();
+    let mut out = StridedArray::<f64>::row_major(&[3, 4]);
+
+    mul_into(&mut out.view_mut(), &a_broadcast, &b_broadcast).unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            assert_relative_eq!(
+                out.get(&[i, j]),
+                a.get(&[i, 0]) * b.get(&[0, j]),
+                epsilon = 1e-10
+            );
+        }
+    }
+}
+
+#[test]
+fn test_mul_into_permuted_noncompact() {
+    let a =
+        StridedArray::<f64>::from_fn_row_major(&[5, 4], |idx| (1 + idx[0] * 10 + idx[1]) as f64);
+    let b = StridedArray::<f64>::from_fn_row_major(&[5, 4], |idx| (2 + idx[0] * 7 + idx[1]) as f64);
+    let a_t = a.view().permute(&[1, 0]).unwrap();
+    let b_t = b.view().permute(&[1, 0]).unwrap();
+    let mut out_base = StridedArray::<f64>::row_major(&[5, 4]);
+    let mut out_t = out_base.view_mut().permute(&[1, 0]).unwrap();
+
+    mul_into(&mut out_t, &a_t, &b_t).unwrap();
+
+    for i in 0..4 {
+        for j in 0..5 {
+            assert_relative_eq!(
+                out_t.get(&[i, j]),
+                a_t.get(&[i, j]) * b_t.get(&[i, j]),
+                epsilon = 1e-10
+            );
+        }
+    }
+}
+
+#[test]
+fn test_mul_into_rejects_shape_mismatch() {
+    let a = StridedArray::<f64>::row_major(&[2, 3]);
+    let b = StridedArray::<f64>::row_major(&[3, 2]);
+    let mut out = StridedArray::<f64>::row_major(&[2, 3]);
+
+    let err = mul_into(&mut out.view_mut(), &a.view(), &b.view()).unwrap_err();
+
+    assert!(matches!(err, StridedError::ShapeMismatch(_, _)));
+}
+
+#[test]
+fn test_broadcast_mul_into_maps_source_axes_without_copy() {
+    let lhs =
+        StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
+    let rhs =
+        StridedArray::<f64>::from_fn_col_major(&[4, 3], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let mut out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+
+    broadcast_mul_into(
+        &mut out.view_mut(),
+        &lhs.view(),
+        &[0, 2],
+        &rhs.view(),
+        &[1, 2],
+    )
+    .unwrap();
+
+    for j in 0..2 {
+        for o in 0..4 {
+            for t in 0..3 {
+                assert_relative_eq!(
+                    out.get(&[j, o, t]),
+                    lhs.get(&[j, t]) * rhs.get(&[o, t]),
+                    epsilon = 1e-10
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_broadcast_mul_into_broadcasts_mapped_size_one_axes() {
+    let lhs = StridedArray::<f64>::from_fn_row_major(&[3, 1], |idx| (1 + idx[0]) as f64);
+    let rhs = StridedArray::<f64>::from_fn_row_major(&[1, 4], |idx| (10 + idx[1]) as f64);
+    let mut out = StridedArray::<f64>::row_major(&[3, 4]);
+
+    broadcast_mul_into(
+        &mut out.view_mut(),
+        &lhs.view(),
+        &[0, 1],
+        &rhs.view(),
+        &[0, 1],
+    )
+    .unwrap();
+
+    for i in 0..3 {
+        for j in 0..4 {
+            assert_relative_eq!(
+                out.get(&[i, j]),
+                lhs.get(&[i, 0]) * rhs.get(&[0, j]),
+                epsilon = 1e-10
+            );
+        }
+    }
+}
+
+#[test]
+fn test_broadcast_mul_into_rejects_invalid_axis_map() {
+    let lhs = StridedArray::<f64>::row_major(&[2, 3]);
+    let rhs = StridedArray::<f64>::row_major(&[4]);
+    let mut out = StridedArray::<f64>::row_major(&[2, 4, 3]);
+
+    let err = broadcast_mul_into(&mut out.view_mut(), &lhs.view(), &[0, 3], &rhs.view(), &[1])
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        StridedError::InvalidAxis { axis: 3, rank: 3 }
+    ));
+}
+
+#[test]
 fn test_batched_outer_product_into_compact() {
     let lhs =
         StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
@@ -68,6 +211,28 @@ fn test_batched_outer_product_into_compact() {
                     lhs.get(&[j, t]) * rhs.get(&[o, t]),
                     epsilon = 1e-10
                 );
+            }
+        }
+    }
+}
+
+#[test]
+fn test_batched_outer_product_into_mixed_types() {
+    let lhs = StridedArray::<Complex64>::from_fn_col_major(&[2, 3], |idx| {
+        Complex64::new((1 + idx[0] + 10 * idx[1]) as f64, (2 + idx[0]) as f64)
+    });
+    let rhs =
+        StridedArray::<f64>::from_fn_col_major(&[4, 3], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let mut out = StridedArray::<Complex64>::col_major(&[2, 4, 3]);
+
+    batched_outer_product_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), 1, 1).unwrap();
+
+    for j in 0..2 {
+        for o in 0..4 {
+            for t in 0..3 {
+                let expected = lhs.get(&[j, t]) * rhs.get(&[o, t]);
+                assert_relative_eq!(out.get(&[j, o, t]).re, expected.re, epsilon = 1e-10);
+                assert_relative_eq!(out.get(&[j, o, t]).im, expected.im, epsilon = 1e-10);
             }
         }
     }
@@ -99,30 +264,56 @@ fn test_batched_outer_product_into_noncompact() {
     }
 }
 
-#[cfg(feature = "parallel")]
 #[test]
-fn test_batched_outer_product_into_parallel_apis() {
-    let lhs =
-        StridedArray::<f64>::from_fn_col_major(&[2, 3], |idx| (1 + idx[0] + 10 * idx[1]) as f64);
+fn test_batched_outer_product_into_matches_broadcast_mul_into() {
+    let lhs_base = StridedArray::<f64>::from_fn_col_major(&[3, 2, 5], |idx| {
+        (1 + idx[0] + 10 * idx[1] + 100 * idx[2]) as f64
+    });
+    let lhs = lhs_base.view().permute(&[1, 0, 2]).unwrap();
     let rhs =
-        StridedArray::<f64>::from_fn_col_major(&[4, 3], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
-    let mut par_out = StridedArray::<f64>::col_major(&[2, 4, 3]);
-    let mut auto_out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+        StridedArray::<f64>::from_fn_col_major(&[4, 5], |idx| (2 + idx[0] + 20 * idx[1]) as f64);
+    let mut outer_out = StridedArray::<f64>::col_major(&[2, 3, 4, 5]);
+    let mut broadcast_out = StridedArray::<f64>::col_major(&[2, 3, 4, 5]);
 
-    batched_outer_product_into_par(&mut par_out.view_mut(), &lhs.view(), &rhs.view(), 1, 1)
-        .unwrap();
-    batched_outer_product_into_auto(&mut auto_out.view_mut(), &lhs.view(), &rhs.view(), 1, 1, 1)
-        .unwrap();
+    batched_outer_product_into(&mut outer_out.view_mut(), &lhs, &rhs.view(), 2, 1).unwrap();
+    broadcast_mul_into(
+        &mut broadcast_out.view_mut(),
+        &lhs,
+        &[0, 1, 3],
+        &rhs.view(),
+        &[2, 3],
+    )
+    .unwrap();
 
     for j in 0..2 {
-        for o in 0..4 {
-            for t in 0..3 {
-                let expected = lhs.get(&[j, t]) * rhs.get(&[o, t]);
-                assert_relative_eq!(par_out.get(&[j, o, t]), expected, epsilon = 1e-10);
-                assert_relative_eq!(auto_out.get(&[j, o, t]), expected, epsilon = 1e-10);
+        for k in 0..3 {
+            for o in 0..4 {
+                for t in 0..5 {
+                    assert_relative_eq!(
+                        outer_out.get(&[j, k, o, t]),
+                        broadcast_out.get(&[j, k, o, t]),
+                        epsilon = 1e-10
+                    );
+                }
             }
         }
     }
+}
+
+#[test]
+fn test_batched_outer_product_into_rejects_mismatched_batch_dims() {
+    let lhs = StridedArray::<f64>::col_major(&[2, 3]);
+    let rhs = StridedArray::<f64>::col_major(&[4, 5]);
+    let mut out = StridedArray::<f64>::col_major(&[2, 4, 3]);
+
+    let err = batched_outer_product_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), 1, 1)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        StridedError::ShapeMismatch(actual, expected)
+            if actual == vec![3] && expected == vec![5]
+    ));
 }
 
 #[test]

--- a/strided-opteinsum/Cargo.toml
+++ b/strided-opteinsum/Cargo.toml
@@ -23,6 +23,9 @@ faer = ["strided-einsum2/faer", "strided-einsum2/faer-traits"]
 parallel = ["strided-einsum2/parallel", "strided-kernel/parallel"]
 blas = ["strided-einsum2/blas"]
 blas-inject = ["strided-einsum2/blas-inject"]
+blas-accelerate = ["blas", "strided-einsum2/blas-accelerate"]
+blas-openblas = ["blas", "strided-einsum2/blas-openblas"]
+blas-mkl = ["blas", "strided-einsum2/blas-mkl"]
 
 [dev-dependencies]
 approx.workspace = true

--- a/strided-rs/Cargo.toml
+++ b/strided-rs/Cargo.toml
@@ -49,5 +49,26 @@ blas-inject = [
     "strided-einsum2/blas-inject",
     "strided-opteinsum/blas-inject",
 ]
+blas-accelerate = [
+    "blas",
+    "strided-einsum2/blas-accelerate",
+    "strided-opteinsum/blas-accelerate",
+    "mdarray-opteinsum?/blas-accelerate",
+    "ndarray-opteinsum?/blas-accelerate",
+]
+blas-openblas = [
+    "blas",
+    "strided-einsum2/blas-openblas",
+    "strided-opteinsum/blas-openblas",
+    "mdarray-opteinsum?/blas-openblas",
+    "ndarray-opteinsum?/blas-openblas",
+]
+blas-mkl = [
+    "blas",
+    "strided-einsum2/blas-mkl",
+    "strided-opteinsum/blas-mkl",
+    "mdarray-opteinsum?/blas-mkl",
+    "ndarray-opteinsum?/blas-mkl",
+]
 mdarray = ["dep:mdarray-opteinsum"]
 ndarray = ["dep:ndarray-opteinsum"]

--- a/strided-rs/README.md
+++ b/strided-rs/README.md
@@ -35,6 +35,11 @@ assert_eq!(dest.get(&[1, 2]), 24.0);
 - `faer` (default): enables the `faer` backend for einsum contractions.
 - `parallel`: enables Rayon-backed parallel kernels where available.
 - `blas`: enables the CBLAS backend for einsum contractions.
+- `blas-accelerate`: enables the CBLAS backend and links Apple's Accelerate
+  provider.
+- `blas-openblas`: enables the CBLAS backend and links OpenBLAS.
+- `blas-mkl`: enables the CBLAS backend and links Intel MKL dynamic parallel
+  libraries.
 - `blas-inject`: enables BLAS through `cblas-inject`.
 - `mdarray`: re-exports the `mdarray-opteinsum` frontend as `strided_rs::mdarray`.
 - `ndarray`: re-exports the `ndarray-opteinsum` frontend as `strided_rs::ndarray`.
@@ -47,6 +52,13 @@ features are disabled, enable one backend feature when using einsum APIs or the
 ```toml
 [dependencies]
 strided-rs = { version = "0.1", default-features = false, features = ["blas"] }
+```
+
+Use a provider feature when the BLAS provider should be fixed explicitly:
+
+```toml
+[dependencies]
+strided-rs = { version = "0.1", default-features = false, features = ["blas-openblas"] }
 ```
 
 ## Namespaced APIs


### PR DESCRIPTION
## Summary
- move broadcast multiply / batched outer product / non-conjugated dot-general execution into reusable strided-rs kernels
- add `strided-einsum2::DotGeneralConfig` with borrowed axis slices and BLAS provider feature aliases
- add PyTorch comparison benches and kernel-writing notes for future SIMD/kernel work

## Why
`tenferro-rs` now delegates CPU binary einsum kernels to `strided-rs`, so these paths need to live behind general stride/layout APIs rather than benchmark-specific tenferro shortcuts.

## Notes
- The implementation is stride/layout driven; it does not branch on benchmark names or fixed tensor shapes.
- `docs/superpowers/...` local planning notes were intentionally not committed.

## Verification
- `cargo fmt --check`
- `cargo test -p strided-kernel --features parallel`
- `cargo test -p strided-einsum2 --features parallel,blas-accelerate --no-default-features`
- `git diff --check`
