### PR TITLE
Add allocation-free raw copy/axpy kernels

### DIFF
--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -878,6 +878,18 @@ mod tests {
         }
     }
 
+    // Single-instruction plan whose sole output is the instruction result. Such
+    // plans always hit `try_static_specialization`, and both the static and the
+    // interpreter path dispatch through the scalar `FusedScalar` methods, so
+    // iterating every op exercises each scalar implementation.
+    fn single_op(input_count: usize, op: FusedOp, inputs: Vec<usize>) -> FusedPlan {
+        FusedPlan {
+            input_count,
+            outputs: vec![input_count],
+            ops: vec![FusedInst { op, inputs }],
+        }
+    }
+
     #[test]
     fn specializes_unary_exp() {
         let a = input(&[1.0, 2.0, 3.0]);
@@ -1009,5 +1021,113 @@ mod tests {
         };
 
         assert_static_matches_interpreter(plan, &[a, b, lo, hi]);
+    }
+
+    // Real negate/conj/abs were the only real scalar ops not reached by the
+    // chains above; cover them so the real `FusedScalar` impl is fully exercised.
+    #[test]
+    fn specializes_real_negate_conj_abs() {
+        for op in [FusedOp::Negate, FusedOp::Conj, FusedOp::Abs] {
+            let x = input(&[-1.5, 2.0, -3.5]);
+            assert_static_matches_interpreter(single_op(1, op, vec![0]), &[x]);
+        }
+    }
+
+    // The complex `FusedScalar` impl had no coverage at all (every existing test
+    // used f64). Run every op over Complex64 so both the static and interpreter
+    // paths dispatch through the complex scalar methods.
+    #[test]
+    fn specializes_every_op_over_complex() {
+        use num_complex::Complex64;
+
+        let c = |re: f64, im: f64| Complex64::new(re, im);
+        let cinput = |values: &[Complex64]| {
+            StridedArray::from_parts(values.to_vec(), &[values.len()], &[1], 0).unwrap()
+        };
+        let assert_complex_match = |plan: FusedPlan, arrays: &[StridedArray<Complex64>]| {
+            let inputs: Vec<_> = arrays.iter().map(|array| array.view()).collect();
+            let mut static_out = StridedArray::<Complex64>::col_major(arrays[0].dims());
+            let used_static = {
+                let mut dests = [static_out.view_mut()];
+                try_static_specialization(&mut dests, &inputs, &plan).unwrap()
+            };
+            let mut interp_out = StridedArray::<Complex64>::col_major(arrays[0].dims());
+            {
+                let mut dests = [interp_out.view_mut()];
+                interpret_fused_elementwise_into(&mut dests, &inputs, &plan).unwrap();
+            }
+            assert!(used_static, "single-op plan should specialize");
+            for (actual, expected) in static_out.iter().zip(interp_out.iter()) {
+                assert!((actual - expected).norm() < 1e-9, "{actual} vs {expected}");
+            }
+        };
+
+        // Positive-real-part, nonzero operands keep div/log/sqrt/pow well defined.
+        let a = cinput(&[c(1.5, 0.5), c(2.0, -1.0), c(0.7, 0.3)]);
+        let b = cinput(&[c(1.1, 0.2), c(0.9, 0.4), c(1.3, -0.6)]);
+        let d = cinput(&[c(2.0, 0.0), c(2.0, 0.0), c(2.0, 0.0)]);
+
+        for op in [
+            FusedOp::Negate,
+            FusedOp::Conj,
+            FusedOp::Abs,
+            FusedOp::Exp,
+            FusedOp::Log,
+            FusedOp::Sin,
+            FusedOp::Cos,
+            FusedOp::Tanh,
+            FusedOp::Sqrt,
+            FusedOp::Rsqrt,
+            FusedOp::Expm1,
+            FusedOp::Log1p,
+        ] {
+            assert_complex_match(single_op(1, op, vec![0]), std::slice::from_ref(&a));
+        }
+        for op in [
+            FusedOp::Add,
+            FusedOp::Multiply,
+            FusedOp::Divide,
+            FusedOp::Maximum,
+            FusedOp::Minimum,
+            FusedOp::Pow,
+        ] {
+            assert_complex_match(single_op(2, op, vec![0, 1]), &[a.clone(), b.clone()]);
+        }
+        assert_complex_match(
+            single_op(3, FusedOp::Clamp, vec![0, 1, 2]),
+            &[a.clone(), b.clone(), d.clone()],
+        );
+    }
+
+    // Error branches in plan/layout validation that the positive tests skip.
+    #[test]
+    fn validate_plan_rejects_out_of_range_output() {
+        // output id refers to a value that no instruction produces.
+        let plan = FusedPlan {
+            input_count: 1,
+            outputs: vec![5],
+            ops: vec![FusedInst {
+                op: FusedOp::Exp,
+                inputs: vec![0],
+            }],
+        };
+        assert!(validate_plan(&plan, 1, 1).is_err());
+    }
+
+    #[test]
+    fn validate_plan_rejects_zero_outputs() {
+        let plan = FusedPlan {
+            input_count: 1,
+            outputs: vec![],
+            ops: vec![],
+        };
+        assert!(validate_plan(&plan, 1, 0).is_err());
+    }
+
+    #[test]
+    fn is_injective_layout_rejects_rank_and_broadcast_mismatch() {
+        assert!(!is_injective_layout(&[2, 3], &[1]));
+        assert!(!is_injective_layout(&[2, 2], &[0, 1]));
+        assert!(is_injective_layout(&[1], &[0]));
     }
 }

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -70,6 +70,7 @@ pub use maybe_sync::{MaybeSend, MaybeSendSync, MaybeSync};
 mod map_view;
 mod ops_view;
 mod outer_product;
+mod raw_ops;
 mod reduce_view;
 
 // ============================================================================
@@ -78,8 +79,8 @@ mod reduce_view;
 pub use strided_view::view;
 pub use strided_view::{
     col_major_strides, row_major_strides, Adjoint, ComposableElementOp, Compose, Conj, ElementOp,
-    ElementOpApply, Identity, Result, StridedArray, StridedError, StridedView, StridedViewMut,
-    Transpose,
+    ElementOpApply, Identity, RawStridedMut, RawStridedRef, Result, StridedArray, StridedError,
+    StridedView, StridedViewMut, Transpose,
 };
 
 // ============================================================================
@@ -105,6 +106,13 @@ pub use outer_product::batched_outer_product_into;
 pub use ops_view::{
     add, axpy, copy_conj, copy_into, copy_into_col_major, copy_scale, copy_transpose_scale_into,
     dot, fma, mul, sum, symmetrize_conj_into, symmetrize_into,
+};
+
+// ============================================================================
+// Raw (borrowed-metadata, allocation-free) operations
+// ============================================================================
+pub use raw_ops::{
+    axpy_conj_raw, axpy_raw, copy_scale_conj_raw, copy_scale_raw, RAW_FUSED_RANK_LIMIT,
 };
 
 // ============================================================================

--- a/strided-kernel/src/raw_ops.rs
+++ b/strided-kernel/src/raw_ops.rs
@@ -1,0 +1,320 @@
+//! Allocation-free copy/axpy over borrowed raw strided layouts.
+//!
+//! [`StridedView`]/[`StridedViewMut`] own their metadata (`Arc<[usize]>` /
+//! `Arc<[isize]>`) and the map/zip kernels build a traversal plan per call;
+//! for small replay copies that fixed cost dominates. These entry points take
+//! [`RawStridedRef`]/[`RawStridedMut`] (borrowed metadata), fuse the stride
+//! pair into a stack-allocated loop nest, and run plain loops - no heap
+//! allocation on any call path with rank at most [`RAW_FUSED_RANK_LIMIT`].
+//! Higher ranks fall back to the view-based kernels.
+
+use crate::ops_view::{axpy, copy_scale};
+use crate::{ElementOpApply, RawStridedMut, RawStridedRef, Result};
+use core::ops::{Add, Mul};
+
+use crate::maybe_sync::MaybeSendSync;
+
+/// Maximum rank fused on the stack before falling back to the view kernels.
+pub const RAW_FUSED_RANK_LIMIT: usize = 8;
+
+#[derive(Clone, Copy, Debug)]
+struct FusedPairLayout {
+    rank: usize,
+    dims: [usize; RAW_FUSED_RANK_LIMIT],
+    dst_strides: [isize; RAW_FUSED_RANK_LIMIT],
+    src_strides: [isize; RAW_FUSED_RANK_LIMIT],
+}
+
+fn fuse_pair_layout(
+    dims: &[usize],
+    dst_strides: &[isize],
+    src_strides: &[isize],
+) -> Option<FusedPairLayout> {
+    if dims.len() > RAW_FUSED_RANK_LIMIT {
+        return None;
+    }
+    let mut layout = FusedPairLayout {
+        rank: 0,
+        dims: [1; RAW_FUSED_RANK_LIMIT],
+        dst_strides: [0; RAW_FUSED_RANK_LIMIT],
+        src_strides: [0; RAW_FUSED_RANK_LIMIT],
+    };
+    for axis in 0..dims.len() {
+        if dims[axis] == 1 {
+            continue;
+        }
+        if dims[axis] == 0 {
+            return Some(FusedPairLayout {
+                rank: 1,
+                dims: [0; RAW_FUSED_RANK_LIMIT],
+                dst_strides: [0; RAW_FUSED_RANK_LIMIT],
+                src_strides: [0; RAW_FUSED_RANK_LIMIT],
+            });
+        }
+        let mut position = layout.rank;
+        while position > 0 && layout.dst_strides[position - 1] > dst_strides[axis] {
+            layout.dims[position] = layout.dims[position - 1];
+            layout.dst_strides[position] = layout.dst_strides[position - 1];
+            layout.src_strides[position] = layout.src_strides[position - 1];
+            position -= 1;
+        }
+        layout.dims[position] = dims[axis];
+        layout.dst_strides[position] = dst_strides[axis];
+        layout.src_strides[position] = src_strides[axis];
+        layout.rank += 1;
+    }
+    if layout.rank == 0 {
+        layout.rank = 1;
+        layout.dims[0] = 1;
+    }
+    let mut fused = 0usize;
+    for axis in 1..layout.rank {
+        let extent = layout.dims[fused] as isize;
+        if layout.dst_strides[fused] * extent == layout.dst_strides[axis]
+            && layout.src_strides[fused] * extent == layout.src_strides[axis]
+        {
+            layout.dims[fused] *= layout.dims[axis];
+        } else {
+            fused += 1;
+            layout.dims[fused] = layout.dims[axis];
+            layout.dst_strides[fused] = layout.dst_strides[axis];
+            layout.src_strides[fused] = layout.src_strides[axis];
+        }
+    }
+    layout.rank = fused + 1;
+    Some(layout)
+}
+
+fn apply_fused_pair<D, S, Apply, Op>(
+    dst: &mut RawStridedMut<'_, D>,
+    src: &RawStridedRef<'_, S>,
+    layout: &FusedPairLayout,
+    apply: Apply,
+    op: Op,
+) where
+    D: Copy,
+    S: Copy,
+    Apply: Fn(&mut D, S),
+    Op: Fn(S) -> S,
+{
+    if layout.dims[..layout.rank].iter().any(|&dim| dim == 0) {
+        return;
+    }
+    let inner_len = layout.dims[0];
+    let inner_dst = layout.dst_strides[0];
+    let inner_src = layout.src_strides[0];
+    let src_data = src.data();
+    let src_offset = src.offset();
+    let dst_offset = dst.offset();
+    let dst_data = dst.data_mut();
+    let mut index = [0usize; RAW_FUSED_RANK_LIMIT];
+    let mut dst_base = dst_offset;
+    let mut src_base = src_offset;
+    loop {
+        if inner_dst == 1 && inner_src == 1 {
+            let dst_start = dst_base as usize;
+            let src_start = src_base as usize;
+            let dst_run = &mut dst_data[dst_start..dst_start + inner_len];
+            let src_run = &src_data[src_start..src_start + inner_len];
+            for position in 0..inner_len {
+                apply(&mut dst_run[position], op(src_run[position]));
+            }
+        } else {
+            for position in 0..inner_len {
+                let dst_position = (dst_base + position as isize * inner_dst) as usize;
+                let src_position = (src_base + position as isize * inner_src) as usize;
+                apply(&mut dst_data[dst_position], op(src_data[src_position]));
+            }
+        }
+        let mut axis = 1;
+        loop {
+            if axis >= layout.rank {
+                return;
+            }
+            index[axis] += 1;
+            dst_base += layout.dst_strides[axis];
+            src_base += layout.src_strides[axis];
+            if index[axis] < layout.dims[axis] {
+                break;
+            }
+            dst_base -= layout.dims[axis] as isize * layout.dst_strides[axis];
+            src_base -= layout.dims[axis] as isize * layout.src_strides[axis];
+            index[axis] = 0;
+            axis += 1;
+        }
+    }
+}
+
+fn ensure_same_dims(dst: &[usize], src: &[usize]) -> Result<()> {
+    if dst != src {
+        return Err(crate::StridedError::ShapeMismatch(
+            dst.to_vec(),
+            src.to_vec(),
+        ));
+    }
+    Ok(())
+}
+
+/// `dest = scale * src` over borrowed raw strided layouts.
+pub fn copy_scale_raw<T>(
+    dest: &mut RawStridedMut<'_, T>,
+    src: &RawStridedRef<'_, T>,
+    scale: T,
+) -> Result<()>
+where
+    T: Copy + Mul<T, Output = T> + ElementOpApply + MaybeSendSync,
+{
+    ensure_same_dims(dest.dims(), src.dims())?;
+    match fuse_pair_layout(dest.dims(), dest.strides(), src.strides()) {
+        Some(layout) => {
+            apply_fused_pair(
+                dest,
+                src,
+                &layout,
+                |dst, value| *dst = value,
+                |value: T| scale * value,
+            );
+            Ok(())
+        }
+        None => copy_scale(&mut dest.as_view_mut(), &src.as_view(), scale),
+    }
+}
+
+/// `dest = scale * conj(src)` over borrowed raw strided layouts.
+pub fn copy_scale_conj_raw<T>(
+    dest: &mut RawStridedMut<'_, T>,
+    src: &RawStridedRef<'_, T>,
+    scale: T,
+) -> Result<()>
+where
+    T: Copy + Mul<T, Output = T> + ElementOpApply + MaybeSendSync,
+{
+    ensure_same_dims(dest.dims(), src.dims())?;
+    match fuse_pair_layout(dest.dims(), dest.strides(), src.strides()) {
+        Some(layout) => {
+            apply_fused_pair(
+                dest,
+                src,
+                &layout,
+                |dst, value| *dst = value,
+                |value: T| scale * value.conj(),
+            );
+            Ok(())
+        }
+        None => copy_scale(&mut dest.as_view_mut(), &src.as_view().conj(), scale),
+    }
+}
+
+/// `dest = alpha * src + dest` over borrowed raw strided layouts.
+pub fn axpy_raw<T>(
+    dest: &mut RawStridedMut<'_, T>,
+    src: &RawStridedRef<'_, T>,
+    alpha: T,
+) -> Result<()>
+where
+    T: Copy + Add<T, Output = T> + Mul<T, Output = T> + ElementOpApply + MaybeSendSync,
+{
+    ensure_same_dims(dest.dims(), src.dims())?;
+    match fuse_pair_layout(dest.dims(), dest.strides(), src.strides()) {
+        Some(layout) => {
+            apply_fused_pair(
+                dest,
+                src,
+                &layout,
+                |dst, value| *dst = *dst + value,
+                |value: T| alpha * value,
+            );
+            Ok(())
+        }
+        None => axpy(&mut dest.as_view_mut(), &src.as_view(), alpha),
+    }
+}
+
+/// `dest = alpha * conj(src) + dest` over borrowed raw strided layouts.
+pub fn axpy_conj_raw<T>(
+    dest: &mut RawStridedMut<'_, T>,
+    src: &RawStridedRef<'_, T>,
+    alpha: T,
+) -> Result<()>
+where
+    T: Copy + Add<T, Output = T> + Mul<T, Output = T> + ElementOpApply + MaybeSendSync,
+{
+    ensure_same_dims(dest.dims(), src.dims())?;
+    match fuse_pair_layout(dest.dims(), dest.strides(), src.strides()) {
+        Some(layout) => {
+            apply_fused_pair(
+                dest,
+                src,
+                &layout,
+                |dst, value| *dst = *dst + value,
+                |value: T| alpha * value.conj(),
+            );
+            Ok(())
+        }
+        None => axpy(&mut dest.as_view_mut(), &src.as_view().conj(), alpha),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{StridedView, StridedViewMut};
+
+    fn reference_copy_scale(
+        dst: &mut [f64],
+        src: &[f64],
+        dims: &[usize],
+        dst_strides: &[isize],
+        src_strides: &[isize],
+        scale: f64,
+    ) {
+        let mut dest_view = StridedViewMut::new(dst, dims, dst_strides, 0).unwrap();
+        let src_view: StridedView<'_, f64> = StridedView::new(src, dims, src_strides, 0).unwrap();
+        copy_scale(&mut dest_view, &src_view, scale).unwrap();
+    }
+
+    #[test]
+    fn raw_copy_scale_matches_view_kernel() {
+        let dims = [2usize, 3, 2];
+        let src_strides = [1isize, 2, 6];
+        let dst_strides = [6isize, 2, 1];
+        let src: Vec<f64> = (0..12).map(|value| value as f64 - 3.0).collect();
+        let mut expected = vec![0.0; 12];
+        reference_copy_scale(&mut expected, &src, &dims, &dst_strides, &src_strides, 1.5);
+
+        let mut actual = vec![0.0; 12];
+        let mut dest = RawStridedMut::new(&mut actual, &dims, &dst_strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &src_strides, 0).unwrap();
+        copy_scale_raw(&mut dest, &source, 1.5).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn raw_axpy_accumulates() {
+        let dims = [4usize];
+        let strides = [1isize];
+        let src = [1.0f64, 2.0, 3.0, 4.0];
+        let mut dst = [10.0f64, 20.0, 30.0, 40.0];
+        let mut dest = RawStridedMut::new(&mut dst, &dims, &strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+        axpy_raw(&mut dest, &source, 2.0).unwrap();
+
+        assert_eq!(dst, [12.0, 24.0, 36.0, 48.0]);
+    }
+
+    #[test]
+    fn raw_copy_scale_conjugates_complex_sources() {
+        use num_complex::Complex64;
+        let dims = [2usize];
+        let strides = [1isize];
+        let src = [Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)];
+        let mut dst = [Complex64::new(0.0, 0.0); 2];
+        let mut dest = RawStridedMut::new(&mut dst, &dims, &strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+        copy_scale_conj_raw(&mut dest, &source, Complex64::new(2.0, 0.0)).unwrap();
+
+        assert_eq!(dst[0], Complex64::new(2.0, -4.0));
+        assert_eq!(dst[1], Complex64::new(-6.0, -8.0));
+    }
+}


### PR DESCRIPTION
# Add allocation-free raw copy/axpy kernels

## Summary

This PR adds allocation-free copy/scale/axpy entry points over borrowed raw
strided layouts (`RawStridedRef` / `RawStridedMut`), the elementwise
counterpart to the raw bgemm API added in #134.

The normal `StridedView` / `StridedViewMut` kernels remain unchanged. The new
functions are for prepared replay paths that already hold validated
`dims` / `strides` / `offset` descriptors and re-run the same small strided
copies many times.

## Motivation

`StridedView` / `StridedViewMut` own their metadata (`Arc<[usize]>` /
`Arc<[isize]>`) and the map/zip kernels build a traversal plan on every call.
For small replay copies that fixed cost — two `Arc` allocations per view plus
per-call planning — dominates the actual data movement.

A replay consumer already has the borrowed layout in hand:

```rust
let dims: &[usize] = &[m, n];
let dst_strides: &[isize] = &[n as isize, 1];
let src_strides: &[isize] = &[1, m as isize];
```

Rebuilding an owning view and re-planning for each such copy is avoidable
overhead. This PR gives that case a raw borrowed-layout path, mirroring the
motivation in #134 for GEMM.

## API

Re-exported from `strided-kernel`:

```rust
use strided_kernel::{
    copy_scale_raw, copy_scale_conj_raw, axpy_raw, axpy_conj_raw,
    RawStridedMut, RawStridedRef,
};

// dest = scale * src
copy_scale_raw(&mut dest, &src, scale)?;
// dest = scale * conj(src)
copy_scale_conj_raw(&mut dest, &src, scale)?;
// dest = alpha * src + dest
axpy_raw(&mut dest, &src, alpha)?;
// dest = alpha * conj(src) + dest
axpy_conj_raw(&mut dest, &src, alpha)?;
```

Each fuses the (dst, src) stride pair into a stack-allocated loop nest and runs
plain loops — no heap allocation on any call path with rank at most
`RAW_FUSED_RANK_LIMIT` (8). Higher ranks fall back to the existing view kernels
(`copy_scale` / `axpy`), so behaviour and results are unchanged there.

## Tests

`strided-kernel` tests cover parity against the view kernels and the raw-only
paths:

- `raw_copy_scale_matches_view_kernel`
- `raw_copy_scale_conjugates_complex_sources`
- `raw_axpy_accumulates`

`cargo test -p strided-kernel` passes; the full workspace builds.

## Scope

This covers the copy/scale/axpy families only. Raw borrowed-layout `reduce` /
partial-trace and a reusable compiled plan (fuse/order/block computed once,
executed many times) are follow-ups tracked in #139.
