### PR TITLE
Add backend-neutral raw strided bgemm API

### DIFF
--- a/strided-einsum2/src/backend.rs
+++ b/strided-einsum2/src/backend.rs
@@ -4,6 +4,8 @@
 //! and the `ActiveBackend` type alias that serves as the single point of
 //! backend selection based on Cargo features.
 
+use strided_view::ElementOp;
+
 /// Trait for backends that can execute batched GEMM on contiguous operands.
 ///
 /// Each backend declares its configuration (conjugation materialization,
@@ -70,22 +72,70 @@ pub struct BlasBackend;
 #[allow(dead_code)]
 pub struct NaiveBackend;
 
-impl<T: crate::ScalarBase> Backend<T> for NaiveBackend {
+impl<T> Backend<T> for NaiveBackend
+where
+    T: crate::ScalarBase + strided_view::ElementOpApply,
+{
     const MATERIALIZES_CONJ: bool = false;
     const REQUIRES_UNIT_STRIDE: bool = false;
 
     fn bgemm_contiguous_into(
-        _c: &mut crate::contiguous::ContiguousOperandMut<T>,
-        _a: &crate::contiguous::ContiguousOperand<T>,
-        _b: &crate::contiguous::ContiguousOperand<T>,
-        _batch_dims: &[usize],
-        _m: usize,
-        _n: usize,
-        _k: usize,
-        _alpha: T,
-        _beta: T,
+        c: &mut crate::contiguous::ContiguousOperandMut<T>,
+        a: &crate::contiguous::ContiguousOperand<T>,
+        b: &crate::contiguous::ContiguousOperand<T>,
+        batch_dims: &[usize],
+        m: usize,
+        n: usize,
+        k: usize,
+        alpha: T,
+        beta: T,
     ) -> strided_view::Result<()> {
-        unreachable!("NaiveBackend GEMM is dispatched directly, not through Backend trait")
+        let a_ptr = a.ptr();
+        let b_ptr = b.ptr();
+        let c_ptr = c.ptr();
+        let a_rs = a.row_stride();
+        let a_cs = a.col_stride();
+        let b_rs = b.row_stride();
+        let b_cs = b.col_stride();
+        let c_rs = c.row_stride();
+        let c_cs = c.col_stride();
+
+        let mut batch_iter = crate::util::MultiIndex::new(batch_dims);
+        while batch_iter.next().is_some() {
+            let a_base = batch_iter.offset(a.batch_strides());
+            let b_base = batch_iter.offset(b.batch_strides());
+            let c_base = batch_iter.offset(c.batch_strides());
+
+            for i in 0..m {
+                for j in 0..n {
+                    let mut acc = T::zero();
+                    for l in 0..k {
+                        let mut a_val = unsafe {
+                            *a_ptr.offset(a_base + i as isize * a_rs + l as isize * a_cs)
+                        };
+                        let mut b_val = unsafe {
+                            *b_ptr.offset(b_base + l as isize * b_rs + j as isize * b_cs)
+                        };
+                        if a.conj() {
+                            a_val = strided_view::Conj::apply(a_val);
+                        }
+                        if b.conj() {
+                            b_val = strided_view::Conj::apply(b_val);
+                        }
+                        acc = acc + a_val * b_val;
+                    }
+                    unsafe {
+                        let c_elem = c_ptr.offset(c_base + i as isize * c_rs + j as isize * c_cs);
+                        if beta == T::zero() {
+                            *c_elem = alpha * acc;
+                        } else {
+                            *c_elem = alpha * acc + beta * (*c_elem);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/strided-einsum2/src/bgemm_faer.rs
+++ b/strided-einsum2/src/bgemm_faer.rs
@@ -12,6 +12,119 @@ use faer::{Accum, Conj, Par};
 use faer_traits::ComplexField;
 use strided_view::{StridedArray, StridedView, StridedViewMut};
 
+/// Borrowed raw strided input for GEMM.
+///
+/// Unlike [`StridedView`], this does not allocate owned shape/stride metadata.
+/// Use [`RawStridedRef::new`] for checked construction, or
+/// [`RawStridedRef::new_unchecked`] when a higher-level compiled plan has
+/// already validated the layout.
+#[derive(Clone, Copy, Debug)]
+pub struct RawStridedRef<'a, T> {
+    data: &'a [T],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a, T> RawStridedRef<'a, T> {
+    pub fn new(
+        data: &'a [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> strided_view::Result<Self> {
+        validate_raw_bounds(data.len(), dims, strides, offset)?;
+        Ok(Self {
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Create a raw strided input without bounds checking.
+    ///
+    /// # Safety
+    /// The caller must ensure every index reachable by `dims`/`strides` from
+    /// `offset` lies inside `data`.
+    pub unsafe fn new_unchecked(
+        data: &'a [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Self {
+        Self {
+            data,
+            dims,
+            strides,
+            offset,
+        }
+    }
+
+    #[inline]
+    fn ptr(&self) -> *const T {
+        unsafe { self.data.as_ptr().offset(self.offset) }
+    }
+
+    #[inline]
+    unsafe fn as_view(&self) -> StridedView<'a, T> {
+        StridedView::new_unchecked(self.data, self.dims, self.strides, self.offset)
+    }
+}
+
+/// Borrowed raw strided output for GEMM.
+///
+/// This is the mutable counterpart to [`RawStridedRef`]. It avoids allocating
+/// owned shape/stride metadata in prepared replay paths.
+#[derive(Debug)]
+pub struct RawStridedMut<'a, T> {
+    data: &'a mut [T],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a, T> RawStridedMut<'a, T> {
+    pub fn new(
+        data: &'a mut [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> strided_view::Result<Self> {
+        validate_raw_bounds(data.len(), dims, strides, offset)?;
+        Ok(Self {
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Create a raw strided output without bounds checking.
+    ///
+    /// # Safety
+    /// The caller must ensure every index reachable by `dims`/`strides` from
+    /// `offset` lies inside `data`, and no aliases violate mutable access.
+    pub unsafe fn new_unchecked(
+        data: &'a mut [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Self {
+        Self {
+            data,
+            dims,
+            strides,
+            offset,
+        }
+    }
+
+    #[inline]
+    fn ptr(&mut self) -> *mut T {
+        unsafe { self.data.as_mut_ptr().offset(self.offset) }
+    }
+}
+
 /// Batched strided GEMM using faer: C = alpha * A * B + beta * C
 ///
 /// Same interface as `bgemm_naive::bgemm_strided_into`. Uses faer's optimized
@@ -42,11 +155,96 @@ where
         + num_traits::One
         + PartialEq,
 {
-    let a_dims = a.dims();
-    let b_dims = b.dims();
-    let a_strides = a.strides();
-    let b_strides = b.strides();
-    let c_strides = c.strides();
+    let a = unsafe { RawStridedRef::new_unchecked(a.data(), a.dims(), a.strides(), a.offset()) };
+    let b = unsafe { RawStridedRef::new_unchecked(b.data(), b.dims(), b.strides(), b.offset()) };
+    let c_dims = c.dims().to_vec();
+    let c_strides = c.strides().to_vec();
+    let c_offset = c.offset();
+    let c = unsafe { RawStridedMut::new_unchecked(c.data_mut(), &c_dims, &c_strides, c_offset) };
+    bgemm_raw_strided_into(
+        c, a, b, _n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
+    )
+}
+
+/// Batched strided GEMM on raw borrowed layout metadata.
+///
+/// This is equivalent to [`bgemm_strided_into`], but avoids constructing
+/// [`StridedView`] wrappers when the caller already has borrowed
+/// dims/strides/offset metadata.
+#[allow(clippy::too_many_arguments)]
+pub fn bgemm_raw_strided_into<T>(
+    c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> strided_view::Result<()>
+where
+    T: ComplexField
+        + Copy
+        + strided_view::ElementOpApply
+        + Send
+        + Sync
+        + std::ops::Mul<Output = T>
+        + std::ops::Add<Output = T>
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq,
+{
+    validate_bgemm_shapes(&c, &a, &b, n_batch, n_lo, n_ro, n_sum)?;
+    unsafe {
+        bgemm_raw_strided_into_unchecked(
+            c, a, b, n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
+        )
+    }
+}
+
+/// Batched strided GEMM on raw borrowed layout metadata without validation.
+///
+/// # Safety
+/// The caller must ensure:
+/// - all raw strided operands are in bounds,
+/// - `n_lo`, `n_ro`, `n_sum`, and `n_batch` partition operand ranks as
+///   `[lo, sum, batch]`, `[sum, ro, batch]`, and `[lo, ro, batch]`,
+/// - matching dimension groups have identical extents,
+/// - `c` does not alias `a` or `b` in a way that violates Rust's mutable access.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn bgemm_raw_strided_into_unchecked<T>(
+    mut c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    _n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> strided_view::Result<()>
+where
+    T: ComplexField
+        + Copy
+        + strided_view::ElementOpApply
+        + Send
+        + Sync
+        + std::ops::Mul<Output = T>
+        + std::ops::Add<Output = T>
+        + num_traits::Zero
+        + num_traits::One
+        + PartialEq,
+{
+    let a_dims = a.dims;
+    let b_dims = b.dims;
+    let a_strides = a.strides;
+    let b_strides = b.strides;
+    let c_strides = c.strides;
 
     // Extract dimension groups (batch-last canonical order)
     // A: [lo, sum, batch], B: [sum, ro, batch], C: [lo, ro, batch]
@@ -88,8 +286,8 @@ where
     let a_contig_buf: Option<StridedArray<T>>;
     let (a_ptr, a_row_stride, a_col_stride);
     if a_needs_copy {
-        let mut buf = alloc_col_major_uninit(a.dims());
-        strided_kernel::copy_into(&mut buf.view_mut(), a)?;
+        let mut buf = alloc_col_major_uninit(a.dims);
+        strided_kernel::copy_into(&mut buf.view_mut(), &a.as_view())?;
         a_ptr = buf.view().ptr();
         // Col-major inner A [lo..., sum...]: lo stride = 1, sum stride = m
         a_row_stride = if m == 0 { 0 } else { 1isize };
@@ -112,8 +310,8 @@ where
     let b_contig_buf: Option<StridedArray<T>>;
     let (b_ptr, b_row_stride, b_col_stride);
     if b_needs_copy {
-        let mut buf = alloc_col_major_uninit(b.dims());
-        strided_kernel::copy_into(&mut buf.view_mut(), b)?;
+        let mut buf = alloc_col_major_uninit(b.dims);
+        strided_kernel::copy_into(&mut buf.view_mut(), &b.as_view())?;
         b_ptr = buf.view().ptr();
         // Col-major inner B [sum..., ro...]: sum stride = 1, ro stride = k
         b_row_stride = if k == 0 { 0 } else { 1isize };
@@ -136,9 +334,11 @@ where
     let c_contig_buf: Option<StridedArray<T>>;
     let (c_ptr, c_row_stride, c_col_stride);
     if c_needs_copy {
-        let mut buf = alloc_col_major_uninit(c.dims());
+        let mut buf = alloc_col_major_uninit(c.dims);
         if beta != T::zero() {
-            strided_kernel::copy_into(&mut buf.view_mut(), &c.as_view())?;
+            let c_view: StridedView<'_, T> =
+                StridedView::new_unchecked(&*c.data, c.dims, c.strides, c.offset);
+            strided_kernel::copy_into(&mut buf.view_mut(), &c_view)?;
         }
         c_ptr = buf.view_mut().as_mut_ptr();
         // Col-major inner C [lo..., ro...]: lo stride = 1, ro stride = m
@@ -148,7 +348,7 @@ where
     } else {
         let (_, rs) = fused_c_lo.unwrap();
         let (_, cs) = fused_c_ro.unwrap();
-        c_ptr = c.as_mut_ptr();
+        c_ptr = c.ptr();
         c_row_stride = rs;
         c_col_stride = cs;
         c_contig_buf = None;
@@ -234,9 +434,120 @@ where
 
     // If C was copied to a temp buffer, copy the result back
     if let Some(ref c_buf) = c_contig_buf {
-        strided_kernel::copy_into(c, &c_buf.view())?;
+        let mut c_view = StridedViewMut::new_unchecked(c.data, c.dims, c.strides, c.offset);
+        strided_kernel::copy_into(&mut c_view, &c_buf.view())?;
     }
 
+    Ok(())
+}
+
+fn validate_raw_bounds(
+    len: usize,
+    dims: &[usize],
+    strides: &[isize],
+    offset: isize,
+) -> strided_view::Result<()> {
+    if dims.len() != strides.len() {
+        return Err(strided_view::StridedError::StrideLengthMismatch);
+    }
+    if dims.iter().any(|&dim| dim == 0) {
+        return Ok(());
+    }
+
+    let mut min_offset = offset;
+    let mut max_offset = offset;
+    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+        if dim <= 1 {
+            continue;
+        }
+        let end = stride
+            .checked_mul(dim as isize - 1)
+            .ok_or(strided_view::StridedError::OffsetOverflow)?;
+        if end >= 0 {
+            max_offset = max_offset
+                .checked_add(end)
+                .ok_or(strided_view::StridedError::OffsetOverflow)?;
+        } else {
+            min_offset = min_offset
+                .checked_add(end)
+                .ok_or(strided_view::StridedError::OffsetOverflow)?;
+        }
+    }
+    if min_offset < 0 || max_offset < 0 {
+        return Err(strided_view::StridedError::OffsetOverflow);
+    }
+    if max_offset as usize >= len {
+        return Err(strided_view::StridedError::OffsetOverflow);
+    }
+    Ok(())
+}
+
+fn validate_bgemm_shapes<T>(
+    c: &RawStridedMut<'_, T>,
+    a: &RawStridedRef<'_, T>,
+    b: &RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+) -> strided_view::Result<()> {
+    let a_rank = n_lo + n_sum + n_batch;
+    let b_rank = n_sum + n_ro + n_batch;
+    let c_rank = n_lo + n_ro + n_batch;
+    if a.dims.len() != a_rank {
+        return Err(strided_view::StridedError::RankMismatch(
+            a_rank,
+            a.dims.len(),
+        ));
+    }
+    if b.dims.len() != b_rank {
+        return Err(strided_view::StridedError::RankMismatch(
+            b_rank,
+            b.dims.len(),
+        ));
+    }
+    if c.dims.len() != c_rank {
+        return Err(strided_view::StridedError::RankMismatch(
+            c_rank,
+            c.dims.len(),
+        ));
+    }
+
+    let lo_dims = &a.dims[..n_lo];
+    let sum_dims = &a.dims[n_lo..n_lo + n_sum];
+    let batch_dims = &a.dims[n_lo + n_sum..];
+    let ro_dims = &b.dims[n_sum..n_sum + n_ro];
+
+    if &b.dims[..n_sum] != sum_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            sum_dims.to_vec(),
+            b.dims[..n_sum].to_vec(),
+        ));
+    }
+    if &b.dims[n_sum + n_ro..] != batch_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            batch_dims.to_vec(),
+            b.dims[n_sum + n_ro..].to_vec(),
+        ));
+    }
+    if &c.dims[..n_lo] != lo_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            lo_dims.to_vec(),
+            c.dims[..n_lo].to_vec(),
+        ));
+    }
+    if &c.dims[n_lo..n_lo + n_ro] != ro_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            ro_dims.to_vec(),
+            c.dims[n_lo..n_lo + n_ro].to_vec(),
+        ));
+    }
+    if &c.dims[n_lo + n_ro..] != batch_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            batch_dims.to_vec(),
+            c.dims[n_lo + n_ro..].to_vec(),
+        ));
+    }
     Ok(())
 }
 
@@ -430,6 +741,111 @@ mod tests {
         assert_eq!(c.get(&[0, 1]), 22.0);
         assert_eq!(c.get(&[1, 0]), 43.0);
         assert_eq!(c.get(&[1, 1]), 50.0);
+    }
+
+    fn raw_bgemm_2x2<T>(one: T, zero: T) -> Vec<T>
+    where
+        T: ComplexField
+            + Copy
+            + strided_view::ElementOpApply
+            + Send
+            + Sync
+            + std::ops::Mul<Output = T>
+            + std::ops::Add<Output = T>
+            + num_traits::Zero
+            + num_traits::One
+            + PartialEq
+            + From<f32>,
+    {
+        let dims = [2, 2];
+        let strides = [2, 1];
+        let a_data = [T::from(1.0), T::from(2.0), T::from(3.0), T::from(4.0)];
+        let b_data = [T::from(5.0), T::from(6.0), T::from(7.0), T::from(8.0)];
+        let mut c_data = vec![zero; 4];
+        let a = RawStridedRef::new(&a_data, &dims, &strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &dims, &strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &dims, &strides, 0).unwrap();
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, one, zero, false, false).unwrap();
+        c_data
+    }
+
+    #[test]
+    fn test_faer_raw_bgemm_f64() {
+        assert_eq!(raw_bgemm_2x2(1.0f64, 0.0), vec![19.0, 22.0, 43.0, 50.0]);
+    }
+
+    #[test]
+    fn test_faer_raw_bgemm_f32() {
+        assert_eq!(raw_bgemm_2x2(1.0f32, 0.0), vec![19.0f32, 22.0, 43.0, 50.0]);
+    }
+
+    #[test]
+    fn test_faer_raw_bgemm_complex_conj() {
+        use num_complex::Complex64;
+
+        let i = Complex64::i();
+        let dims = [2, 2];
+        let strides = [2, 1];
+        let a_data = [
+            Complex64::new(1.0, 0.0) + i,
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0) - i,
+        ];
+        let b_data = [
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ];
+        let mut c_data = vec![Complex64::new(0.0, 0.0); 4];
+        let a = RawStridedRef::new(&a_data, &dims, &strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &dims, &strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &dims, &strides, 0).unwrap();
+        bgemm_raw_strided_into(
+            c,
+            a,
+            b,
+            0,
+            1,
+            1,
+            1,
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            c_data,
+            vec![
+                Complex64::new(1.0, -1.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+                Complex64::new(4.0, 1.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_faer_raw_bgemm_checked_shape_mismatch() {
+        let a_dims = [2, 2];
+        let b_dims = [3, 2];
+        let c_dims = [2, 2];
+        let a_strides = [2, 1];
+        let b_strides = [2, 1];
+        let c_strides = [2, 1];
+        let a_data = [1.0, 2.0, 3.0, 4.0];
+        let b_data = [0.0; 6];
+        let mut c_data = [0.0; 4];
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+        let err = bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false).unwrap_err();
+        assert!(matches!(
+            err,
+            strided_view::StridedError::ShapeMismatch(_, _)
+        ));
     }
 
     #[test]

--- a/strided-einsum2/src/bgemm_faer.rs
+++ b/strided-einsum2/src/bgemm_faer.rs
@@ -140,6 +140,10 @@ where
     let batch_dims = &a_dims[n_lo + n_sum..];
     let ro_dims = &b_dims[n_sum..n_sum + n_ro];
 
+    if c.dims().iter().any(|&dim| dim == 0) {
+        return Ok(());
+    }
+
     // Fused sizes for the matrix multiply
     let m: usize = lo_dims.iter().product::<usize>().max(1);
     let k: usize = sum_dims.iter().product::<usize>().max(1);

--- a/strided-einsum2/src/bgemm_faer.rs
+++ b/strided-einsum2/src/bgemm_faer.rs
@@ -10,120 +10,7 @@ use faer::linalg::matmul::matmul_with_conj;
 use faer::mat::{MatMut, MatRef};
 use faer::{Accum, Conj, Par};
 use faer_traits::ComplexField;
-use strided_view::{StridedArray, StridedView, StridedViewMut};
-
-/// Borrowed raw strided input for GEMM.
-///
-/// Unlike [`StridedView`], this does not allocate owned shape/stride metadata.
-/// Use [`RawStridedRef::new`] for checked construction, or
-/// [`RawStridedRef::new_unchecked`] when a higher-level compiled plan has
-/// already validated the layout.
-#[derive(Clone, Copy, Debug)]
-pub struct RawStridedRef<'a, T> {
-    data: &'a [T],
-    dims: &'a [usize],
-    strides: &'a [isize],
-    offset: isize,
-}
-
-impl<'a, T> RawStridedRef<'a, T> {
-    pub fn new(
-        data: &'a [T],
-        dims: &'a [usize],
-        strides: &'a [isize],
-        offset: isize,
-    ) -> strided_view::Result<Self> {
-        validate_raw_bounds(data.len(), dims, strides, offset)?;
-        Ok(Self {
-            data,
-            dims,
-            strides,
-            offset,
-        })
-    }
-
-    /// Create a raw strided input without bounds checking.
-    ///
-    /// # Safety
-    /// The caller must ensure every index reachable by `dims`/`strides` from
-    /// `offset` lies inside `data`.
-    pub unsafe fn new_unchecked(
-        data: &'a [T],
-        dims: &'a [usize],
-        strides: &'a [isize],
-        offset: isize,
-    ) -> Self {
-        Self {
-            data,
-            dims,
-            strides,
-            offset,
-        }
-    }
-
-    #[inline]
-    fn ptr(&self) -> *const T {
-        unsafe { self.data.as_ptr().offset(self.offset) }
-    }
-
-    #[inline]
-    unsafe fn as_view(&self) -> StridedView<'a, T> {
-        StridedView::new_unchecked(self.data, self.dims, self.strides, self.offset)
-    }
-}
-
-/// Borrowed raw strided output for GEMM.
-///
-/// This is the mutable counterpart to [`RawStridedRef`]. It avoids allocating
-/// owned shape/stride metadata in prepared replay paths.
-#[derive(Debug)]
-pub struct RawStridedMut<'a, T> {
-    data: &'a mut [T],
-    dims: &'a [usize],
-    strides: &'a [isize],
-    offset: isize,
-}
-
-impl<'a, T> RawStridedMut<'a, T> {
-    pub fn new(
-        data: &'a mut [T],
-        dims: &'a [usize],
-        strides: &'a [isize],
-        offset: isize,
-    ) -> strided_view::Result<Self> {
-        validate_raw_bounds(data.len(), dims, strides, offset)?;
-        Ok(Self {
-            data,
-            dims,
-            strides,
-            offset,
-        })
-    }
-
-    /// Create a raw strided output without bounds checking.
-    ///
-    /// # Safety
-    /// The caller must ensure every index reachable by `dims`/`strides` from
-    /// `offset` lies inside `data`, and no aliases violate mutable access.
-    pub unsafe fn new_unchecked(
-        data: &'a mut [T],
-        dims: &'a [usize],
-        strides: &'a [isize],
-        offset: isize,
-    ) -> Self {
-        Self {
-            data,
-            dims,
-            strides,
-            offset,
-        }
-    }
-
-    #[inline]
-    fn ptr(&mut self) -> *mut T {
-        unsafe { self.data.as_mut_ptr().offset(self.offset) }
-    }
-}
+use strided_view::{RawStridedMut, RawStridedRef, StridedArray, StridedView, StridedViewMut};
 
 /// Batched strided GEMM using faer: C = alpha * A * B + beta * C
 ///
@@ -172,7 +59,7 @@ where
 /// [`StridedView`] wrappers when the caller already has borrowed
 /// dims/strides/offset metadata.
 #[allow(clippy::too_many_arguments)]
-pub fn bgemm_raw_strided_into<T>(
+pub(crate) fn bgemm_raw_strided_into<T>(
     c: RawStridedMut<'_, T>,
     a: RawStridedRef<'_, T>,
     b: RawStridedRef<'_, T>,
@@ -215,7 +102,7 @@ where
 /// - matching dimension groups have identical extents,
 /// - `c` does not alias `a` or `b` in a way that violates Rust's mutable access.
 #[allow(clippy::too_many_arguments)]
-pub unsafe fn bgemm_raw_strided_into_unchecked<T>(
+pub(crate) unsafe fn bgemm_raw_strided_into_unchecked<T>(
     mut c: RawStridedMut<'_, T>,
     a: RawStridedRef<'_, T>,
     b: RawStridedRef<'_, T>,
@@ -240,11 +127,11 @@ where
         + num_traits::One
         + PartialEq,
 {
-    let a_dims = a.dims;
-    let b_dims = b.dims;
-    let a_strides = a.strides;
-    let b_strides = b.strides;
-    let c_strides = c.strides;
+    let a_dims = a.dims();
+    let b_dims = b.dims();
+    let a_strides = a.strides();
+    let b_strides = b.strides();
+    let c_strides = c.strides();
 
     // Extract dimension groups (batch-last canonical order)
     // A: [lo, sum, batch], B: [sum, ro, batch], C: [lo, ro, batch]
@@ -286,7 +173,7 @@ where
     let a_contig_buf: Option<StridedArray<T>>;
     let (a_ptr, a_row_stride, a_col_stride);
     if a_needs_copy {
-        let mut buf = alloc_col_major_uninit(a.dims);
+        let mut buf = alloc_col_major_uninit(a.dims());
         strided_kernel::copy_into(&mut buf.view_mut(), &a.as_view())?;
         a_ptr = buf.view().ptr();
         // Col-major inner A [lo..., sum...]: lo stride = 1, sum stride = m
@@ -310,7 +197,7 @@ where
     let b_contig_buf: Option<StridedArray<T>>;
     let (b_ptr, b_row_stride, b_col_stride);
     if b_needs_copy {
-        let mut buf = alloc_col_major_uninit(b.dims);
+        let mut buf = alloc_col_major_uninit(b.dims());
         strided_kernel::copy_into(&mut buf.view_mut(), &b.as_view())?;
         b_ptr = buf.view().ptr();
         // Col-major inner B [sum..., ro...]: sum stride = 1, ro stride = k
@@ -334,10 +221,9 @@ where
     let c_contig_buf: Option<StridedArray<T>>;
     let (c_ptr, c_row_stride, c_col_stride);
     if c_needs_copy {
-        let mut buf = alloc_col_major_uninit(c.dims);
+        let mut buf = alloc_col_major_uninit(c.dims());
         if beta != T::zero() {
-            let c_view: StridedView<'_, T> =
-                StridedView::new_unchecked(&*c.data, c.dims, c.strides, c.offset);
+            let c_view: StridedView<'_, T> = c.as_view();
             strided_kernel::copy_into(&mut buf.view_mut(), &c_view)?;
         }
         c_ptr = buf.view_mut().as_mut_ptr();
@@ -348,7 +234,7 @@ where
     } else {
         let (_, rs) = fused_c_lo.unwrap();
         let (_, cs) = fused_c_ro.unwrap();
-        c_ptr = c.ptr();
+        c_ptr = c.as_mut_ptr();
         c_row_stride = rs;
         c_col_stride = cs;
         c_contig_buf = None;
@@ -434,51 +320,10 @@ where
 
     // If C was copied to a temp buffer, copy the result back
     if let Some(ref c_buf) = c_contig_buf {
-        let mut c_view = StridedViewMut::new_unchecked(c.data, c.dims, c.strides, c.offset);
+        let mut c_view = c.as_view_mut();
         strided_kernel::copy_into(&mut c_view, &c_buf.view())?;
     }
 
-    Ok(())
-}
-
-fn validate_raw_bounds(
-    len: usize,
-    dims: &[usize],
-    strides: &[isize],
-    offset: isize,
-) -> strided_view::Result<()> {
-    if dims.len() != strides.len() {
-        return Err(strided_view::StridedError::StrideLengthMismatch);
-    }
-    if dims.iter().any(|&dim| dim == 0) {
-        return Ok(());
-    }
-
-    let mut min_offset = offset;
-    let mut max_offset = offset;
-    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
-        if dim <= 1 {
-            continue;
-        }
-        let end = stride
-            .checked_mul(dim as isize - 1)
-            .ok_or(strided_view::StridedError::OffsetOverflow)?;
-        if end >= 0 {
-            max_offset = max_offset
-                .checked_add(end)
-                .ok_or(strided_view::StridedError::OffsetOverflow)?;
-        } else {
-            min_offset = min_offset
-                .checked_add(end)
-                .ok_or(strided_view::StridedError::OffsetOverflow)?;
-        }
-    }
-    if min_offset < 0 || max_offset < 0 {
-        return Err(strided_view::StridedError::OffsetOverflow);
-    }
-    if max_offset as usize >= len {
-        return Err(strided_view::StridedError::OffsetOverflow);
-    }
     Ok(())
 }
 
@@ -494,58 +339,58 @@ fn validate_bgemm_shapes<T>(
     let a_rank = n_lo + n_sum + n_batch;
     let b_rank = n_sum + n_ro + n_batch;
     let c_rank = n_lo + n_ro + n_batch;
-    if a.dims.len() != a_rank {
+    if a.dims().len() != a_rank {
         return Err(strided_view::StridedError::RankMismatch(
             a_rank,
-            a.dims.len(),
+            a.dims().len(),
         ));
     }
-    if b.dims.len() != b_rank {
+    if b.dims().len() != b_rank {
         return Err(strided_view::StridedError::RankMismatch(
             b_rank,
-            b.dims.len(),
+            b.dims().len(),
         ));
     }
-    if c.dims.len() != c_rank {
+    if c.dims().len() != c_rank {
         return Err(strided_view::StridedError::RankMismatch(
             c_rank,
-            c.dims.len(),
+            c.dims().len(),
         ));
     }
 
-    let lo_dims = &a.dims[..n_lo];
-    let sum_dims = &a.dims[n_lo..n_lo + n_sum];
-    let batch_dims = &a.dims[n_lo + n_sum..];
-    let ro_dims = &b.dims[n_sum..n_sum + n_ro];
+    let lo_dims = &a.dims()[..n_lo];
+    let sum_dims = &a.dims()[n_lo..n_lo + n_sum];
+    let batch_dims = &a.dims()[n_lo + n_sum..];
+    let ro_dims = &b.dims()[n_sum..n_sum + n_ro];
 
-    if &b.dims[..n_sum] != sum_dims {
+    if &b.dims()[..n_sum] != sum_dims {
         return Err(strided_view::StridedError::ShapeMismatch(
             sum_dims.to_vec(),
-            b.dims[..n_sum].to_vec(),
+            b.dims()[..n_sum].to_vec(),
         ));
     }
-    if &b.dims[n_sum + n_ro..] != batch_dims {
+    if &b.dims()[n_sum + n_ro..] != batch_dims {
         return Err(strided_view::StridedError::ShapeMismatch(
             batch_dims.to_vec(),
-            b.dims[n_sum + n_ro..].to_vec(),
+            b.dims()[n_sum + n_ro..].to_vec(),
         ));
     }
-    if &c.dims[..n_lo] != lo_dims {
+    if &c.dims()[..n_lo] != lo_dims {
         return Err(strided_view::StridedError::ShapeMismatch(
             lo_dims.to_vec(),
-            c.dims[..n_lo].to_vec(),
+            c.dims()[..n_lo].to_vec(),
         ));
     }
-    if &c.dims[n_lo..n_lo + n_ro] != ro_dims {
+    if &c.dims()[n_lo..n_lo + n_ro] != ro_dims {
         return Err(strided_view::StridedError::ShapeMismatch(
             ro_dims.to_vec(),
-            c.dims[n_lo..n_lo + n_ro].to_vec(),
+            c.dims()[n_lo..n_lo + n_ro].to_vec(),
         ));
     }
-    if &c.dims[n_lo + n_ro..] != batch_dims {
+    if &c.dims()[n_lo + n_ro..] != batch_dims {
         return Err(strided_view::StridedError::ShapeMismatch(
             batch_dims.to_vec(),
-            c.dims[n_lo + n_ro..].to_vec(),
+            c.dims()[n_lo + n_ro..].to_vec(),
         ));
     }
     Ok(())

--- a/strided-einsum2/src/contiguous.rs
+++ b/strided-einsum2/src/contiguous.rs
@@ -8,7 +8,7 @@ use crate::ScalarBase;
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use strided_view::{StridedArray, StridedView, StridedViewMut};
+use strided_view::{RawStridedMut, RawStridedRef, StridedArray, StridedView, StridedViewMut};
 
 /// GEMM-ready input operand with contiguous data.
 pub struct ContiguousOperand<T: Copy + 'static> {
@@ -231,6 +231,20 @@ impl<T: Copy + Send + Sync> ContiguousOperandMut<T> {
         if self.needs_writeback {
             if let Some(ref buf) = self._buf {
                 strided_perm::copy_into(dest, &buf.view())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// After GEMM: copy the internal buffer back to a raw destination if needed.
+    ///
+    /// This mirrors [`Self::finalize_into`] for prepared replay paths that use
+    /// borrowed raw layout metadata instead of owned-metadata views.
+    pub fn finalize_raw_into(self, dest: &mut RawStridedMut<'_, T>) -> crate::Result<()> {
+        if self.needs_writeback {
+            if let Some(ref buf) = self._buf {
+                let mut dest_view = dest.as_view_mut();
+                strided_perm::copy_into(&mut dest_view, &buf.view())?;
             }
         }
         Ok(())
@@ -463,6 +477,79 @@ pub fn prepare_input_view<T: ScalarBase + 'static>(
     }
 }
 
+/// Prepare a borrowed raw input layout for GEMM.
+///
+/// This is the raw-layout counterpart to [`prepare_input_view`]. Direct
+/// fusable layouts do not construct `StridedView` wrappers; a view is created
+/// only when a copy/materialization path needs to call a generic strided kernel.
+pub fn prepare_input_raw<T: ScalarBase + 'static>(
+    view: &RawStridedRef<'_, T>,
+    n_group1: usize,
+    n_group2: usize,
+    conj: bool,
+    requires_unit_stride: bool,
+    use_pool: bool,
+    materialize_conj_fn: Option<fn(T) -> T>,
+) -> crate::Result<ContiguousOperand<T>> {
+    let dims = view.dims();
+    let strides = view.strides();
+    let n_inner = n_group1 + n_group2;
+
+    if let Some(conj_fn) = materialize_conj_fn {
+        if conj {
+            let (mut buf, buf_is_pooled) = alloc_maybe_pooled(dims, use_pool);
+            strided_kernel::map_into(&mut buf.view_mut(), &view.as_view(), conj_fn)?;
+            let ptr = buf.view().ptr();
+            let (row_stride, col_stride, batch_strides) = col_major_layout(&buf, n_group1, n_inner);
+            return Ok(ContiguousOperand {
+                ptr,
+                row_stride,
+                col_stride,
+                batch_strides,
+                conj: false,
+                _buf: Some(buf),
+                buf_is_pooled,
+            });
+        }
+    }
+
+    let check = check_contiguity(
+        &dims[..n_group1],
+        &strides[..n_group1],
+        &dims[n_group1..n_inner],
+        &strides[n_group1..n_inner],
+        requires_unit_stride,
+    );
+
+    if check.needs_copy {
+        let (mut buf, buf_is_pooled) = alloc_maybe_pooled(dims, use_pool);
+        strided_kernel::copy_into_col_major(&mut buf.view_mut(), &view.as_view())?;
+        let ptr = buf.view().ptr();
+        let (row_stride, col_stride, batch_strides) = col_major_layout(&buf, n_group1, n_inner);
+        Ok(ContiguousOperand {
+            ptr,
+            row_stride,
+            col_stride,
+            batch_strides,
+            conj,
+            _buf: Some(buf),
+            buf_is_pooled,
+        })
+    } else {
+        let (_, rs) = check.fused_g1.unwrap();
+        let (_, cs) = check.fused_g2.unwrap();
+        Ok(ContiguousOperand {
+            ptr: view.ptr(),
+            row_stride: rs,
+            col_stride: cs,
+            batch_strides: strides[n_inner..].to_vec(),
+            conj,
+            _buf: None,
+            buf_is_pooled: false,
+        })
+    }
+}
+
 /// Prepare an owned input array for GEMM.
 ///
 /// Expects batch-last canonical order: `[group1..., group2..., batch...]`.
@@ -558,6 +645,62 @@ pub fn prepare_input_owned<T: ScalarBase + 'static>(
 /// the returned operand and that no aliasing mutable references exist during GEMM.
 pub fn prepare_output_view<T: ScalarBase + 'static>(
     view: &mut StridedViewMut<T>,
+    n_group1: usize,
+    n_group2: usize,
+    beta: T,
+    requires_unit_stride: bool,
+    use_pool: bool,
+) -> crate::Result<ContiguousOperandMut<T>> {
+    let dims = view.dims().to_vec();
+    let strides = view.strides().to_vec();
+    let n_inner = n_group1 + n_group2;
+
+    let check = check_contiguity(
+        &dims[..n_group1],
+        &strides[..n_group1],
+        &dims[n_group1..n_inner],
+        &strides[n_group1..n_inner],
+        requires_unit_stride,
+    );
+
+    if check.needs_copy {
+        let (mut buf, buf_is_pooled) = alloc_maybe_pooled(&dims, use_pool);
+        if beta != T::zero() {
+            strided_kernel::copy_into_col_major(&mut buf.view_mut(), &view.as_view())?;
+        }
+        let ptr = buf.view_mut().as_mut_ptr();
+        let (row_stride, col_stride, batch_strides) = col_major_layout(&buf, n_group1, n_inner);
+        Ok(ContiguousOperandMut {
+            ptr,
+            row_stride,
+            col_stride,
+            batch_strides,
+            needs_writeback: true,
+            _buf: Some(buf),
+            buf_is_pooled,
+        })
+    } else {
+        let (_, rs) = check.fused_g1.unwrap();
+        let (_, cs) = check.fused_g2.unwrap();
+        Ok(ContiguousOperandMut {
+            ptr: view.as_mut_ptr(),
+            row_stride: rs,
+            col_stride: cs,
+            batch_strides: strides[n_inner..].to_vec(),
+            needs_writeback: false,
+            _buf: None,
+            buf_is_pooled: false,
+        })
+    }
+}
+
+/// Prepare a borrowed raw output layout for GEMM.
+///
+/// This is the raw-layout counterpart to [`prepare_output_view`]. Direct
+/// fusable layouts do not construct `StridedViewMut` wrappers; a view is
+/// created only when a copy/writeback path needs a generic strided kernel.
+pub fn prepare_output_raw<T: ScalarBase + 'static>(
+    view: &mut RawStridedMut<'_, T>,
     n_group1: usize,
     n_group2: usize,
     beta: T,

--- a/strided-einsum2/src/lib.rs
+++ b/strided-einsum2/src/lib.rs
@@ -53,6 +53,8 @@ pub mod contiguous;
 pub mod dot_general;
 /// Contraction planning: axis classification and permutation computation.
 pub mod plan;
+/// Raw borrowed-layout batched GEMM entry points.
+pub mod raw_bgemm;
 /// Trace-axis reduction (summing axes that appear only in one operand).
 pub mod trace;
 /// Shared helpers (permutation inversion, multi-index iteration, dimension fusion).
@@ -71,11 +73,17 @@ use strided_view::StridedArray;
 use strided_view::{Adjoint, Conj, ElementOp, ElementOpApply};
 
 pub use strided_traits::ScalarBase;
-pub use strided_view::{col_major_strides, StridedView, StridedViewMut};
+pub use strided_view::{
+    col_major_strides, RawStridedMut, RawStridedRef, StridedView, StridedViewMut,
+};
 
 pub use backend::Backend;
 pub use dot_general::{dot_general_into, dot_general_with_backend_into, DotGeneralConfig};
 pub use plan::Einsum2Plan;
+pub use raw_bgemm::{
+    bgemm_raw_strided_into, bgemm_raw_strided_into_unchecked, bgemm_raw_with_backend_into,
+    bgemm_raw_with_backend_into_unchecked,
+};
 
 /// Trait alias for axis label types.
 pub trait AxisId: Clone + Eq + Hash + Debug {}

--- a/strided-einsum2/src/raw_bgemm.rs
+++ b/strided-einsum2/src/raw_bgemm.rs
@@ -390,4 +390,92 @@ mod tests {
             crate::EinsumError::Strided(strided_view::StridedError::ShapeMismatch(_, _))
         ));
     }
+
+    #[test]
+    fn raw_bgemm_explicit_backend_checked_rank_mismatch() {
+        let a_dims = [2, 2];
+        let b_dims = [2, 2];
+        let c_dims = [2];
+        let strides = [2, 1];
+        let c_strides = [1];
+        let a_data = [1.0, 2.0, 3.0, 4.0];
+        let b_data = [5.0, 6.0, 7.0, 8.0];
+        let mut c_data = [0.0; 2];
+        let a = RawStridedRef::new(&a_data, &a_dims, &strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+        let err = bgemm_raw_with_backend_into::<f64, crate::backend::ActiveBackend>(
+            c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::EinsumError::Strided(strided_view::StridedError::RankMismatch(2, 1))
+        ));
+    }
+
+    #[test]
+    fn raw_bgemm_zero_sum_scales_destination() {
+        let a_dims = [2, 0];
+        let b_dims = [0, 2];
+        let c_dims = [2, 2];
+        let a_strides = [0, 0];
+        let b_strides = [0, 0];
+        let c_strides = [2, 1];
+        let a_data = [0.0; 1];
+        let b_data = [0.0; 1];
+        let mut c_data = [1.0, 2.0, 3.0, 4.0];
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 2.0, false, false).unwrap();
+
+        assert_eq!(c_data, [2.0, 4.0, 6.0, 8.0]);
+    }
+
+    #[test]
+    fn raw_bgemm_zero_sum_beta_zero_clears_destination() {
+        let a_dims = [2, 0];
+        let b_dims = [0, 2];
+        let c_dims = [2, 2];
+        let a_strides = [0, 0];
+        let b_strides = [0, 0];
+        let c_strides = [2, 1];
+        let a_data = [0.0; 1];
+        let b_data = [0.0; 1];
+        let mut c_data = [1.0, 2.0, 3.0, 4.0];
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false).unwrap();
+
+        assert_eq!(c_data, [0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn raw_bgemm_noncontiguous_output_writes_back() {
+        let a_dims = [2, 2];
+        let b_dims = [2, 2];
+        let c_dims = [2, 2];
+        let a_strides = [2, 1];
+        let b_strides = [2, 1];
+        let c_strides = [1, 3];
+        let a_data = [1.0, 2.0, 3.0, 4.0];
+        let b_data = [5.0, 6.0, 7.0, 8.0];
+        let mut c_data = [0.0; 8];
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 1).unwrap();
+
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false).unwrap();
+
+        assert_eq!(c_data[1], 19.0);
+        assert_eq!(c_data[4], 22.0);
+        assert_eq!(c_data[2], 43.0);
+        assert_eq!(c_data[5], 50.0);
+        assert_eq!(c_data[0], 0.0);
+        assert_eq!(c_data[3], 0.0);
+    }
 }

--- a/strided-einsum2/src/raw_bgemm.rs
+++ b/strided-einsum2/src/raw_bgemm.rs
@@ -134,6 +134,9 @@ where
     let batch_dims = &a_dims[n_lo + n_sum..];
     let ro_dims = &b_dims[n_sum..n_sum + n_ro];
 
+    if c.dims().iter().any(|&dim| dim == 0) {
+        return Ok(());
+    }
     if sum_dims.iter().any(|&dim| dim == 0) {
         scale_or_zero_raw_mut(&mut c, beta);
         return Ok(());
@@ -452,6 +455,27 @@ mod tests {
         bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false).unwrap();
 
         assert_eq!(c_data, [0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn raw_bgemm_empty_output_is_noop() {
+        let a_dims = [0, 2];
+        let b_dims = [2, 2];
+        let c_dims = [0, 2];
+        let a_strides = [2, 1];
+        let b_strides = [2, 1];
+        let c_strides = [2, 1];
+        let a_data = [1.0, 2.0];
+        let b_data = [3.0, 4.0, 5.0, 6.0];
+        let mut c_data = [7.0, 8.0, 9.0, 10.0];
+        let expected = c_data;
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 1.0, false, false).unwrap();
+
+        assert_eq!(c_data, expected);
     }
 
     #[test]

--- a/strided-einsum2/src/raw_bgemm.rs
+++ b/strided-einsum2/src/raw_bgemm.rs
@@ -1,0 +1,393 @@
+//! Raw borrowed-layout batched GEMM entry points.
+//!
+//! This module is the prepared-replay boundary for callers that already own
+//! validated layout metadata. It keeps the public API independent of a concrete
+//! GEMM backend while still allowing backend modules to provide specialized raw
+//! implementations.
+
+use crate::backend::Backend;
+use crate::{contiguous, Scalar, ScalarBase};
+use strided_view::{Conj, ElementOp, ElementOpApply, RawStridedMut, RawStridedRef};
+
+/// Batched strided GEMM on raw borrowed layout metadata using the active backend.
+///
+/// This is the raw-layout counterpart to backend-specific `bgemm_strided_into`
+/// functions. It avoids constructing owned-metadata `StridedView` wrappers when
+/// a caller already has borrowed `dims`/`strides`/`offset` descriptors.
+#[allow(clippy::too_many_arguments)]
+pub fn bgemm_raw_strided_into<T>(
+    c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> crate::Result<()>
+where
+    T: Scalar,
+    crate::backend::ActiveBackend: Backend<T>,
+{
+    validate_bgemm_shapes(&c, &a, &b, n_batch, n_lo, n_ro, n_sum)?;
+    unsafe {
+        bgemm_raw_strided_into_unchecked(
+            c, a, b, n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
+        )
+    }
+}
+
+/// Batched strided GEMM on raw borrowed layout metadata without validation.
+///
+/// # Safety
+/// The caller must ensure:
+/// - all raw strided operands are in bounds,
+/// - `n_lo`, `n_ro`, `n_sum`, and `n_batch` partition operand ranks as
+///   `[lo, sum, batch]`, `[sum, ro, batch]`, and `[lo, ro, batch]`,
+/// - matching dimension groups have identical extents,
+/// - `c` does not alias `a` or `b` in a way that violates mutable access.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn bgemm_raw_strided_into_unchecked<T>(
+    c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> crate::Result<()>
+where
+    T: Scalar,
+    crate::backend::ActiveBackend: Backend<T>,
+{
+    bgemm_raw_with_backend_into_unchecked::<T, crate::backend::ActiveBackend>(
+        c, a, b, n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
+    )
+}
+
+/// Batched strided GEMM on raw borrowed metadata using an explicit backend.
+///
+/// Backend implementations that do not provide a specialized raw path use the
+/// same preparation pipeline as `einsum2_dispatch`: materialize/copy only when
+/// the backend requires it, call `Backend::bgemm_contiguous_into`, then finalize
+/// the destination.
+#[allow(clippy::too_many_arguments)]
+pub fn bgemm_raw_with_backend_into<T, B>(
+    c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> crate::Result<()>
+where
+    T: ScalarBase + ElementOpApply,
+    B: Backend<T>,
+{
+    validate_bgemm_shapes(&c, &a, &b, n_batch, n_lo, n_ro, n_sum)?;
+    unsafe {
+        bgemm_raw_with_backend_into_unchecked::<T, B>(
+            c, a, b, n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
+        )
+    }
+}
+
+/// Unchecked variant of [`bgemm_raw_with_backend_into`].
+///
+/// # Safety
+/// The caller must uphold the same layout and aliasing invariants as
+/// [`bgemm_raw_strided_into_unchecked`].
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn bgemm_raw_with_backend_into_unchecked<T, B>(
+    mut c: RawStridedMut<'_, T>,
+    a: RawStridedRef<'_, T>,
+    b: RawStridedRef<'_, T>,
+    _n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+    alpha: T,
+    beta: T,
+    conj_a: bool,
+    conj_b: bool,
+) -> crate::Result<()>
+where
+    T: ScalarBase + ElementOpApply,
+    B: Backend<T>,
+{
+    let a_dims = a.dims();
+    let b_dims = b.dims();
+    let lo_dims = &a_dims[..n_lo];
+    let sum_dims = &a_dims[n_lo..n_lo + n_sum];
+    let batch_dims = &a_dims[n_lo + n_sum..];
+    let ro_dims = &b_dims[n_sum..n_sum + n_ro];
+
+    if sum_dims.iter().any(|&dim| dim == 0) {
+        scale_or_zero_raw_mut(&mut c, beta);
+        return Ok(());
+    }
+
+    let use_pool = true;
+    let materialize = if B::MATERIALIZES_CONJ {
+        Some(Conj::apply as fn(T) -> T)
+    } else {
+        None
+    };
+
+    let a_op = contiguous::prepare_input_raw(
+        &a,
+        n_lo,
+        n_sum,
+        conj_a,
+        B::REQUIRES_UNIT_STRIDE,
+        use_pool,
+        materialize,
+    )?;
+    let b_op = contiguous::prepare_input_raw(
+        &b,
+        n_sum,
+        n_ro,
+        conj_b,
+        B::REQUIRES_UNIT_STRIDE,
+        use_pool,
+        materialize,
+    )?;
+    let mut c_op = contiguous::prepare_output_raw(
+        &mut c,
+        n_lo,
+        n_ro,
+        beta,
+        B::REQUIRES_UNIT_STRIDE,
+        use_pool,
+    )?;
+
+    let m: usize = lo_dims.iter().product::<usize>().max(1);
+    let k: usize = sum_dims.iter().product::<usize>().max(1);
+    let n: usize = ro_dims.iter().product::<usize>().max(1);
+
+    B::bgemm_contiguous_into(&mut c_op, &a_op, &b_op, batch_dims, m, n, k, alpha, beta)?;
+    c_op.finalize_raw_into(&mut c)?;
+
+    Ok(())
+}
+
+pub(crate) fn validate_bgemm_shapes<T>(
+    c: &RawStridedMut<'_, T>,
+    a: &RawStridedRef<'_, T>,
+    b: &RawStridedRef<'_, T>,
+    n_batch: usize,
+    n_lo: usize,
+    n_ro: usize,
+    n_sum: usize,
+) -> crate::Result<()> {
+    let a_rank = n_lo + n_sum + n_batch;
+    let b_rank = n_sum + n_ro + n_batch;
+    let c_rank = n_lo + n_ro + n_batch;
+    if a.dims().len() != a_rank {
+        return Err(strided_view::StridedError::RankMismatch(a_rank, a.dims().len()).into());
+    }
+    if b.dims().len() != b_rank {
+        return Err(strided_view::StridedError::RankMismatch(b_rank, b.dims().len()).into());
+    }
+    if c.dims().len() != c_rank {
+        return Err(strided_view::StridedError::RankMismatch(c_rank, c.dims().len()).into());
+    }
+
+    let lo_dims = &a.dims()[..n_lo];
+    let sum_dims = &a.dims()[n_lo..n_lo + n_sum];
+    let batch_dims = &a.dims()[n_lo + n_sum..];
+    let ro_dims = &b.dims()[n_sum..n_sum + n_ro];
+
+    if &b.dims()[..n_sum] != sum_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            sum_dims.to_vec(),
+            b.dims()[..n_sum].to_vec(),
+        )
+        .into());
+    }
+    if &b.dims()[n_sum + n_ro..] != batch_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            batch_dims.to_vec(),
+            b.dims()[n_sum + n_ro..].to_vec(),
+        )
+        .into());
+    }
+    if &c.dims()[..n_lo] != lo_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            lo_dims.to_vec(),
+            c.dims()[..n_lo].to_vec(),
+        )
+        .into());
+    }
+    if &c.dims()[n_lo..n_lo + n_ro] != ro_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            ro_dims.to_vec(),
+            c.dims()[n_lo..n_lo + n_ro].to_vec(),
+        )
+        .into());
+    }
+    if &c.dims()[n_lo + n_ro..] != batch_dims {
+        return Err(strided_view::StridedError::ShapeMismatch(
+            batch_dims.to_vec(),
+            c.dims()[n_lo + n_ro..].to_vec(),
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub(crate) fn scale_or_zero_raw_mut<T: ScalarBase>(c: &mut RawStridedMut<'_, T>, beta: T) {
+    if c.dims().iter().any(|&dim| dim == 0) {
+        return;
+    }
+
+    fn visit<T: ScalarBase>(
+        ptr: *mut T,
+        dims: &[usize],
+        strides: &[isize],
+        axis: usize,
+        offset: isize,
+        beta: T,
+        zero: T,
+    ) {
+        if axis == dims.len() {
+            unsafe {
+                let dst = ptr.offset(offset);
+                if beta == zero {
+                    *dst = zero;
+                } else {
+                    *dst = beta * *dst;
+                }
+            }
+            return;
+        }
+
+        for i in 0..dims[axis] {
+            visit(
+                ptr,
+                dims,
+                strides,
+                axis + 1,
+                offset + i as isize * strides[axis],
+                beta,
+                zero,
+            );
+        }
+    }
+
+    visit(c.as_mut_ptr(), c.dims(), c.strides(), 0, 0, beta, T::zero());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_bgemm_2x2<T>(one: T, zero: T) -> Vec<T>
+    where
+        T: Scalar,
+        crate::backend::ActiveBackend: Backend<T>,
+        T: From<f32>,
+    {
+        let dims = [2, 2];
+        let strides = [2, 1];
+        let a_data = [T::from(1.0), T::from(2.0), T::from(3.0), T::from(4.0)];
+        let b_data = [T::from(5.0), T::from(6.0), T::from(7.0), T::from(8.0)];
+        let mut c_data = vec![zero; 4];
+        let a = RawStridedRef::new(&a_data, &dims, &strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &dims, &strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &dims, &strides, 0).unwrap();
+        bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, one, zero, false, false).unwrap();
+        c_data
+    }
+
+    #[test]
+    fn raw_bgemm_active_backend_f64() {
+        assert_eq!(raw_bgemm_2x2(1.0f64, 0.0), vec![19.0, 22.0, 43.0, 50.0]);
+    }
+
+    #[test]
+    fn raw_bgemm_active_backend_f32() {
+        assert_eq!(raw_bgemm_2x2(1.0f32, 0.0), vec![19.0f32, 22.0, 43.0, 50.0]);
+    }
+
+    #[test]
+    fn raw_bgemm_active_backend_complex_conj() {
+        use num_complex::Complex64;
+
+        let i = Complex64::i();
+        let dims = [2, 2];
+        let strides = [2, 1];
+        let a_data = [
+            Complex64::new(1.0, 0.0) + i,
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0) - i,
+        ];
+        let b_data = [
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ];
+        let mut c_data = vec![Complex64::new(0.0, 0.0); 4];
+        let a = RawStridedRef::new(&a_data, &dims, &strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &dims, &strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &dims, &strides, 0).unwrap();
+        bgemm_raw_strided_into(
+            c,
+            a,
+            b,
+            0,
+            1,
+            1,
+            1,
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            c_data,
+            vec![
+                Complex64::new(1.0, -1.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+                Complex64::new(4.0, 1.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_bgemm_active_backend_checked_shape_mismatch() {
+        let a_dims = [2, 2];
+        let b_dims = [3, 2];
+        let c_dims = [2, 2];
+        let a_strides = [2, 1];
+        let b_strides = [2, 1];
+        let c_strides = [2, 1];
+        let a_data = [1.0, 2.0, 3.0, 4.0];
+        let b_data = [0.0; 6];
+        let mut c_data = [0.0; 4];
+        let a = RawStridedRef::new(&a_data, &a_dims, &a_strides, 0).unwrap();
+        let b = RawStridedRef::new(&b_data, &b_dims, &b_strides, 0).unwrap();
+        let c = RawStridedMut::new(&mut c_data, &c_dims, &c_strides, 0).unwrap();
+        let err = bgemm_raw_strided_into(c, a, b, 0, 1, 1, 1, 1.0, 0.0, false, false).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::EinsumError::Strided(strided_view::StridedError::ShapeMismatch(_, _))
+        ));
+    }
+}

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod auxiliary;
 mod element_op;
+mod raw;
 pub mod view;
 
 // ============================================================================
@@ -32,6 +33,7 @@ pub use element_op::{
 // ============================================================================
 // View-based types
 // ============================================================================
+pub use raw::{RawStridedMut, RawStridedRef};
 pub use view::{col_major_strides, row_major_strides, StridedArray, StridedView, StridedViewMut};
 
 // ============================================================================

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -1,0 +1,220 @@
+//! Borrowed raw strided layout types.
+//!
+//! These are the prepared-replay counterparts to [`crate::StridedView`] and
+//! [`crate::StridedViewMut`]. They borrow shape/stride metadata instead of
+//! owning it, so compiled kernels can reuse already-validated layout
+//! descriptors without rebuilding dynamic-rank view wrappers.
+
+use crate::element_op::Identity;
+use crate::view::validate_bounds;
+use crate::{Result, StridedView, StridedViewMut};
+
+/// Borrowed raw strided input layout.
+///
+/// Use [`RawStridedRef::new`] for checked construction, or
+/// [`RawStridedRef::new_unchecked`] when a higher-level compiled plan has
+/// already validated bounds.
+#[derive(Clone, Copy, Debug)]
+pub struct RawStridedRef<'a, T> {
+    data: &'a [T],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a, T> RawStridedRef<'a, T> {
+    /// Create a raw strided input after validating reachable offsets.
+    pub fn new(
+        data: &'a [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        validate_bounds(data.len(), dims, strides, offset)?;
+        Ok(Self {
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Create a raw strided input without bounds checking.
+    ///
+    /// # Safety
+    /// The caller must ensure every index reachable by `dims`/`strides` from
+    /// `offset` lies inside `data`.
+    pub unsafe fn new_unchecked(
+        data: &'a [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Self {
+        Self {
+            data,
+            dims,
+            strides,
+            offset,
+        }
+    }
+
+    #[inline]
+    pub fn data(&self) -> &'a [T] {
+        self.data
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    #[inline]
+    pub fn ptr(&self) -> *const T {
+        unsafe { self.data.as_ptr().offset(self.offset) }
+    }
+
+    /// Convert to an immutable owning-metadata view.
+    ///
+    /// This is for compatibility paths. Hot prepared paths should use the raw
+    /// accessors directly and avoid this conversion.
+    #[inline]
+    pub fn as_view(&self) -> StridedView<'a, T, Identity> {
+        unsafe { StridedView::new_unchecked(self.data, self.dims, self.strides, self.offset) }
+    }
+}
+
+/// Borrowed raw strided output layout.
+///
+/// This is the mutable counterpart to [`RawStridedRef`]. It avoids allocating
+/// owned shape/stride metadata in prepared replay paths.
+#[derive(Debug)]
+pub struct RawStridedMut<'a, T> {
+    data: &'a mut [T],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a, T> RawStridedMut<'a, T> {
+    /// Create a raw strided output after validating reachable offsets.
+    pub fn new(
+        data: &'a mut [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        validate_bounds(data.len(), dims, strides, offset)?;
+        Ok(Self {
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Create a raw strided output without bounds checking.
+    ///
+    /// # Safety
+    /// The caller must ensure every index reachable by `dims`/`strides` from
+    /// `offset` lies inside `data`, and no aliases violate mutable access.
+    pub unsafe fn new_unchecked(
+        data: &'a mut [T],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Self {
+        Self {
+            data,
+            dims,
+            strides,
+            offset,
+        }
+    }
+
+    #[inline]
+    pub fn data(&self) -> &[T] {
+        self.data
+    }
+
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut [T] {
+        self.data
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    #[inline]
+    pub fn ptr(&self) -> *const T {
+        unsafe { self.data.as_ptr().offset(self.offset) }
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        unsafe { self.data.as_mut_ptr().offset(self.offset) }
+    }
+
+    /// Convert to an immutable owning-metadata view.
+    ///
+    /// This is for compatibility paths. Hot prepared paths should use the raw
+    /// accessors directly and avoid this conversion.
+    #[inline]
+    pub fn as_view(&self) -> StridedView<'_, T, Identity> {
+        unsafe { StridedView::new_unchecked(self.data, self.dims, self.strides, self.offset) }
+    }
+
+    /// Convert to a mutable owning-metadata view.
+    ///
+    /// This is for compatibility paths. Hot prepared paths should use the raw
+    /// accessors directly and avoid this conversion.
+    #[inline]
+    pub fn as_view_mut(&mut self) -> StridedViewMut<'_, T> {
+        unsafe { StridedViewMut::new_unchecked(self.data, self.dims, self.strides, self.offset) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_ref_rejects_out_of_bounds_layout() {
+        let data = [0.0f64; 4];
+        let err = RawStridedRef::new(&data, &[2, 3], &[3, 1], 0).unwrap_err();
+        assert!(matches!(err, crate::StridedError::OffsetOverflow));
+    }
+
+    #[test]
+    fn raw_mut_can_reborrow_as_view() {
+        let mut data = [1, 2, 3, 4];
+        let mut raw = RawStridedMut::new(&mut data, &[2, 2], &[2, 1], 0).unwrap();
+        {
+            let view = raw.as_view();
+            assert_eq!(view.dims(), &[2, 2]);
+        }
+        let view_mut = raw.as_view_mut();
+        assert_eq!(view_mut.get(&[1, 1]), 4);
+    }
+}

--- a/strided-view/src/view.rs
+++ b/strided-view/src/view.rs
@@ -19,7 +19,12 @@ use crate::{Result, StridedError};
 // ============================================================================
 
 /// Validate that all accessed offsets stay within `[0, len)`.
-fn validate_bounds(len: usize, dims: &[usize], strides: &[isize], offset: isize) -> Result<()> {
+pub(crate) fn validate_bounds(
+    len: usize,
+    dims: &[usize],
+    strides: &[isize],
+    offset: isize,
+) -> Result<()> {
     if dims.len() != strides.len() {
         return Err(StridedError::StrideLengthMismatch);
     }

--- a/strided-view/src/view.rs
+++ b/strided-view/src/view.rs
@@ -527,6 +527,18 @@ impl<'a, T> StridedViewMut<'a, T> {
         self.ptr
     }
 
+    /// Returns a reference to the backing data slice.
+    #[inline]
+    pub fn data(&self) -> &[T] {
+        &self.data
+    }
+
+    /// Returns a mutable reference to the backing data slice.
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut [T] {
+        &mut self.data
+    }
+
     /// Permute dimensions, consuming the mutable view.
     ///
     /// Returns a new mutable view with reordered dimensions and strides.


### PR DESCRIPTION
## Summary

This PR adds a backend-neutral raw borrowed-layout entry point for strided
batched GEMM.

The normal `StridedView` / `StridedViewMut` APIs remain unchanged. The new API
is for prepared replay paths that already have validated
`dims` / `strides` / `offset` descriptors and should not rebuild owning
view metadata for every small GEMM.

## Motivation

Tensor contraction engines often split execution into two phases:

1. Build or compile a structural plan once.
2. Replay the same strided subblock layouts many times.

In the replay phase, the caller already has borrowed layout metadata:

```rust
let dims: &[usize] = &[m, k];
let strides: &[isize] = &[k as isize, 1];
let offset: isize = 0;
```

Constructing a new `StridedView` for every replay allocates owned dynamic-rank
metadata. That is fine for the general view API, but it is avoidable overhead
for compiled replay. This PR adds a raw borrowed-layout API for that case.

## API shape

Raw layout types live in `strided-view`, not in a concrete backend module:

```rust
use strided_view::{RawStridedMut, RawStridedRef};
```

The backend-neutral GEMM entry point is re-exported from `strided-einsum2`:

```rust
use strided_einsum2::{bgemm_raw_strided_into, RawStridedMut, RawStridedRef};

let a = RawStridedRef::new(a_data, &[m, k], &[k as isize, 1], 0)?;
let b = RawStridedRef::new(b_data, &[k, n], &[n as isize, 1], 0)?;
let c = RawStridedMut::new(c_data, &[m, n], &[n as isize, 1], 0)?;

bgemm_raw_strided_into(
    c,
    a,
    b,
    0, // n_batch
    1, // n_lo
    1, // n_ro
    1, // n_sum
    1.0,
    0.0,
    false, // conj_a
    false, // conj_b
)?;
```

For compiled plans that have already validated bounds and ranks:

```rust
let a = unsafe {
    RawStridedRef::new_unchecked(a_data, prepared_a_dims, prepared_a_strides, prepared_a_offset)
};
let b = unsafe {
    RawStridedRef::new_unchecked(b_data, prepared_b_dims, prepared_b_strides, prepared_b_offset)
};
let c = unsafe {
    RawStridedMut::new_unchecked(c_data, prepared_c_dims, prepared_c_strides, prepared_c_offset)
};

unsafe {
    bgemm_raw_strided_into_unchecked(
        c, a, b, n_batch, n_lo, n_ro, n_sum, alpha, beta, conj_a, conj_b,
    )?;
}
```

The unchecked path requires the caller to prove:

- every reachable element is inside the backing slice,
- the rank partitions match `[lo, sum, batch]`, `[sum, ro, batch]`, and
  `[lo, ro, batch]`,
- matching dimension groups have identical extents,
- `C` does not alias `A` or `B` in a way that violates mutable access.

## Backend behavior

The raw API is not faer-specific. It lowers through the same backend-neutral
prepare path:

```text
RawStridedRef/Mut
  -> prepare_input_raw / prepare_output_raw
  -> Backend::bgemm_contiguous_into
```

That means faer, BLAS, and future backends can share the same raw metadata
boundary. The concrete backend difference stays at the final GEMM call.

## Compatibility

Existing `bgemm_strided_into` callers continue to use `StridedView` /
`StridedViewMut`. The faer module keeps its compatibility wrapper, but external
callers should use the backend-neutral `strided_einsum2::bgemm_raw_strided_into`
API for prepared replay.

## Tests

Validated:

```text
cargo test -p strided-einsum2 --no-default-features --quiet
cargo test -p strided-view -p strided-einsum2 --features faer --quiet
```

Coverage includes:

- raw GEMM through the active backend for `f64`
- raw GEMM through the active backend for `f32`
- `Complex64` raw GEMM with conjugation
- explicit backend dispatch
- checked shape/rank mismatch reporting
- zero-size contraction with `beta == 0` and `beta != 0`
- non-contiguous output writeback
- existing view-based compatibility behavior
