### PR TITLE
Add fused elementwise DAG kernels

### DIFF
--- a/docs/superpowers/plans/2026-07-04-fused-elementwise-dag.md
+++ b/docs/superpowers/plans/2026-07-04-fused-elementwise-dag.md
@@ -1,0 +1,448 @@
+# Fused Elementwise DAG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #136 end to end: fused runtime-DAG elementwise kernels in `strided-kernel`, performance benchmarks, and follow-up benchmark-suite support.
+
+**Architecture:** Add a focused `strided-kernel/src/fused.rs` module with public plan types, scalar semantics, validation, static specialization, and interpreter fallback. The interpreter reuses existing shape/block/parallel traversal; the specialization path reuses `map_into` and `zip_map*_into`. Benchmark-suite changes are made only after the `strided-rs` implementation is committed so the exact hash can be recorded.
+
+**Tech Stack:** Rust 2021, `strided-view`, `strided-kernel`, `num-complex`, Criterion benchmarks, sibling `strided-rs-benchmark-suite`.
+
+## Global Constraints
+
+- Follow `AGENTS.md`: run `du -s .` before work; if over 100GB, propose cleanup before continuing.
+- Follow `strided-rs/AGENTS.md`: before push or PR, `cargo fmt --check` and `cargo test` must pass.
+- Use CodeGraph before grep/find for code understanding when `.codegraph/` exists.
+- Keep public API small; expose only `FusedOp`, `FusedInst`, `FusedPlan`, `FusedScalar`, and `fused_elementwise_into`.
+- Validate every plan, shape, rank, and output condition before unsafe pointer loops.
+- No BLAS dependency and no mixed-dtype promotion.
+- Benchmarks must not run concurrently.
+- Benchmark-suite result notes must record the exact committed `strided-rs` hash; on macOS, state that CPU pinning is unavailable.
+
+---
+
+## File Structure
+
+- Create `strided-kernel/src/fused.rs`: public fused API, scalar semantics, validation, static matcher, interpreter execution, and private unit tests.
+- Modify `strided-kernel/src/lib.rs`: export the new fused module API.
+- Create `strided-kernel/tests/fused_elementwise.rs`: integration tests for public behavior and edge cases.
+- Modify `strided-kernel/Cargo.toml`: add `fused_elementwise` benchmark target.
+- Create `strided-kernel/benches/fused_elementwise.rs`: Criterion comparisons against per-op baselines.
+- Modify `strided-rs-benchmark-suite/Cargo.toml` and `src/main.rs` or add a dedicated benchmark binary if the suite structure makes that cleaner.
+- Modify `strided-rs-benchmark-suite/README.md` or `benchmarks/README.md`: add fused benchmark usage and recorded hash/result notes.
+
+## Task 1: Public API And Validation
+
+**Files:**
+- Create: `strided-kernel/src/fused.rs`
+- Modify: `strided-kernel/src/lib.rs`
+- Test: `strided-kernel/tests/fused_elementwise.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub enum FusedOp`
+  - `pub struct FusedInst { pub op: FusedOp, pub inputs: Vec<usize> }`
+  - `pub struct FusedPlan { pub input_count: usize, pub outputs: Vec<usize>, pub ops: Vec<FusedInst> }`
+  - `pub trait FusedScalar`
+  - `pub fn fused_elementwise_into<T: FusedScalar>(dests: &mut [StridedViewMut<'_, T>], inputs: &[StridedView<'_, T>], plan: &FusedPlan) -> Result<()>`
+
+- [ ] **Step 1: Write failing validation tests**
+
+Add tests that import `fused_elementwise_into`, `FusedInst`, `FusedOp`, and `FusedPlan`. Cover:
+
+```rust
+#[test]
+fn fused_rejects_input_count_mismatch() { /* inputs.len() != plan.input_count */ }
+
+#[test]
+fn fused_rejects_destination_count_mismatch() { /* dests.len() != plan.outputs.len() */ }
+
+#[test]
+fn fused_rejects_bad_value_id_before_writing() { /* op references future value */ }
+
+#[test]
+fn fused_rejects_wrong_op_arity_before_writing() { /* Add with one input */ }
+
+#[test]
+fn fused_rejects_shape_mismatch_before_writing() { /* input shape differs */ }
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+```
+
+Expected: compile failure because the fused API is not exported yet.
+
+- [ ] **Step 3: Implement minimal public API and validation**
+
+Create `fused.rs`, add the public types, implement `validate_plan`, and make `fused_elementwise_into` call validation then return `Ok(())` only for zero-length shapes or panic-free no-op behavior. Export from `lib.rs`.
+
+- [ ] **Step 4: Verify GREEN for validation**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+```
+
+Expected: validation tests pass or fail only because outputs are not computed yet; if computation assertions are absent in this task, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add strided-kernel/src/fused.rs strided-kernel/src/lib.rs strided-kernel/tests/fused_elementwise.rs
+git commit -m "feat: add fused elementwise plan validation"
+```
+
+## Task 2: Interpreter Fallback Correctness
+
+**Files:**
+- Modify: `strided-kernel/src/fused.rs`
+- Modify: `strided-kernel/tests/fused_elementwise.rs`
+
+**Interfaces:**
+- Consumes: Task 1 public API.
+- Produces: correct interpreter execution for arbitrary valid DAGs and multiple outputs.
+
+- [ ] **Step 1: Write failing interpreter tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn fused_interprets_reused_dag_value() {
+    // out = (a + b) * a
+}
+
+#[test]
+fn fused_interprets_multiple_outputs() {
+    // out0 = a + b, out1 = a * b
+}
+
+#[test]
+fn fused_interprets_broadcast_stride_zero_inputs() {
+    // y = exp(a * b + c_broadcast)
+}
+
+#[test]
+fn fused_interprets_noncontiguous_inputs_and_outputs() {
+    // permuted views for both input and destination
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+```
+
+Expected: new tests fail because output values remain uncomputed.
+
+- [ ] **Step 3: Implement interpreter execution**
+
+Use `build_plan_fused_small` / `build_plan_fused`, collect destination and input strides, and use `for_each_inner_block_preordered`. For each element in an inner block:
+
+```rust
+regs[0..input_count] = loaded input values;
+for inst in &plan.ops {
+    regs.push(eval_op(inst.op, &regs, &inst.inputs));
+}
+for (dst, &value_id) in dest_ptrs.iter().zip(&plan.outputs) {
+    *dst = regs[value_id];
+}
+```
+
+For parallel builds, mirror the existing `map_view` pattern with `mapreduce_threaded` and `SendPtr`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+cargo test -p strided-kernel
+```
+
+Expected: all `strided-kernel` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add strided-kernel/src/fused.rs strided-kernel/tests/fused_elementwise.rs
+git commit -m "feat: interpret fused elementwise dag plans"
+```
+
+## Task 3: Scalar Semantics Edge Cases
+
+**Files:**
+- Modify: `strided-kernel/src/fused.rs`
+- Modify: `strided-kernel/tests/fused_elementwise.rs`
+
+**Interfaces:**
+- Consumes: interpreter execution from Task 2.
+- Produces: documented real and complex semantics for all `FusedOp` variants.
+
+- [ ] **Step 1: Write failing scalar semantics tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn fused_real_maximum_minimum_match_nan_contract() {
+    // max(NaN, 3.0) == 3.0; min(3.0, NaN) == 3.0; max(NaN, NaN).is_nan()
+}
+
+#[test]
+fn fused_complex_divide_matches_native_complex_division() {
+    // out = a / b for Complex64
+}
+
+#[test]
+fn fused_complex_abs_returns_norm_in_real_component() {
+    // abs(3+4i) == 5+0i
+}
+
+#[test]
+fn fused_all_real_ops_have_basic_parity() {
+    // Divide, Clamp, Log, Sin, Cos, Tanh, Sqrt, Rsqrt, Pow, Expm1, Log1p
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+```
+
+Expected: tests fail for unimplemented or incorrect ops.
+
+- [ ] **Step 3: Complete `FusedScalar` implementations**
+
+Implement `FusedScalar` for `f32`, `f64`, `Complex32`, and `Complex64`. Real `maximum` / `minimum` use `max` / `min`. Complex ordering ops compare `norm_sqr()` and return one operand; complex `abs` returns `Complex::new(norm, 0.0)`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo test -p strided-kernel --test fused_elementwise
+cargo test -p strided-kernel
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add strided-kernel/src/fused.rs strided-kernel/tests/fused_elementwise.rs
+git commit -m "feat: define fused scalar semantics"
+```
+
+## Task 4: Static Specialization
+
+**Files:**
+- Modify: `strided-kernel/src/fused.rs`
+- Modify: `strided-kernel/tests/fused_elementwise.rs`
+
+**Interfaces:**
+- Consumes: validated plans and semantic interpreter.
+- Produces: static dispatch for common one-output patterns through existing map kernels.
+
+- [ ] **Step 1: Write failing specialization parity tests**
+
+In `fused.rs` unit tests, compare `try_static_specialization` output against direct interpreter execution for:
+
+```rust
+// unary Exp
+// binary Add
+// ternary Clamp
+// chain (a + b) * a
+// chain exp(a * b + c)
+```
+
+Add an integration test that verifies a static-specialized plan still handles broadcast inputs.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p strided-kernel fused
+```
+
+Expected: tests fail because the matcher returns false.
+
+- [ ] **Step 3: Implement static matcher**
+
+Add `try_static_specialization` before interpreter fallback. Match only valid single-output plans with exact input ids and op sequences. Dispatch to:
+
+```rust
+map_into(&mut dests[0], &inputs[0], |x| eval_unary(op, x))
+zip_map2_into(&mut dests[0], &inputs[0], &inputs[1], |a, b| eval_binary(op, a, b))
+zip_map3_into(&mut dests[0], &inputs[0], &inputs[1], &inputs[2], |a, b, c| {
+    eval_ternary(op, a, b, c)
+})
+zip_map4_into(&mut dests[0], &inputs[0], &inputs[1], &inputs[2], &inputs[3], |a, b, c, d| {
+    eval_four_input_chain(a, b, c, d)
+})
+```
+
+Return `Ok(true)` if a specialized path ran and `Ok(false)` otherwise.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo test -p strided-kernel
+cargo test -p strided-kernel --features parallel
+```
+
+Expected: all tests pass with and without parallel feature.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add strided-kernel/src/fused.rs strided-kernel/tests/fused_elementwise.rs
+git commit -m "perf: specialize common fused elementwise plans"
+```
+
+## Task 5: `strided-kernel` Benchmark And Performance Check
+
+**Files:**
+- Modify: `strided-kernel/Cargo.toml`
+- Create: `strided-kernel/benches/fused_elementwise.rs`
+
+**Interfaces:**
+- Consumes: public fused API.
+- Produces: release benchmark evidence against per-op baselines.
+
+- [ ] **Step 1: Write benchmark target**
+
+Create Criterion benchmarks for:
+
+```rust
+// contiguous_per_op_add_mul
+// contiguous_fused_add_mul
+// broadcast_per_op_exp_mul_add
+// broadcast_fused_exp_mul_add
+// long_chain_per_op
+// long_chain_fused_interpreter
+```
+
+Use preallocated arrays inside benchmark setup, not inside timed loops except for explicit per-op intermediate buffers that represent baseline cost. Use `black_box`.
+
+- [ ] **Step 2: Run benchmark sequentially**
+
+Run on macOS:
+
+```bash
+RAYON_NUM_THREADS=1 cargo bench -p strided-kernel --bench fused_elementwise
+```
+
+Expected: benchmark completes. Record that CPU pinning was unavailable on macOS.
+
+- [ ] **Step 3: Verify repository gates**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo test -p strided-kernel
+cargo test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add strided-kernel/Cargo.toml strided-kernel/benches/fused_elementwise.rs
+git commit -m "bench: compare fused elementwise dag kernels"
+```
+
+Record the resulting `git rev-parse HEAD` hash for benchmark-suite notes.
+
+## Task 6: Benchmark Suite Support
+
+**Files:**
+- Read first: `strided-rs-benchmark-suite/AGENTS.md`
+- Modify: `strided-rs-benchmark-suite/Cargo.toml`
+- Modify or create: `strided-rs-benchmark-suite/src/main.rs` or `strided-rs-benchmark-suite/src/bin/fused_elementwise.rs`
+- Modify: `strided-rs-benchmark-suite/README.md` or `benchmarks/README.md`
+
+**Interfaces:**
+- Consumes: committed sibling `../strided-rs` hash with fused API.
+- Produces: a reproducible benchmark-suite entry for fused elementwise DAGs.
+
+- [ ] **Step 1: Inspect suite structure and choose binary shape**
+
+Prefer a dedicated binary if `main.rs` is tightly focused on einsum benchmarks:
+
+```toml
+[[bin]]
+name = "fused-elementwise"
+path = "src/bin/fused_elementwise.rs"
+```
+
+- [ ] **Step 2: Implement benchmark-suite benchmark**
+
+Benchmark the same three scenarios as `strided-kernel`, but as a standalone suite command using the path dependency on `../strided-rs`.
+
+- [ ] **Step 3: Run benchmark sequentially**
+
+Run:
+
+```bash
+cargo run --release --bin fused-elementwise
+```
+
+Expected: command prints timings for per-op, specialized fused, and interpreter fused scenarios. On macOS, output or README notes state CPU pinning unavailable.
+
+- [ ] **Step 4: Record exact `strided-rs` hash**
+
+Run in `strided-rs`:
+
+```bash
+git rev-parse HEAD
+```
+
+Add that hash to the benchmark-suite result note.
+
+- [ ] **Step 5: Commit benchmark-suite changes**
+
+```bash
+git add Cargo.toml src/bin/fused_elementwise.rs README.md benchmarks/README.md
+git commit -m "bench: add fused elementwise suite"
+```
+
+## Final Verification
+
+- [ ] Run in `strided-rs`:
+
+```bash
+cargo fmt --check
+cargo test
+RAYON_NUM_THREADS=1 cargo bench -p strided-kernel --bench fused_elementwise
+git log --oneline --decorate -8
+```
+
+- [ ] Run in `strided-rs-benchmark-suite`:
+
+```bash
+cargo fmt --check
+cargo test
+cargo run --release --bin fused-elementwise
+git log --oneline --decorate -5
+```
+
+- [ ] Confirm no `.codegraph/` content is staged.
+- [ ] Confirm one `strided-rs` feature branch contains all implementation commits for one PR.

--- a/docs/superpowers/specs/2026-07-04-fused-elementwise-dag-design.md
+++ b/docs/superpowers/specs/2026-07-04-fused-elementwise-dag-design.md
@@ -1,0 +1,172 @@
+# Fused Elementwise DAG Kernel Design
+
+## Goal
+
+Add the full issue #136 fused elementwise runtime-DAG API to `strided-kernel`, then add matching benchmarks in `strided-rs-benchmark-suite`.
+
+The feature provides one public entry point that evaluates a runtime-built scalar expression DAG over broadcast-aware strided inputs and one or more outputs. It must avoid main-memory intermediates, reuse the existing cache-blocked and parallel traversal machinery, and opportunistically dispatch common shapes to existing static map kernels.
+
+## Public API
+
+`strided-kernel` exposes a new `fused` module through `lib.rs`:
+
+```rust
+pub enum FusedOp {
+    Add,
+    Multiply,
+    Negate,
+    Conj,
+    Divide,
+    Abs,
+    Maximum,
+    Minimum,
+    Clamp,
+    Exp,
+    Log,
+    Sin,
+    Cos,
+    Tanh,
+    Sqrt,
+    Rsqrt,
+    Pow,
+    Expm1,
+    Log1p,
+}
+
+pub struct FusedInst {
+    pub op: FusedOp,
+    pub inputs: Vec<usize>,
+}
+
+pub struct FusedPlan {
+    pub input_count: usize,
+    pub outputs: Vec<usize>,
+    pub ops: Vec<FusedInst>,
+}
+
+pub trait FusedScalar: Copy + MaybeSendSync + 'static {
+    fn fused_add(self, rhs: Self) -> Self;
+    fn fused_multiply(self, rhs: Self) -> Self;
+    fn fused_negate(self) -> Self;
+    fn fused_conj(self) -> Self;
+    fn fused_divide(self, rhs: Self) -> Self;
+    fn fused_abs(self) -> Self;
+    fn fused_maximum(self, rhs: Self) -> Self;
+    fn fused_minimum(self, rhs: Self) -> Self;
+    fn fused_clamp(self, min: Self, max: Self) -> Self;
+    fn fused_exp(self) -> Self;
+    fn fused_log(self) -> Self;
+    fn fused_sin(self) -> Self;
+    fn fused_cos(self) -> Self;
+    fn fused_tanh(self) -> Self;
+    fn fused_sqrt(self) -> Self;
+    fn fused_rsqrt(self) -> Self;
+    fn fused_pow(self, rhs: Self) -> Self;
+    fn fused_expm1(self) -> Self;
+    fn fused_log1p(self) -> Self;
+}
+
+pub fn fused_elementwise_into<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()>;
+```
+
+The first implementation targets `f32`, `f64`, `Complex32`, and `Complex64`. All operations are same-dtype. Mixed dtype promotion remains out of scope.
+
+## Semantics
+
+For each logical element position:
+
+1. Load all `inputs` using their existing strides. Broadcast is represented by stride-0 views created before calling `fused_elementwise_into`.
+2. Evaluate `plan.ops` in topological order into a per-element register file. Values `0..plan.input_count` are inputs; op `i` appends value id `plan.input_count + i`.
+3. Store `plan.outputs[j]` into `dests[j]`.
+
+Validation happens before any output write:
+
+- `inputs.len() == plan.input_count`.
+- `dests.len() == plan.outputs.len()`.
+- At least one destination exists.
+- All inputs and destinations have the same logical shape.
+- Every instruction input id refers to an existing earlier value id.
+- Each op receives its required arity: unary, binary, or ternary for `Clamp`.
+- Every output id refers to an existing value.
+
+Validation errors use existing `StridedError` variants where they fit: `ShapeMismatch`, `RankMismatch`, and `InvalidAxis`. Invalid plan structure uses `StridedError::InvalidAxis { axis, rank }`, where `rank` is the number of values available at that validation point.
+
+`Maximum` and `Minimum` use Rust float `max` / `min` semantics for real scalars: if exactly one operand is NaN, the non-NaN operand is returned; if both are NaN, the result is NaN. Complex maximum/minimum/clamp are not ordered mathematically, so their `FusedScalar` implementation compares magnitudes (`norm`) and returns one of the original complex operands. Complex `Abs` returns a complex value whose real component is the norm and whose imaginary component is zero. Complex `Divide` is native complex division.
+
+## Execution Paths
+
+The public function has two paths behind the same validation and API:
+
+1. Static specialization:
+   - Match a small set of common one-output DAGs.
+   - Dispatch to existing `map_into`, `zip_map2_into`, `zip_map3_into`, or `zip_map4_into` closures.
+   - This preserves the current contiguous fast paths, SIMD dispatch, blocking, and parallel execution.
+   - Initial recognized patterns:
+     - unary: `Negate`, `Conj`, `Abs`, `Exp`, `Log`, `Sin`, `Cos`, `Tanh`, `Sqrt`, `Rsqrt`, `Expm1`, `Log1p`
+     - binary: `Add`, `Multiply`, `Divide`, `Maximum`, `Minimum`, `Pow`
+     - ternary: `Clamp`
+     - chains: `(a + b) * a`, `exp(a * b + c)`, and equivalent output ids produced by these exact DAGs.
+2. Runtime interpreter fallback:
+   - Handles arbitrary arity, arbitrary DAGs, multiple outputs, repeated value use, and operations not recognized by the static matcher.
+   - Reuses `build_plan_fused`, `build_plan_fused_small`, `for_each_inner_block_preordered`, and the existing parallel `mapreduce_threaded` path.
+   - Allocates the per-element register file once per inner block and reuses it across elements.
+
+The interpreter is the semantic authority. Static specialization is an optimization only; every specialized pattern has a parity test against the same plan evaluated through a non-specialized fallback plan.
+
+## Testing
+
+Tests live primarily in `strided-kernel/tests/fused_elementwise.rs` with focused unit tests in `strided-kernel/src/fused.rs` when private helpers need coverage.
+
+Coverage requirements:
+
+- Basic unary, binary, ternary, and chained real operations.
+- DAG reuse such as `(a + b) * a`.
+- Multiple outputs.
+- Broadcast stride-0 inputs with no materialization.
+- Shape mismatch, destination count mismatch, bad value id, wrong arity, and empty output errors.
+- Parity against explicit per-op `map_into` / `zip_map*_into` baselines for `f32`, `f64`, `Complex32`, and `Complex64`.
+- `Maximum` / `Minimum` NaN behavior for real floats.
+- Complex `Divide` and `Abs` behavior.
+- Static-specialized results matching interpreter fallback.
+
+Repository gates:
+
+```bash
+cargo fmt --check
+cargo test -p strided-kernel
+cargo test
+```
+
+## Benchmarks
+
+In `strided-rs`, add a Criterion benchmark target under `strided-kernel/benches/fused_elementwise.rs` comparing:
+
+- sequential per-op baseline with intermediate arrays
+- `fused_elementwise_into` static-specialized plans
+- `fused_elementwise_into` interpreter fallback plans
+
+Benchmark scenarios include contiguous and broadcast inputs for:
+
+- `(a + b) * a`
+- `exp(a * b + c)`
+- a longer SVD-backward-like chain using `Divide`, `Maximum`, `Minimum`, `Sqrt`, and `Rsqrt`
+
+After implementation commits are in place and benchmark output is captured, update `strided-rs-benchmark-suite` with a corresponding benchmark program or mode that depends on the sibling `../strided-rs` path. Its result notes must include the exact `strided-rs` git hash. On macOS, record that CPU pinning is unavailable.
+
+## Commit Strategy
+
+Use one feature branch and one eventual PR for `strided-rs`. Keep commits staged:
+
+1. Spec and implementation plan.
+2. Public fused API and validation tests.
+3. Interpreter fallback and correctness tests.
+4. Scalar semantics edge cases.
+5. Static specialization and parity tests.
+6. `strided-kernel` benchmark and recorded performance check.
+7. Benchmark-suite support in `strided-rs-benchmark-suite` after the `strided-rs` hash is committed.
+
+Each implementation commit must be backed by tests. Benchmark-related commits must include release benchmark evidence gathered sequentially.

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -55,3 +55,7 @@ harness = false
 [[bench]]
 name = "mul_pytorch_compare"
 harness = false
+
+[[bench]]
+name = "fused_elementwise"
+harness = false

--- a/strided-kernel/benches/fused_elementwise.rs
+++ b/strided-kernel/benches/fused_elementwise.rs
@@ -1,0 +1,196 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+use strided_kernel::{
+    fused_elementwise_into, map_into, zip_map2_into, FusedInst, FusedOp, FusedPlan, StridedArray,
+};
+
+const N: usize = 512;
+const DIMS: [usize; 2] = [N, N];
+
+fn make_input(seed: f64) -> StridedArray<f64> {
+    StridedArray::<f64>::from_fn_col_major(&DIMS, |idx| {
+        seed + 0.001 * idx[0] as f64 + 0.000_01 * idx[1] as f64
+    })
+}
+
+fn make_constant(value: f64) -> StridedArray<f64> {
+    StridedArray::<f64>::from_fn_col_major(&DIMS, |_| value)
+}
+
+fn bench_add_mul(c: &mut Criterion) {
+    let a = make_input(1.0);
+    let b = make_input(2.0);
+    let mut tmp = StridedArray::<f64>::col_major(&DIMS);
+    let mut out = StridedArray::<f64>::col_major(&DIMS);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![3],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![2, 0],
+            },
+        ],
+    };
+
+    let mut group = c.benchmark_group("fused_add_mul");
+    group.bench_function("per_op_reused_buffers", |bch| {
+        bch.iter(|| {
+            zip_map2_into(&mut tmp.view_mut(), &a.view(), &b.view(), |x, y| x + y).unwrap();
+            zip_map2_into(&mut out.view_mut(), &tmp.view(), &a.view(), |x, y| x * y).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.bench_function("fused_static", |bch| {
+        bch.iter(|| {
+            fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.finish();
+}
+
+fn bench_broadcast_exp_mul_add(c: &mut Criterion) {
+    let a = make_input(0.25);
+    let b = make_input(0.5);
+    let c_scalar = StridedArray::<f64>::from_parts(vec![0.125], &[1, 1], &[1, 1], 0).unwrap();
+    let c_view = c_scalar.view();
+    let c_broadcast = c_view.broadcast(&DIMS).unwrap();
+    let mut tmp_mul = StridedArray::<f64>::col_major(&DIMS);
+    let mut tmp_add = StridedArray::<f64>::col_major(&DIMS);
+    let mut out = StridedArray::<f64>::col_major(&DIMS);
+    let plan = FusedPlan {
+        input_count: 3,
+        outputs: vec![5],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![3, 2],
+            },
+            FusedInst {
+                op: FusedOp::Exp,
+                inputs: vec![4],
+            },
+        ],
+    };
+
+    let mut group = c.benchmark_group("fused_broadcast_exp_mul_add");
+    group.bench_function("per_op_reused_buffers", |bch| {
+        bch.iter(|| {
+            zip_map2_into(&mut tmp_mul.view_mut(), &a.view(), &b.view(), |x, y| x * y).unwrap();
+            zip_map2_into(
+                &mut tmp_add.view_mut(),
+                &tmp_mul.view(),
+                &c_broadcast,
+                |x, y| x + y,
+            )
+            .unwrap();
+            map_into(&mut out.view_mut(), &tmp_add.view(), |x| x.exp()).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.bench_function("fused_static", |bch| {
+        bch.iter(|| {
+            fused_elementwise_into(
+                &mut [out.view_mut()],
+                &[a.view(), b.view(), c_broadcast.clone()],
+                &plan,
+            )
+            .unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.finish();
+}
+
+fn bench_long_chain(c: &mut Criterion) {
+    let a = make_input(2.0);
+    let b = make_input(1.0);
+    let lo = make_constant(0.25);
+    let hi = make_constant(4.0);
+    let mut tmp_div = StridedArray::<f64>::col_major(&DIMS);
+    let mut tmp_max = StridedArray::<f64>::col_major(&DIMS);
+    let mut tmp_min = StridedArray::<f64>::col_major(&DIMS);
+    let mut tmp_sqrt = StridedArray::<f64>::col_major(&DIMS);
+    let mut out = StridedArray::<f64>::col_major(&DIMS);
+    let plan = FusedPlan {
+        input_count: 4,
+        outputs: vec![8],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Divide,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Maximum,
+                inputs: vec![4, 2],
+            },
+            FusedInst {
+                op: FusedOp::Minimum,
+                inputs: vec![5, 3],
+            },
+            FusedInst {
+                op: FusedOp::Sqrt,
+                inputs: vec![6],
+            },
+            FusedInst {
+                op: FusedOp::Rsqrt,
+                inputs: vec![7],
+            },
+        ],
+    };
+
+    let mut group = c.benchmark_group("fused_long_chain");
+    group.bench_function("per_op_reused_buffers", |bch| {
+        bch.iter(|| {
+            zip_map2_into(&mut tmp_div.view_mut(), &a.view(), &b.view(), |x, y| x / y).unwrap();
+            zip_map2_into(
+                &mut tmp_max.view_mut(),
+                &tmp_div.view(),
+                &lo.view(),
+                |x, y| x.max(y),
+            )
+            .unwrap();
+            zip_map2_into(
+                &mut tmp_min.view_mut(),
+                &tmp_max.view(),
+                &hi.view(),
+                |x, y| x.min(y),
+            )
+            .unwrap();
+            map_into(&mut tmp_sqrt.view_mut(), &tmp_min.view(), |x| x.sqrt()).unwrap();
+            map_into(&mut out.view_mut(), &tmp_sqrt.view(), |x| 1.0 / x.sqrt()).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.bench_function("fused_static", |bch| {
+        bch.iter(|| {
+            fused_elementwise_into(
+                &mut [out.view_mut()],
+                &[a.view(), b.view(), lo.view(), hi.view()],
+                &plan,
+            )
+            .unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+    targets = bench_add_mul, bench_broadcast_exp_mul_add, bench_long_chain
+}
+criterion_main!(benches);

--- a/strided-kernel/benches/fused_elementwise.rs
+++ b/strided-kernel/benches/fused_elementwise.rs
@@ -185,12 +185,55 @@ fn bench_long_chain(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_interpreter_fallback(c: &mut Criterion) {
+    let a = make_input(0.25);
+    let b = make_input(0.5);
+    let mut tmp_add = StridedArray::<f64>::col_major(&DIMS);
+    let mut tmp_neg = StridedArray::<f64>::col_major(&DIMS);
+    let mut out = StridedArray::<f64>::col_major(&DIMS);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![4],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Negate,
+                inputs: vec![2],
+            },
+            FusedInst {
+                op: FusedOp::Exp,
+                inputs: vec![3],
+            },
+        ],
+    };
+
+    let mut group = c.benchmark_group("fused_interpreter_fallback");
+    group.bench_function("per_op_reused_buffers", |bch| {
+        bch.iter(|| {
+            zip_map2_into(&mut tmp_add.view_mut(), &a.view(), &b.view(), |x, y| x + y).unwrap();
+            map_into(&mut tmp_neg.view_mut(), &tmp_add.view(), |x| -x).unwrap();
+            map_into(&mut out.view_mut(), &tmp_neg.view(), |x| x.exp()).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.bench_function("fused_interpreter", |bch| {
+        bch.iter(|| {
+            fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+            black_box(out.data().as_ptr());
+        });
+    });
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .sample_size(10)
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(2));
-    targets = bench_add_mul, bench_broadcast_exp_mul_add, bench_long_chain
+    targets = bench_add_mul, bench_broadcast_exp_mul_add, bench_long_chain, bench_interpreter_fallback
 }
 criterion_main!(benches);

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -56,7 +56,23 @@ pub struct FusedPlan {
 pub trait FusedScalar: Copy + MaybeSendSync + 'static {
     fn fused_add(self, rhs: Self) -> Self;
     fn fused_multiply(self, rhs: Self) -> Self;
+    fn fused_negate(self) -> Self;
+    fn fused_conj(self) -> Self;
+    fn fused_divide(self, rhs: Self) -> Self;
+    fn fused_abs(self) -> Self;
+    fn fused_maximum(self, rhs: Self) -> Self;
+    fn fused_minimum(self, rhs: Self) -> Self;
+    fn fused_clamp(self, min: Self, max: Self) -> Self;
     fn fused_exp(self) -> Self;
+    fn fused_log(self) -> Self;
+    fn fused_sin(self) -> Self;
+    fn fused_cos(self) -> Self;
+    fn fused_tanh(self) -> Self;
+    fn fused_sqrt(self) -> Self;
+    fn fused_rsqrt(self) -> Self;
+    fn fused_pow(self, rhs: Self) -> Self;
+    fn fused_expm1(self) -> Self;
+    fn fused_log1p(self) -> Self;
 }
 
 macro_rules! impl_real_fused_scalar {
@@ -73,8 +89,88 @@ macro_rules! impl_real_fused_scalar {
             }
 
             #[inline(always)]
+            fn fused_negate(self) -> Self {
+                -self
+            }
+
+            #[inline(always)]
+            fn fused_conj(self) -> Self {
+                self
+            }
+
+            #[inline(always)]
+            fn fused_divide(self, rhs: Self) -> Self {
+                self / rhs
+            }
+
+            #[inline(always)]
+            fn fused_abs(self) -> Self {
+                self.abs()
+            }
+
+            #[inline(always)]
+            fn fused_maximum(self, rhs: Self) -> Self {
+                self.max(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_minimum(self, rhs: Self) -> Self {
+                self.min(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_clamp(self, min: Self, max: Self) -> Self {
+                self.clamp(min, max)
+            }
+
+            #[inline(always)]
             fn fused_exp(self) -> Self {
                 self.exp()
+            }
+
+            #[inline(always)]
+            fn fused_log(self) -> Self {
+                self.ln()
+            }
+
+            #[inline(always)]
+            fn fused_sin(self) -> Self {
+                self.sin()
+            }
+
+            #[inline(always)]
+            fn fused_cos(self) -> Self {
+                self.cos()
+            }
+
+            #[inline(always)]
+            fn fused_tanh(self) -> Self {
+                self.tanh()
+            }
+
+            #[inline(always)]
+            fn fused_sqrt(self) -> Self {
+                self.sqrt()
+            }
+
+            #[inline(always)]
+            fn fused_rsqrt(self) -> Self {
+                1.0 / self.sqrt()
+            }
+
+            #[inline(always)]
+            fn fused_pow(self, rhs: Self) -> Self {
+                self.powf(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_expm1(self) -> Self {
+                self.exp_m1()
+            }
+
+            #[inline(always)]
+            fn fused_log1p(self) -> Self {
+                self.ln_1p()
             }
         }
     };
@@ -94,8 +190,96 @@ macro_rules! impl_complex_fused_scalar {
             }
 
             #[inline(always)]
+            fn fused_negate(self) -> Self {
+                -self
+            }
+
+            #[inline(always)]
+            fn fused_conj(self) -> Self {
+                num_complex::Complex::conj(&self)
+            }
+
+            #[inline(always)]
+            fn fused_divide(self, rhs: Self) -> Self {
+                self / rhs
+            }
+
+            #[inline(always)]
+            fn fused_abs(self) -> Self {
+                Self::new(self.norm(), 0.0)
+            }
+
+            #[inline(always)]
+            fn fused_maximum(self, rhs: Self) -> Self {
+                if self.norm_sqr() >= rhs.norm_sqr() {
+                    self
+                } else {
+                    rhs
+                }
+            }
+
+            #[inline(always)]
+            fn fused_minimum(self, rhs: Self) -> Self {
+                if self.norm_sqr() <= rhs.norm_sqr() {
+                    self
+                } else {
+                    rhs
+                }
+            }
+
+            #[inline(always)]
+            fn fused_clamp(self, min: Self, max: Self) -> Self {
+                self.fused_maximum(min).fused_minimum(max)
+            }
+
+            #[inline(always)]
             fn fused_exp(self) -> Self {
                 self.exp()
+            }
+
+            #[inline(always)]
+            fn fused_log(self) -> Self {
+                self.ln()
+            }
+
+            #[inline(always)]
+            fn fused_sin(self) -> Self {
+                self.sin()
+            }
+
+            #[inline(always)]
+            fn fused_cos(self) -> Self {
+                self.cos()
+            }
+
+            #[inline(always)]
+            fn fused_tanh(self) -> Self {
+                self.tanh()
+            }
+
+            #[inline(always)]
+            fn fused_sqrt(self) -> Self {
+                self.sqrt()
+            }
+
+            #[inline(always)]
+            fn fused_rsqrt(self) -> Self {
+                Self::new(1.0, 0.0) / self.sqrt()
+            }
+
+            #[inline(always)]
+            fn fused_pow(self, rhs: Self) -> Self {
+                self.powc(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_expm1(self) -> Self {
+                self.exp() - Self::new(1.0, 0.0)
+            }
+
+            #[inline(always)]
+            fn fused_log1p(self) -> Self {
+                (self + Self::new(1.0, 0.0)).ln()
             }
         }
     };
@@ -193,8 +377,23 @@ fn eval_op<T: FusedScalar>(op: FusedOp, regs: &[T], inputs: &[usize]) -> T {
     match op {
         FusedOp::Add => regs[inputs[0]].fused_add(regs[inputs[1]]),
         FusedOp::Multiply => regs[inputs[0]].fused_multiply(regs[inputs[1]]),
+        FusedOp::Negate => regs[inputs[0]].fused_negate(),
+        FusedOp::Conj => regs[inputs[0]].fused_conj(),
+        FusedOp::Divide => regs[inputs[0]].fused_divide(regs[inputs[1]]),
+        FusedOp::Abs => regs[inputs[0]].fused_abs(),
+        FusedOp::Maximum => regs[inputs[0]].fused_maximum(regs[inputs[1]]),
+        FusedOp::Minimum => regs[inputs[0]].fused_minimum(regs[inputs[1]]),
+        FusedOp::Clamp => regs[inputs[0]].fused_clamp(regs[inputs[1]], regs[inputs[2]]),
         FusedOp::Exp => regs[inputs[0]].fused_exp(),
-        _ => unimplemented!("{op:?} is not implemented yet"),
+        FusedOp::Log => regs[inputs[0]].fused_log(),
+        FusedOp::Sin => regs[inputs[0]].fused_sin(),
+        FusedOp::Cos => regs[inputs[0]].fused_cos(),
+        FusedOp::Tanh => regs[inputs[0]].fused_tanh(),
+        FusedOp::Sqrt => regs[inputs[0]].fused_sqrt(),
+        FusedOp::Rsqrt => regs[inputs[0]].fused_rsqrt(),
+        FusedOp::Pow => regs[inputs[0]].fused_pow(regs[inputs[1]]),
+        FusedOp::Expm1 => regs[inputs[0]].fused_expm1(),
+        FusedOp::Log1p => regs[inputs[0]].fused_log1p(),
     }
 }
 

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -4,7 +4,7 @@ use crate::kernel::{
     build_plan_fused, build_plan_fused_small, ensure_same_shape, for_each_inner_block_preordered,
     total_len, SMALL_TENSOR_THRESHOLD,
 };
-use crate::map_view::{map_into, zip_map2_into, zip_map3_into};
+use crate::map_view::{map_into, zip_map2_into, zip_map3_into, zip_map4_into};
 use crate::{MaybeSendSync, Result, StridedError, StridedView, StridedViewMut};
 
 #[cfg(feature = "parallel")]
@@ -527,6 +527,37 @@ fn try_static_specialization<T: FusedScalar>(
         return Ok(true);
     }
 
+    if plan.input_count == 4
+        && plan.outputs.as_slice() == [8]
+        && plan.ops.len() == 5
+        && plan.ops[0].op == FusedOp::Divide
+        && plan.ops[0].inputs.as_slice() == [0, 1]
+        && plan.ops[1].op == FusedOp::Maximum
+        && plan.ops[1].inputs.as_slice() == [4, 2]
+        && plan.ops[2].op == FusedOp::Minimum
+        && plan.ops[2].inputs.as_slice() == [5, 3]
+        && plan.ops[3].op == FusedOp::Sqrt
+        && plan.ops[3].inputs.as_slice() == [6]
+        && plan.ops[4].op == FusedOp::Rsqrt
+        && plan.ops[4].inputs.as_slice() == [7]
+    {
+        zip_map4_into(
+            &mut dests[0],
+            &inputs[0],
+            &inputs[1],
+            &inputs[2],
+            &inputs[3],
+            |a, b, lo, hi| {
+                a.fused_divide(b)
+                    .fused_maximum(lo)
+                    .fused_minimum(hi)
+                    .fused_sqrt()
+                    .fused_rsqrt()
+            },
+        )?;
+        return Ok(true);
+    }
+
     Ok(false)
 }
 
@@ -805,5 +836,41 @@ mod tests {
         };
 
         assert_static_matches_interpreter(plan, &[a, b, c]);
+    }
+
+    #[test]
+    fn specializes_divide_clamp_sqrt_rsqrt_chain() {
+        let a = input(&[4.0, 9.0, 16.0]);
+        let b = input(&[2.0, 3.0, 4.0]);
+        let lo = input(&[1.5, 1.5, 1.5]);
+        let hi = input(&[8.0, 8.0, 8.0]);
+        let plan = FusedPlan {
+            input_count: 4,
+            outputs: vec![8],
+            ops: vec![
+                FusedInst {
+                    op: FusedOp::Divide,
+                    inputs: vec![0, 1],
+                },
+                FusedInst {
+                    op: FusedOp::Maximum,
+                    inputs: vec![4, 2],
+                },
+                FusedInst {
+                    op: FusedOp::Minimum,
+                    inputs: vec![5, 3],
+                },
+                FusedInst {
+                    op: FusedOp::Sqrt,
+                    inputs: vec![6],
+                },
+                FusedInst {
+                    op: FusedOp::Rsqrt,
+                    inputs: vec![7],
+                },
+            ],
+        };
+
+        assert_static_matches_interpreter(plan, &[a, b, lo, hi]);
     }
 }

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -1,0 +1,144 @@
+//! Runtime-DAG fused elementwise kernels.
+
+use crate::kernel::ensure_same_shape;
+use crate::{MaybeSendSync, Result, StridedError, StridedView, StridedViewMut};
+
+/// Runtime scalar operation for a fused elementwise plan.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FusedOp {
+    Add,
+    Multiply,
+    Negate,
+    Conj,
+    Divide,
+    Abs,
+    Maximum,
+    Minimum,
+    Clamp,
+    Exp,
+    Log,
+    Sin,
+    Cos,
+    Tanh,
+    Sqrt,
+    Rsqrt,
+    Pow,
+    Expm1,
+    Log1p,
+}
+
+/// One SSA instruction in a [`FusedPlan`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FusedInst {
+    pub op: FusedOp,
+    pub inputs: Vec<usize>,
+}
+
+/// Topologically ordered fused elementwise DAG.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FusedPlan {
+    pub input_count: usize,
+    pub outputs: Vec<usize>,
+    pub ops: Vec<FusedInst>,
+}
+
+/// Scalar types supported by [`fused_elementwise_into`].
+pub trait FusedScalar: Copy + MaybeSendSync + 'static {}
+
+impl FusedScalar for f32 {}
+impl FusedScalar for f64 {}
+impl FusedScalar for num_complex::Complex32 {}
+impl FusedScalar for num_complex::Complex64 {}
+
+#[inline]
+fn op_arity(op: FusedOp) -> usize {
+    match op {
+        FusedOp::Negate
+        | FusedOp::Conj
+        | FusedOp::Abs
+        | FusedOp::Exp
+        | FusedOp::Log
+        | FusedOp::Sin
+        | FusedOp::Cos
+        | FusedOp::Tanh
+        | FusedOp::Sqrt
+        | FusedOp::Rsqrt
+        | FusedOp::Expm1
+        | FusedOp::Log1p => 1,
+        FusedOp::Add
+        | FusedOp::Multiply
+        | FusedOp::Divide
+        | FusedOp::Maximum
+        | FusedOp::Minimum
+        | FusedOp::Pow => 2,
+        FusedOp::Clamp => 3,
+    }
+}
+
+fn validate_plan(plan: &FusedPlan, input_count: usize, output_count: usize) -> Result<()> {
+    if input_count != plan.input_count {
+        return Err(StridedError::RankMismatch(input_count, plan.input_count));
+    }
+    if output_count != plan.outputs.len() {
+        return Err(StridedError::RankMismatch(output_count, plan.outputs.len()));
+    }
+    if output_count == 0 {
+        return Err(StridedError::RankMismatch(0, 1));
+    }
+
+    let mut value_count = plan.input_count;
+    for inst in &plan.ops {
+        let expected_arity = op_arity(inst.op);
+        if inst.inputs.len() != expected_arity {
+            return Err(StridedError::RankMismatch(
+                inst.inputs.len(),
+                expected_arity,
+            ));
+        }
+        for &input in &inst.inputs {
+            if input >= value_count {
+                return Err(StridedError::InvalidAxis {
+                    axis: input,
+                    rank: value_count,
+                });
+            }
+        }
+        value_count += 1;
+    }
+
+    for &output in &plan.outputs {
+        if output >= value_count {
+            return Err(StridedError::InvalidAxis {
+                axis: output,
+                rank: value_count,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_shapes<T: FusedScalar>(
+    dests: &[StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+) -> Result<()> {
+    let dims = dests[0].dims();
+    for dest in &dests[1..] {
+        ensure_same_shape(dims, dest.dims())?;
+    }
+    for input in inputs {
+        ensure_same_shape(dims, input.dims())?;
+    }
+    Ok(())
+}
+
+/// Evaluate a runtime-DAG elementwise plan into one or more destinations.
+pub fn fused_elementwise_into<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()> {
+    validate_plan(plan, inputs.len(), dests.len())?;
+    validate_shapes(dests, inputs)?;
+    Ok(())
+}

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -4,6 +4,7 @@ use crate::kernel::{
     build_plan_fused, build_plan_fused_small, ensure_same_shape, for_each_inner_block_preordered,
     total_len, SMALL_TENSOR_THRESHOLD,
 };
+use crate::map_view::{map_into, zip_map2_into, zip_map3_into};
 use crate::{MaybeSendSync, Result, StridedError, StridedView, StridedViewMut};
 
 #[cfg(feature = "parallel")]
@@ -375,26 +376,158 @@ fn validate_shapes<T: FusedScalar>(
 #[inline(always)]
 fn eval_op<T: FusedScalar>(op: FusedOp, regs: &[T], inputs: &[usize]) -> T {
     match op {
-        FusedOp::Add => regs[inputs[0]].fused_add(regs[inputs[1]]),
-        FusedOp::Multiply => regs[inputs[0]].fused_multiply(regs[inputs[1]]),
-        FusedOp::Negate => regs[inputs[0]].fused_negate(),
-        FusedOp::Conj => regs[inputs[0]].fused_conj(),
-        FusedOp::Divide => regs[inputs[0]].fused_divide(regs[inputs[1]]),
-        FusedOp::Abs => regs[inputs[0]].fused_abs(),
-        FusedOp::Maximum => regs[inputs[0]].fused_maximum(regs[inputs[1]]),
-        FusedOp::Minimum => regs[inputs[0]].fused_minimum(regs[inputs[1]]),
-        FusedOp::Clamp => regs[inputs[0]].fused_clamp(regs[inputs[1]], regs[inputs[2]]),
-        FusedOp::Exp => regs[inputs[0]].fused_exp(),
-        FusedOp::Log => regs[inputs[0]].fused_log(),
-        FusedOp::Sin => regs[inputs[0]].fused_sin(),
-        FusedOp::Cos => regs[inputs[0]].fused_cos(),
-        FusedOp::Tanh => regs[inputs[0]].fused_tanh(),
-        FusedOp::Sqrt => regs[inputs[0]].fused_sqrt(),
-        FusedOp::Rsqrt => regs[inputs[0]].fused_rsqrt(),
-        FusedOp::Pow => regs[inputs[0]].fused_pow(regs[inputs[1]]),
-        FusedOp::Expm1 => regs[inputs[0]].fused_expm1(),
-        FusedOp::Log1p => regs[inputs[0]].fused_log1p(),
+        FusedOp::Negate
+        | FusedOp::Conj
+        | FusedOp::Abs
+        | FusedOp::Exp
+        | FusedOp::Log
+        | FusedOp::Sin
+        | FusedOp::Cos
+        | FusedOp::Tanh
+        | FusedOp::Sqrt
+        | FusedOp::Rsqrt
+        | FusedOp::Expm1
+        | FusedOp::Log1p => eval_unary(op, regs[inputs[0]]),
+        FusedOp::Add
+        | FusedOp::Multiply
+        | FusedOp::Divide
+        | FusedOp::Maximum
+        | FusedOp::Minimum
+        | FusedOp::Pow => eval_binary(op, regs[inputs[0]], regs[inputs[1]]),
+        FusedOp::Clamp => eval_ternary(op, regs[inputs[0]], regs[inputs[1]], regs[inputs[2]]),
     }
+}
+
+#[inline(always)]
+fn eval_unary<T: FusedScalar>(op: FusedOp, x: T) -> T {
+    match op {
+        FusedOp::Negate => x.fused_negate(),
+        FusedOp::Conj => x.fused_conj(),
+        FusedOp::Abs => x.fused_abs(),
+        FusedOp::Exp => x.fused_exp(),
+        FusedOp::Log => x.fused_log(),
+        FusedOp::Sin => x.fused_sin(),
+        FusedOp::Cos => x.fused_cos(),
+        FusedOp::Tanh => x.fused_tanh(),
+        FusedOp::Sqrt => x.fused_sqrt(),
+        FusedOp::Rsqrt => x.fused_rsqrt(),
+        FusedOp::Expm1 => x.fused_expm1(),
+        FusedOp::Log1p => x.fused_log1p(),
+        _ => unreachable!("not a unary fused op: {op:?}"),
+    }
+}
+
+#[inline(always)]
+fn eval_binary<T: FusedScalar>(op: FusedOp, a: T, b: T) -> T {
+    match op {
+        FusedOp::Add => a.fused_add(b),
+        FusedOp::Multiply => a.fused_multiply(b),
+        FusedOp::Divide => a.fused_divide(b),
+        FusedOp::Maximum => a.fused_maximum(b),
+        FusedOp::Minimum => a.fused_minimum(b),
+        FusedOp::Pow => a.fused_pow(b),
+        _ => unreachable!("not a binary fused op: {op:?}"),
+    }
+}
+
+#[inline(always)]
+fn eval_ternary<T: FusedScalar>(op: FusedOp, a: T, b: T, c: T) -> T {
+    match op {
+        FusedOp::Clamp => a.fused_clamp(b, c),
+        _ => unreachable!("not a ternary fused op: {op:?}"),
+    }
+}
+
+fn try_static_specialization<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<bool> {
+    if dests.len() != 1 || plan.outputs.len() != 1 {
+        return Ok(false);
+    }
+
+    if let [inst] = plan.ops.as_slice() {
+        let output_id = plan.input_count;
+        if plan.outputs[0] != output_id {
+            return Ok(false);
+        }
+
+        match op_arity(inst.op) {
+            1 => {
+                map_into(&mut dests[0], &inputs[inst.inputs[0]], |x| {
+                    eval_unary(inst.op, x)
+                })?;
+                return Ok(true);
+            }
+            2 => {
+                zip_map2_into(
+                    &mut dests[0],
+                    &inputs[inst.inputs[0]],
+                    &inputs[inst.inputs[1]],
+                    |a, b| eval_binary(inst.op, a, b),
+                )?;
+                return Ok(true);
+            }
+            3 => {
+                zip_map3_into(
+                    &mut dests[0],
+                    &inputs[inst.inputs[0]],
+                    &inputs[inst.inputs[1]],
+                    &inputs[inst.inputs[2]],
+                    |a, b, c| eval_ternary(inst.op, a, b, c),
+                )?;
+                return Ok(true);
+            }
+            _ => unreachable!("unsupported fused op arity"),
+        }
+    }
+
+    if plan.input_count == 2
+        && plan.outputs.as_slice() == [3]
+        && plan.ops.len() == 2
+        && plan.ops[0].op == FusedOp::Add
+        && plan.ops[0].inputs.as_slice() == [0, 1]
+        && plan.ops[1].op == FusedOp::Multiply
+    {
+        match plan.ops[1].inputs.as_slice() {
+            [2, 0] => {
+                zip_map2_into(&mut dests[0], &inputs[0], &inputs[1], |a, b| {
+                    a.fused_add(b).fused_multiply(a)
+                })?;
+                return Ok(true);
+            }
+            [0, 2] => {
+                zip_map2_into(&mut dests[0], &inputs[0], &inputs[1], |a, b| {
+                    a.fused_multiply(a.fused_add(b))
+                })?;
+                return Ok(true);
+            }
+            _ => {}
+        }
+    }
+
+    if plan.input_count == 3
+        && plan.outputs.as_slice() == [5]
+        && plan.ops.len() == 3
+        && plan.ops[0].op == FusedOp::Multiply
+        && plan.ops[0].inputs.as_slice() == [0, 1]
+        && plan.ops[1].op == FusedOp::Add
+        && plan.ops[1].inputs.as_slice() == [3, 2]
+        && plan.ops[2].op == FusedOp::Exp
+        && plan.ops[2].inputs.as_slice() == [4]
+    {
+        zip_map3_into(
+            &mut dests[0],
+            &inputs[0],
+            &inputs[1],
+            &inputs[2],
+            |a, b, c| a.fused_multiply(b).fused_add(c).fused_exp(),
+        )?;
+        return Ok(true);
+    }
+
+    Ok(false)
 }
 
 unsafe fn interpret_inner_loop<T: FusedScalar>(
@@ -531,5 +664,146 @@ pub fn fused_elementwise_into<T: FusedScalar>(
 ) -> Result<()> {
     validate_plan(plan, inputs.len(), dests.len())?;
     validate_shapes(dests, inputs)?;
+    if try_static_specialization(dests, inputs, plan)? {
+        return Ok(());
+    }
     interpret_fused_elementwise_into(dests, inputs, plan)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StridedArray;
+
+    fn input(values: &[f64]) -> StridedArray<f64> {
+        StridedArray::from_parts(values.to_vec(), &[values.len()], &[1], 0).unwrap()
+    }
+
+    fn run_static(plan: &FusedPlan, arrays: &[StridedArray<f64>]) -> (bool, Vec<f64>) {
+        let inputs: Vec<_> = arrays.iter().map(|array| array.view()).collect();
+        let mut out = StridedArray::<f64>::col_major(arrays[0].dims());
+        let used_static = {
+            let mut dests = [out.view_mut()];
+            try_static_specialization(&mut dests, &inputs, plan).unwrap()
+        };
+        (used_static, out.iter().copied().collect())
+    }
+
+    fn run_interpreter(plan: &FusedPlan, arrays: &[StridedArray<f64>]) -> Vec<f64> {
+        let inputs: Vec<_> = arrays.iter().map(|array| array.view()).collect();
+        let mut out = StridedArray::<f64>::col_major(arrays[0].dims());
+        {
+            let mut dests = [out.view_mut()];
+            interpret_fused_elementwise_into(&mut dests, &inputs, plan).unwrap();
+        }
+        out.iter().copied().collect()
+    }
+
+    fn assert_static_matches_interpreter(plan: FusedPlan, arrays: &[StridedArray<f64>]) {
+        let (used_static, static_values) = run_static(&plan, arrays);
+        let interpreter_values = run_interpreter(&plan, arrays);
+
+        assert!(used_static, "plan should use static specialization");
+        assert_eq!(static_values.len(), interpreter_values.len());
+        for (actual, expected) in static_values.iter().zip(interpreter_values.iter()) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn specializes_unary_exp() {
+        let a = input(&[1.0, 2.0, 3.0]);
+        let plan = FusedPlan {
+            input_count: 1,
+            outputs: vec![1],
+            ops: vec![FusedInst {
+                op: FusedOp::Exp,
+                inputs: vec![0],
+            }],
+        };
+
+        assert_static_matches_interpreter(plan, &[a]);
+    }
+
+    #[test]
+    fn specializes_binary_add() {
+        let a = input(&[1.0, 2.0, 3.0]);
+        let b = input(&[10.0, 20.0, 30.0]);
+        let plan = FusedPlan {
+            input_count: 2,
+            outputs: vec![2],
+            ops: vec![FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            }],
+        };
+
+        assert_static_matches_interpreter(plan, &[a, b]);
+    }
+
+    #[test]
+    fn specializes_ternary_clamp() {
+        let x = input(&[1.0, 2.0, 3.0]);
+        let lo = input(&[1.5, 1.5, 1.5]);
+        let hi = input(&[2.5, 2.5, 2.5]);
+        let plan = FusedPlan {
+            input_count: 3,
+            outputs: vec![3],
+            ops: vec![FusedInst {
+                op: FusedOp::Clamp,
+                inputs: vec![0, 1, 2],
+            }],
+        };
+
+        assert_static_matches_interpreter(plan, &[x, lo, hi]);
+    }
+
+    #[test]
+    fn specializes_add_then_multiply_reusing_input() {
+        let a = input(&[1.0, 2.0, 3.0]);
+        let b = input(&[10.0, 20.0, 30.0]);
+        let plan = FusedPlan {
+            input_count: 2,
+            outputs: vec![3],
+            ops: vec![
+                FusedInst {
+                    op: FusedOp::Add,
+                    inputs: vec![0, 1],
+                },
+                FusedInst {
+                    op: FusedOp::Multiply,
+                    inputs: vec![2, 0],
+                },
+            ],
+        };
+
+        assert_static_matches_interpreter(plan, &[a, b]);
+    }
+
+    #[test]
+    fn specializes_exp_of_multiply_add_chain() {
+        let a = input(&[1.0, 2.0, 3.0]);
+        let b = input(&[0.5, 1.5, 2.5]);
+        let c = input(&[2.0, 2.0, 2.0]);
+        let plan = FusedPlan {
+            input_count: 3,
+            outputs: vec![5],
+            ops: vec![
+                FusedInst {
+                    op: FusedOp::Multiply,
+                    inputs: vec![0, 1],
+                },
+                FusedInst {
+                    op: FusedOp::Add,
+                    inputs: vec![3, 2],
+                },
+                FusedInst {
+                    op: FusedOp::Exp,
+                    inputs: vec![4],
+                },
+            ],
+        };
+
+        assert_static_matches_interpreter(plan, &[a, b, c]);
+    }
 }

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -45,7 +45,18 @@ pub struct FusedInst {
     pub inputs: Vec<usize>,
 }
 
-/// Topologically ordered fused elementwise DAG.
+/// Topologically ordered fused elementwise SSA DAG.
+///
+/// Values are numbered in evaluation order. Input values occupy
+/// `0..input_count`; each instruction appends one value after the previous
+/// inputs/instructions. For example, with `input_count == 2`, the first
+/// instruction writes value `2`, the second writes value `3`, and so on.
+/// `outputs` contains the value ids to write to `dests` in order.
+///
+/// All inputs and destinations passed to [`fused_elementwise_into`] must have
+/// the same shape and scalar type. Broadcast inputs should be represented with
+/// `StridedView::broadcast` before building the plan; the fused API does not
+/// perform implicit broadcasting.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FusedPlan {
     pub input_count: usize,
@@ -121,7 +132,7 @@ macro_rules! impl_real_fused_scalar {
 
             #[inline(always)]
             fn fused_clamp(self, min: Self, max: Self) -> Self {
-                self.clamp(min, max)
+                self.fused_maximum(min).fused_minimum(max)
             }
 
             #[inline(always)]
@@ -364,6 +375,9 @@ fn validate_shapes<T: FusedScalar>(
     inputs: &[StridedView<'_, T>],
 ) -> Result<()> {
     let dims = dests[0].dims();
+    for dest in dests {
+        validate_destination_layout(dest)?;
+    }
     for dest in &dests[1..] {
         ensure_same_shape(dims, dest.dims())?;
     }
@@ -371,6 +385,110 @@ fn validate_shapes<T: FusedScalar>(
         ensure_same_shape(dims, input.dims())?;
     }
     Ok(())
+}
+
+fn validate_destination_layout<T>(dest: &StridedViewMut<'_, T>) -> Result<()> {
+    if is_injective_layout(dest.dims(), dest.strides()) {
+        Ok(())
+    } else {
+        Err(StridedError::NonInjectiveOutputLayout)
+    }
+}
+
+fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
+    if dims.len() != strides.len() {
+        return false;
+    }
+
+    let Some(total) = dims
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+    else {
+        return false;
+    };
+    if total <= 1 {
+        return true;
+    }
+    if dims
+        .iter()
+        .zip(strides.iter())
+        .any(|(&dim, &stride)| dim > 1 && stride == 0)
+    {
+        return false;
+    }
+
+    const EXACT_CHECK_LIMIT: usize = 4096;
+    if total <= EXACT_CHECK_LIMIT {
+        return has_unique_offsets_exact(dims, strides, total);
+    }
+
+    has_disjoint_stride_spans(dims, strides)
+}
+
+fn has_unique_offsets_exact(dims: &[usize], strides: &[isize], total: usize) -> bool {
+    let mut seen = std::collections::HashSet::with_capacity(total);
+    let mut indices = vec![0usize; dims.len()];
+    let mut offset = 0isize;
+
+    for _ in 0..total {
+        if !seen.insert(offset) {
+            return false;
+        }
+
+        for axis in 0..dims.len() {
+            indices[axis] += 1;
+            offset = match offset.checked_add(strides[axis]) {
+                Some(offset) => offset,
+                None => return false,
+            };
+            if indices[axis] < dims[axis] {
+                break;
+            }
+
+            let rewind = match strides[axis].checked_mul(indices[axis] as isize) {
+                Some(rewind) => rewind,
+                None => return false,
+            };
+            offset = match offset.checked_sub(rewind) {
+                Some(offset) => offset,
+                None => return false,
+            };
+            indices[axis] = 0;
+        }
+    }
+
+    true
+}
+
+fn has_disjoint_stride_spans(dims: &[usize], strides: &[isize]) -> bool {
+    let mut axes = Vec::with_capacity(dims.len());
+    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+        if dim <= 1 {
+            continue;
+        }
+        let stride_abs = match stride.checked_abs() {
+            Some(stride_abs) => stride_abs as u128,
+            None => return false,
+        };
+        axes.push((stride_abs, dim as u128 - 1));
+    }
+    axes.sort_unstable_by_key(|&(stride, _)| stride);
+
+    let mut covered_span = 0u128;
+    for (stride, extent) in axes {
+        if stride <= covered_span {
+            return false;
+        }
+        covered_span = match stride
+            .checked_mul(extent)
+            .and_then(|span| covered_span.checked_add(span))
+        {
+            Some(covered_span) => covered_span,
+            None => return false,
+        };
+    }
+
+    true
 }
 
 #[inline(always)]
@@ -688,6 +806,25 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
 }
 
 /// Evaluate a runtime-DAG elementwise plan into one or more destinations.
+///
+/// The plan is validated before any destination is written:
+///
+/// - `inputs.len()` must equal `plan.input_count`;
+/// - `dests.len()` must equal `plan.outputs.len()`;
+/// - instruction operands must reference earlier SSA values with the right
+///   arity for their [`FusedOp`];
+/// - every input and destination must have exactly the destination shape;
+/// - each mutable destination layout must be injective, so two logical output
+///   elements never map to the same memory address.
+///
+/// The implementation dispatches known single-output plans to existing static
+/// `map_into`/`zip_map*_into` kernels and uses a generic interpreter fallback
+/// for arbitrary validated DAGs. Overlapping source/destination memory is not
+/// supported by the strided kernels generally.
+///
+/// Real `Maximum`, `Minimum`, and `Clamp` use Rust `f32`/`f64` `max`/`min`
+/// semantics. Complex `Abs` returns the norm in the real component; complex
+/// `Maximum`, `Minimum`, and `Clamp` compare by squared norm.
 pub fn fused_elementwise_into<T: FusedScalar>(
     dests: &mut [StridedViewMut<'_, T>],
     inputs: &[StridedView<'_, T>],

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -1,7 +1,17 @@
 //! Runtime-DAG fused elementwise kernels.
 
-use crate::kernel::ensure_same_shape;
+use crate::kernel::{
+    build_plan_fused, build_plan_fused_small, ensure_same_shape, for_each_inner_block_preordered,
+    total_len, SMALL_TENSOR_THRESHOLD,
+};
 use crate::{MaybeSendSync, Result, StridedError, StridedView, StridedViewMut};
+
+#[cfg(feature = "parallel")]
+use crate::fuse::compute_costs;
+#[cfg(feature = "parallel")]
+use crate::threading::{
+    for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
+};
 
 /// Runtime scalar operation for a fused elementwise plan.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -43,12 +53,58 @@ pub struct FusedPlan {
 }
 
 /// Scalar types supported by [`fused_elementwise_into`].
-pub trait FusedScalar: Copy + MaybeSendSync + 'static {}
+pub trait FusedScalar: Copy + MaybeSendSync + 'static {
+    fn fused_add(self, rhs: Self) -> Self;
+    fn fused_multiply(self, rhs: Self) -> Self;
+    fn fused_exp(self) -> Self;
+}
 
-impl FusedScalar for f32 {}
-impl FusedScalar for f64 {}
-impl FusedScalar for num_complex::Complex32 {}
-impl FusedScalar for num_complex::Complex64 {}
+macro_rules! impl_real_fused_scalar {
+    ($ty:ty) => {
+        impl FusedScalar for $ty {
+            #[inline(always)]
+            fn fused_add(self, rhs: Self) -> Self {
+                self + rhs
+            }
+
+            #[inline(always)]
+            fn fused_multiply(self, rhs: Self) -> Self {
+                self * rhs
+            }
+
+            #[inline(always)]
+            fn fused_exp(self) -> Self {
+                self.exp()
+            }
+        }
+    };
+}
+
+macro_rules! impl_complex_fused_scalar {
+    ($ty:ty) => {
+        impl FusedScalar for $ty {
+            #[inline(always)]
+            fn fused_add(self, rhs: Self) -> Self {
+                self + rhs
+            }
+
+            #[inline(always)]
+            fn fused_multiply(self, rhs: Self) -> Self {
+                self * rhs
+            }
+
+            #[inline(always)]
+            fn fused_exp(self) -> Self {
+                self.exp()
+            }
+        }
+    };
+}
+
+impl_real_fused_scalar!(f32);
+impl_real_fused_scalar!(f64);
+impl_complex_fused_scalar!(num_complex::Complex32);
+impl_complex_fused_scalar!(num_complex::Complex64);
 
 #[inline]
 fn op_arity(op: FusedOp) -> usize {
@@ -132,6 +188,142 @@ fn validate_shapes<T: FusedScalar>(
     Ok(())
 }
 
+#[inline(always)]
+fn eval_op<T: FusedScalar>(op: FusedOp, regs: &[T], inputs: &[usize]) -> T {
+    match op {
+        FusedOp::Add => regs[inputs[0]].fused_add(regs[inputs[1]]),
+        FusedOp::Multiply => regs[inputs[0]].fused_multiply(regs[inputs[1]]),
+        FusedOp::Exp => regs[inputs[0]].fused_exp(),
+        _ => unimplemented!("{op:?} is not implemented yet"),
+    }
+}
+
+unsafe fn interpret_inner_loop<T: FusedScalar>(
+    dst_ptrs: &[*mut T],
+    input_ptrs: &[*const T],
+    plan: &FusedPlan,
+    offsets: &[isize],
+    len: usize,
+    strides: &[isize],
+) {
+    let output_count = dst_ptrs.len();
+    let mut regs = Vec::with_capacity(plan.input_count + plan.ops.len());
+
+    for i in 0..len {
+        let i = i as isize;
+        regs.clear();
+
+        for (input_index, &input_ptr) in input_ptrs.iter().enumerate() {
+            let stride_index = output_count + input_index;
+            regs.push(*input_ptr.offset(offsets[stride_index] + i * strides[stride_index]));
+        }
+
+        for inst in &plan.ops {
+            regs.push(eval_op(inst.op, &regs, &inst.inputs));
+        }
+
+        for (output_index, &dst_ptr) in dst_ptrs.iter().enumerate() {
+            *dst_ptr.offset(offsets[output_index] + i * strides[output_index]) =
+                regs[plan.outputs[output_index]];
+        }
+    }
+}
+
+fn interpret_fused_elementwise_into<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()> {
+    let dims = dests[0].dims().to_vec();
+    if total_len(&dims) == 0 {
+        return Ok(());
+    }
+
+    let dst_ptrs: Vec<*mut T> = dests.iter_mut().map(|dest| dest.as_mut_ptr()).collect();
+    let input_ptrs: Vec<*const T> = inputs.iter().map(StridedView::ptr).collect();
+
+    let mut strides_list: Vec<&[isize]> = Vec::with_capacity(dests.len() + inputs.len());
+    for dest in dests.iter() {
+        strides_list.push(dest.strides());
+    }
+    for input in inputs {
+        strides_list.push(input.strides());
+    }
+
+    let elem_size = std::mem::size_of::<T>();
+    let total = total_len(&dims);
+    let (fused_dims, ordered_strides, kernel_plan) = if total <= SMALL_TENSOR_THRESHOLD {
+        build_plan_fused_small(&dims, &strides_list)
+    } else {
+        build_plan_fused(&dims, &strides_list, Some(0), elem_size)
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        let total: usize = fused_dims.iter().product();
+        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+            let dst_send: Vec<SendPtr<T>> = dst_ptrs.iter().map(|&ptr| SendPtr(ptr)).collect();
+            let input_send: Vec<SendPtr<T>> = input_ptrs
+                .iter()
+                .map(|&ptr| SendPtr(ptr as *mut T))
+                .collect();
+
+            let costs = compute_costs(&ordered_strides);
+            let initial_offsets = vec![0isize; ordered_strides.len()];
+            let nthreads = rayon::current_num_threads();
+
+            return mapreduce_threaded(
+                &fused_dims,
+                &kernel_plan.block,
+                &ordered_strides,
+                &initial_offsets,
+                &costs,
+                nthreads,
+                0,
+                1,
+                &|dims, blocks, strides_list, offsets| {
+                    let dst_ptrs: Vec<*mut T> = dst_send.iter().map(|ptr| ptr.as_ptr()).collect();
+                    let input_ptrs: Vec<*const T> =
+                        input_send.iter().map(|ptr| ptr.as_const()).collect();
+                    for_each_inner_block_with_offsets(
+                        dims,
+                        blocks,
+                        strides_list,
+                        offsets,
+                        |offsets, len, strides| {
+                            unsafe {
+                                interpret_inner_loop(
+                                    &dst_ptrs,
+                                    &input_ptrs,
+                                    plan,
+                                    offsets,
+                                    len,
+                                    strides,
+                                );
+                            }
+                            Ok(())
+                        },
+                    )
+                },
+            );
+        }
+    }
+
+    let initial_offsets = vec![0isize; ordered_strides.len()];
+    for_each_inner_block_preordered(
+        &fused_dims,
+        &kernel_plan.block,
+        &ordered_strides,
+        &initial_offsets,
+        |offsets, len, strides| {
+            unsafe {
+                interpret_inner_loop(&dst_ptrs, &input_ptrs, plan, offsets, len, strides);
+            }
+            Ok(())
+        },
+    )
+}
+
 /// Evaluate a runtime-DAG elementwise plan into one or more destinations.
 pub fn fused_elementwise_into<T: FusedScalar>(
     dests: &mut [StridedViewMut<'_, T>],
@@ -140,5 +332,5 @@ pub fn fused_elementwise_into<T: FusedScalar>(
 ) -> Result<()> {
     validate_plan(plan, inputs.len(), dests.len())?;
     validate_shapes(dests, inputs)?;
-    Ok(())
+    interpret_fused_elementwise_into(dests, inputs, plan)
 }

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -56,6 +56,7 @@
 
 mod block;
 mod fuse;
+mod fused;
 mod kernel;
 mod order;
 mod simd;
@@ -87,6 +88,11 @@ pub use strided_view::{
 pub use map_view::{
     broadcast_mul_into, map_into, mul_into, zip_map2_into, zip_map3_into, zip_map4_into,
 };
+
+// ============================================================================
+// Runtime-DAG fused elementwise operations
+// ============================================================================
+pub use fused::{fused_elementwise_into, FusedInst, FusedOp, FusedPlan, FusedScalar};
 
 // ============================================================================
 // Outer-product operations

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -1,3 +1,4 @@
+use approx::assert_relative_eq;
 use strided_kernel::{
     fused_elementwise_into, FusedInst, FusedOp, FusedPlan, StridedArray, StridedError,
 };
@@ -107,4 +108,149 @@ fn fused_rejects_shape_mismatch_before_writing() {
     assert!(matches!(err, StridedError::ShapeMismatch(_, _)));
     assert_eq!(out.get(&[0]), 0.0);
     assert_eq!(out.get(&[1]), 0.0);
+}
+
+#[test]
+fn fused_interprets_reused_dag_value() {
+    let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let b = input(&[10.0, 20.0, 30.0, 40.0], &[4]);
+    let mut out = StridedArray::<f64>::col_major(&[4]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![3],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![2, 0],
+            },
+        ],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+
+    for i in 0..4 {
+        assert_relative_eq!(
+            out.get(&[i]),
+            (a.get(&[i]) + b.get(&[i])) * a.get(&[i]),
+            epsilon = 1e-12
+        );
+    }
+}
+
+#[test]
+fn fused_interprets_multiple_outputs() {
+    let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let b = input(&[10.0, 20.0, 30.0, 40.0], &[4]);
+    let mut sum = StridedArray::<f64>::col_major(&[4]);
+    let mut product = StridedArray::<f64>::col_major(&[4]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2, 3],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![0, 1],
+            },
+        ],
+    };
+
+    fused_elementwise_into(
+        &mut [sum.view_mut(), product.view_mut()],
+        &[a.view(), b.view()],
+        &plan,
+    )
+    .unwrap();
+
+    for i in 0..4 {
+        assert_relative_eq!(sum.get(&[i]), a.get(&[i]) + b.get(&[i]), epsilon = 1e-12);
+        assert_relative_eq!(
+            product.get(&[i]),
+            a.get(&[i]) * b.get(&[i]),
+            epsilon = 1e-12
+        );
+    }
+}
+
+#[test]
+fn fused_interprets_broadcast_stride_zero_inputs() {
+    let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let b = input(&[0.5, 1.5, 2.5, 3.5], &[4]);
+    let c = input(&[2.0], &[1]);
+    let c_view = c.view();
+    let c_broadcast = c_view.broadcast(&[4]).unwrap();
+    let mut out = StridedArray::<f64>::col_major(&[4]);
+    let plan = FusedPlan {
+        input_count: 3,
+        outputs: vec![5],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![3, 2],
+            },
+            FusedInst {
+                op: FusedOp::Exp,
+                inputs: vec![4],
+            },
+        ],
+    };
+
+    fused_elementwise_into(
+        &mut [out.view_mut()],
+        &[a.view(), b.view(), c_broadcast],
+        &plan,
+    )
+    .unwrap();
+
+    for i in 0..4 {
+        assert_relative_eq!(
+            out.get(&[i]),
+            (a.get(&[i]) * b.get(&[i]) + 2.0).exp(),
+            epsilon = 1e-12
+        );
+    }
+}
+
+#[test]
+fn fused_interprets_noncontiguous_inputs_and_outputs() {
+    let a_base =
+        StridedArray::<f64>::from_fn_row_major(&[3, 2], |idx| (1 + idx[0] * 10 + idx[1]) as f64);
+    let b_base =
+        StridedArray::<f64>::from_fn_row_major(&[3, 2], |idx| (2 + idx[0] * 7 + idx[1]) as f64);
+    let a = a_base.view().permute(&[1, 0]).unwrap();
+    let b = b_base.view().permute(&[1, 0]).unwrap();
+    let mut out_base = StridedArray::<f64>::row_major(&[3, 2]);
+    let out = out_base.view_mut().permute(&[1, 0]).unwrap();
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    fused_elementwise_into(&mut [out], &[a.clone(), b.clone()], &plan).unwrap();
+
+    let out = out_base.view().permute(&[1, 0]).unwrap();
+    for i in 0..2 {
+        for j in 0..3 {
+            assert_relative_eq!(
+                out.get(&[i, j]),
+                a.get(&[i, j]) + b.get(&[i, j]),
+                epsilon = 1e-12
+            );
+        }
+    }
 }

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -486,3 +486,26 @@ fn fused_all_real_ops_have_basic_parity() {
         }
     }
 }
+
+#[test]
+fn fused_specialized_binary_plan_handles_broadcast_inputs() {
+    let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let b = input(&[10.0], &[1]);
+    let b_view = b.view();
+    let b_broadcast = b_view.broadcast(&[4]).unwrap();
+    let mut out = StridedArray::<f64>::col_major(&[4]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b_broadcast], &plan).unwrap();
+
+    for i in 0..4 {
+        assert_relative_eq!(out.get(&[i]), a.get(&[i]) + 10.0, epsilon = 1e-12);
+    }
+}

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -1,4 +1,5 @@
 use approx::assert_relative_eq;
+use num_complex::{Complex32, Complex64};
 use strided_kernel::{
     fused_elementwise_into, FusedInst, FusedOp, FusedPlan, StridedArray, StridedError,
 };
@@ -251,6 +252,237 @@ fn fused_interprets_noncontiguous_inputs_and_outputs() {
                 a.get(&[i, j]) + b.get(&[i, j]),
                 epsilon = 1e-12
             );
+        }
+    }
+}
+
+#[test]
+fn fused_real_maximum_minimum_match_nan_contract() {
+    let a = input(&[f64::NAN, 3.0, f64::NAN], &[3]);
+    let b = input(&[3.0, f64::NAN, f64::NAN], &[3]);
+    let mut max_out = StridedArray::<f64>::col_major(&[3]);
+    let mut min_out = StridedArray::<f64>::col_major(&[3]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2, 3],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Maximum,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Minimum,
+                inputs: vec![0, 1],
+            },
+        ],
+    };
+
+    fused_elementwise_into(
+        &mut [max_out.view_mut(), min_out.view_mut()],
+        &[a.view(), b.view()],
+        &plan,
+    )
+    .unwrap();
+
+    assert_eq!(max_out.get(&[0]), 3.0);
+    assert_eq!(min_out.get(&[0]), 3.0);
+    assert_eq!(max_out.get(&[1]), 3.0);
+    assert_eq!(min_out.get(&[1]), 3.0);
+    assert!(max_out.get(&[2]).is_nan());
+    assert!(min_out.get(&[2]).is_nan());
+}
+
+#[test]
+fn fused_complex_divide_matches_native_complex_division() {
+    let a = StridedArray::<Complex64>::from_parts(
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        &[2],
+        &[1],
+        0,
+    )
+    .unwrap();
+    let b = StridedArray::<Complex64>::from_parts(
+        vec![Complex64::new(0.25, -1.0), Complex64::new(2.0, 3.0)],
+        &[2],
+        &[1],
+        0,
+    )
+    .unwrap();
+    let mut out = StridedArray::<Complex64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Divide,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+
+    for i in 0..2 {
+        let expected = a.get(&[i]) / b.get(&[i]);
+        assert_relative_eq!(out.get(&[i]).re, expected.re, epsilon = 1e-12);
+        assert_relative_eq!(out.get(&[i]).im, expected.im, epsilon = 1e-12);
+    }
+}
+
+#[test]
+fn fused_complex_abs_returns_norm_in_real_component() {
+    let a = StridedArray::<Complex64>::from_parts(
+        vec![Complex64::new(3.0, 4.0), Complex64::new(5.0, 12.0)],
+        &[2],
+        &[1],
+        0,
+    )
+    .unwrap();
+    let mut out = StridedArray::<Complex64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op: FusedOp::Abs,
+            inputs: vec![0],
+        }],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).unwrap();
+
+    assert_relative_eq!(out.get(&[0]).re, 5.0, epsilon = 1e-12);
+    assert_relative_eq!(out.get(&[0]).im, 0.0, epsilon = 1e-12);
+    assert_relative_eq!(out.get(&[1]).re, 13.0, epsilon = 1e-12);
+    assert_relative_eq!(out.get(&[1]).im, 0.0, epsilon = 1e-12);
+}
+
+#[test]
+fn fused_complex32_add_multiply_matches_native_complex_arithmetic() {
+    let a = StridedArray::<Complex32>::from_parts(
+        vec![Complex32::new(1.0, 2.0), Complex32::new(-3.0, 0.5)],
+        &[2],
+        &[1],
+        0,
+    )
+    .unwrap();
+    let b = StridedArray::<Complex32>::from_parts(
+        vec![Complex32::new(0.25, -1.0), Complex32::new(2.0, 3.0)],
+        &[2],
+        &[1],
+        0,
+    )
+    .unwrap();
+    let mut out = StridedArray::<Complex32>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![3],
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Add,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Multiply,
+                inputs: vec![2, 0],
+            },
+        ],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+
+    for i in 0..2 {
+        let expected = (a.get(&[i]) + b.get(&[i])) * a.get(&[i]);
+        assert_relative_eq!(out.get(&[i]).re, expected.re, epsilon = 1e-5);
+        assert_relative_eq!(out.get(&[i]).im, expected.im, epsilon = 1e-5);
+    }
+}
+
+#[test]
+fn fused_all_real_ops_have_basic_parity() {
+    let x = input(&[1.25, 2.5], &[2]);
+    let y = input(&[0.5, 1.5], &[2]);
+    let lo = input(&[1.5, 1.5], &[2]);
+    let hi = input(&[2.0, 2.0], &[2]);
+    let mut outputs: Vec<StridedArray<f64>> = (0..11)
+        .map(|_| StridedArray::<f64>::col_major(&[2]))
+        .collect();
+    let plan = FusedPlan {
+        input_count: 4,
+        outputs: (4..15).collect(),
+        ops: vec![
+            FusedInst {
+                op: FusedOp::Divide,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Clamp,
+                inputs: vec![0, 2, 3],
+            },
+            FusedInst {
+                op: FusedOp::Log,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Sin,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Cos,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Tanh,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Sqrt,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Rsqrt,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Pow,
+                inputs: vec![0, 1],
+            },
+            FusedInst {
+                op: FusedOp::Expm1,
+                inputs: vec![0],
+            },
+            FusedInst {
+                op: FusedOp::Log1p,
+                inputs: vec![0],
+            },
+        ],
+    };
+
+    {
+        let mut views: Vec<_> = outputs.iter_mut().map(|out| out.view_mut()).collect();
+        fused_elementwise_into(
+            &mut views,
+            &[x.view(), y.view(), lo.view(), hi.view()],
+            &plan,
+        )
+        .unwrap();
+    }
+
+    for i in 0..2 {
+        let x = x.get(&[i]);
+        let y = y.get(&[i]);
+        let expected = [
+            x / y,
+            x.clamp(1.5, 2.0),
+            x.ln(),
+            x.sin(),
+            x.cos(),
+            x.tanh(),
+            x.sqrt(),
+            1.0 / x.sqrt(),
+            x.powf(y),
+            x.exp_m1(),
+            x.ln_1p(),
+        ];
+        for (output, &expected) in outputs.iter().zip(expected.iter()) {
+            assert_relative_eq!(output.get(&[i]), expected, epsilon = 1e-12);
         }
     }
 }

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -1,0 +1,110 @@
+use strided_kernel::{
+    fused_elementwise_into, FusedInst, FusedOp, FusedPlan, StridedArray, StridedError,
+};
+
+fn input(values: &[f64], dims: &[usize]) -> StridedArray<f64> {
+    StridedArray::from_parts(values.to_vec(), dims, &[1], 0).unwrap()
+}
+
+#[test]
+fn fused_rejects_input_count_mismatch() {
+    let a = input(&[1.0, 2.0], &[2]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![0],
+        ops: vec![],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(matches!(err, StridedError::RankMismatch(1, 2)));
+    assert_eq!(out.get(&[0]), 0.0);
+    assert_eq!(out.get(&[1]), 0.0);
+}
+
+#[test]
+fn fused_rejects_destination_count_mismatch() {
+    let a = input(&[1.0, 2.0], &[2]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![0, 0],
+        ops: vec![],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(matches!(err, StridedError::RankMismatch(1, 2)));
+    assert_eq!(out.get(&[0]), 0.0);
+    assert_eq!(out.get(&[1]), 0.0);
+}
+
+#[test]
+fn fused_rejects_bad_value_id_before_writing() {
+    let a = input(&[1.0, 2.0], &[2]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op: FusedOp::Negate,
+            inputs: vec![2],
+        }],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(matches!(
+        err,
+        StridedError::InvalidAxis { axis: 2, rank: 1 }
+    ));
+    assert_eq!(out.get(&[0]), 0.0);
+    assert_eq!(out.get(&[1]), 0.0);
+}
+
+#[test]
+fn fused_rejects_wrong_op_arity_before_writing() {
+    let a = input(&[1.0, 2.0], &[2]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0],
+        }],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(matches!(err, StridedError::RankMismatch(1, 2)));
+    assert_eq!(out.get(&[0]), 0.0);
+    assert_eq!(out.get(&[1]), 0.0);
+}
+
+#[test]
+fn fused_rejects_shape_mismatch_before_writing() {
+    let a = input(&[1.0, 2.0], &[2]);
+    let b = input(&[1.0, 2.0, 3.0], &[3]);
+    let mut out = StridedArray::<f64>::col_major(&[2]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    let err = fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan)
+        .expect_err("must fail");
+
+    assert!(matches!(err, StridedError::ShapeMismatch(_, _)));
+    assert_eq!(out.get(&[0]), 0.0);
+    assert_eq!(out.get(&[1]), 0.0);
+}

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -112,6 +112,47 @@ fn fused_rejects_shape_mismatch_before_writing() {
 }
 
 #[test]
+fn fused_rejects_stride_zero_destination_before_writing() {
+    let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
+    let mut out = StridedArray::<f64>::from_parts(vec![0.0], &[4], &[0], 0).unwrap();
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op: FusedOp::Negate,
+            inputs: vec![0],
+        }],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(err.to_string().contains("output layout"));
+    assert_eq!(out.data(), &[0.0]);
+}
+
+#[test]
+fn fused_rejects_overlapping_destination_offsets_before_writing() {
+    let a = StridedArray::<f64>::from_parts(vec![1.0, 2.0, 3.0, 4.0], &[2, 2], &[1, 2], 0).unwrap();
+    let mut out =
+        StridedArray::<f64>::from_parts(vec![0.0, 0.0, 0.0], &[2, 2], &[1, 1], 0).unwrap();
+    let plan = FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op: FusedOp::Negate,
+            inputs: vec![0],
+        }],
+    };
+
+    let err =
+        fused_elementwise_into(&mut [out.view_mut()], &[a.view()], &plan).expect_err("must fail");
+
+    assert!(err.to_string().contains("output layout"));
+    assert_eq!(out.data(), &[0.0, 0.0, 0.0]);
+}
+
+#[test]
 fn fused_interprets_reused_dag_value() {
     let a = input(&[1.0, 2.0, 3.0, 4.0], &[4]);
     let b = input(&[10.0, 20.0, 30.0, 40.0], &[4]);
@@ -293,6 +334,36 @@ fn fused_real_maximum_minimum_match_nan_contract() {
 }
 
 #[test]
+fn fused_real_clamp_does_not_panic_on_unordered_or_nan_bounds() {
+    let x = input(&[1.0, 2.0, 3.0], &[3]);
+    let lo = input(&[0.0, 4.0, f64::NAN], &[3]);
+    let hi = input(&[3.0, 1.0, 2.0], &[3]);
+    let mut out = StridedArray::<f64>::col_major(&[3]);
+    let plan = FusedPlan {
+        input_count: 3,
+        outputs: vec![3],
+        ops: vec![FusedInst {
+            op: FusedOp::Clamp,
+            inputs: vec![0, 1, 2],
+        }],
+    };
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fused_elementwise_into(
+            &mut [out.view_mut()],
+            &[x.view(), lo.view(), hi.view()],
+            &plan,
+        )
+    }));
+
+    assert!(result.is_ok(), "clamp should not panic for data values");
+    result.unwrap().unwrap();
+    assert_eq!(out.get(&[0]), 1.0);
+    assert_eq!(out.get(&[1]), 1.0);
+    assert_eq!(out.get(&[2]), 2.0);
+}
+
+#[test]
 fn fused_complex_divide_matches_native_complex_division() {
     let a = StridedArray::<Complex64>::from_parts(
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
@@ -470,7 +541,7 @@ fn fused_all_real_ops_have_basic_parity() {
         let y = y.get(&[i]);
         let expected = [
             x / y,
-            x.clamp(1.5, 2.0),
+            x.max(1.5).min(2.0),
             x.ln(),
             x.sin(),
             x.cos(),

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -70,6 +70,10 @@ pub enum StridedError {
     /// Matrix is not square when a square matrix was required.
     #[error("non-square matrix: rows={rows}, cols={cols}")]
     NonSquare { rows: usize, cols: usize },
+
+    /// Mutable output layout maps multiple logical elements to the same memory offset.
+    #[error("mutable output layout is not injective")]
+    NonInjectiveOutputLayout,
 }
 
 /// Result type for strided array operations.


### PR DESCRIPTION
## Summary
- add `strided-kernel` runtime SSA-DAG fused elementwise API and scalar semantics
- add validation before writes, including non-injective mutable output rejection
- add interpreter fallback plus static specializations for common fused chains
- add Criterion benchmarks for static and fallback paths

Closes #136

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo test -p strided-kernel --features parallel`
- `RAYON_NUM_THREADS=1 cargo bench -p strided-kernel --bench fused_elementwise`

## Benchmark Notes
- Static fused cases remain faster than per-op reused buffers.
- Interpreter fallback is measured separately and is slower, as expected for arbitrary runtime DAG dispatch.
- macOS CPU pinning was unavailable.