### PR TITLE
Add compiled CopyPlan for prepared strided copies (stage 1 of #139)

### DIFF
--- a/strided-kernel/src/copy_plan.rs
+++ b/strided-kernel/src/copy_plan.rs
@@ -1,0 +1,427 @@
+//! Prepared (compile-once, execute-many) copy plans over raw strided layouts.
+//!
+//! [`copy_scale_raw`](crate::copy_scale_raw) and friends rebuild the fused
+//! loop nest on every call; for prepared-replay consumers that issue many
+//! small copies with a fixed layout, that per-call planning dominates
+//! (see issue #139). [`CopyPlan`] splits the work: [`CopyPlan::compile`]
+//! validates the layout pair and builds the fused traversal once,
+//! [`CopyPlan::execute`]/[`CopyPlan::execute_scale`]/[`CopyPlan::execute_conj`]
+//! replay it with no planning and no heap allocation for ranks at most
+//! [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).
+
+use core::ops::Mul;
+
+use crate::ops_view::{copy_conj, copy_into, copy_scale};
+use crate::raw_ops::{apply_fused_pair, fuse_pair_layout, FusedPairLayout};
+use crate::{ElementOpApply, MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError};
+
+// Same pattern as map_view.rs / outer_product.rs: stack storage when the
+// parallel feature pulls in smallvec, plain Vec otherwise. Only `compile`
+// touches these; `execute*` never allocates either way.
+#[cfg(feature = "parallel")]
+type AxisVec<T> = smallvec::SmallVec<[T; crate::RAW_FUSED_RANK_LIMIT]>;
+#[cfg(not(feature = "parallel"))]
+type AxisVec<T> = Vec<T>;
+
+/// A compiled copy traversal for one `(dims, dst_strides, src_strides)`
+/// layout pair.
+///
+/// `compile` proves the layout facts once (rank agreement, extent overflow,
+/// destination injectivity) and fuses/orders the loop nest; each `execute*`
+/// call then only re-checks the per-call facts (that the supplied views carry
+/// exactly the compiled layout) before replaying the prepared loops.
+///
+/// Overlapping `src`/`dest` memory is not supported, matching the rest of the
+/// crate.
+///
+/// Ranks above [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT) are supported through the view-based
+/// kernels; only that fallback path may allocate.
+///
+/// # Example
+///
+/// ```rust
+/// use strided_kernel::{CopyPlan, RawStridedMut, RawStridedRef};
+///
+/// let dims = [2usize, 3];
+/// let src_strides = [3isize, 1];
+/// let dst_strides = [1isize, 2]; // transposed destination
+/// let plan = CopyPlan::compile(&dims, &dst_strides, &src_strides).unwrap();
+///
+/// let src = [0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0];
+/// let mut dst = [0.0f64; 6];
+/// let src_ref = RawStridedRef::new(&src, &dims, &src_strides, 0).unwrap();
+/// let mut dst_mut = RawStridedMut::new(&mut dst, &dims, &dst_strides, 0).unwrap();
+/// plan.execute(&mut dst_mut, &src_ref).unwrap();
+/// assert_eq!(dst, [0.0, 10.0, 1.0, 11.0, 2.0, 12.0]);
+/// ```
+#[derive(Clone, Debug)]
+pub struct CopyPlan {
+    dims: AxisVec<usize>,
+    dst_strides: AxisVec<isize>,
+    src_strides: AxisVec<isize>,
+    /// `None` when rank exceeds [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT); `execute*` then
+    /// falls back to the view-based kernels.
+    fused: Option<FusedPairLayout>,
+}
+
+impl CopyPlan {
+    /// Compile a copy plan for the given layout pair.
+    ///
+    /// Performs the layout validation and traversal construction
+    /// (fuse + order) once:
+    ///
+    /// - `dims`, `dst_strides`, and `src_strides` must have equal length
+    ///   ([`StridedError::StrideLengthMismatch`]);
+    /// - the total element count must not overflow `usize`
+    ///   ([`StridedError::OffsetOverflow`]);
+    /// - the destination layout must be injective, i.e. map distinct logical
+    ///   indices to distinct offsets
+    ///   ([`StridedError::NonInjectiveOutputLayout`]).
+    pub fn compile(dims: &[usize], dst_strides: &[isize], src_strides: &[isize]) -> Result<Self> {
+        if dims.len() != dst_strides.len() || dims.len() != src_strides.len() {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        if dims
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .is_none()
+        {
+            return Err(StridedError::OffsetOverflow);
+        }
+        if !crate::fused::is_injective_layout(dims, dst_strides) {
+            return Err(StridedError::NonInjectiveOutputLayout);
+        }
+        Ok(Self {
+            dims: dims.into(),
+            dst_strides: dst_strides.into(),
+            src_strides: src_strides.into(),
+            fused: fuse_pair_layout(dims, dst_strides, src_strides),
+        })
+    }
+
+    /// Check the per-call facts: the supplied views must carry exactly the
+    /// compiled layout. Buffer bounds against that layout were already proven
+    /// by [`RawStridedRef::new`]/[`RawStridedMut::new`] (or asserted by the
+    /// caller of the `new_unchecked` constructors), so layout equality is the
+    /// complete precondition for the unsafe-free fused replay below.
+    fn check_call<T>(&self, dest: &RawStridedMut<'_, T>, src: &RawStridedRef<'_, T>) -> Result<()> {
+        if dest.dims() != &self.dims[..]
+            || src.dims() != &self.dims[..]
+            || dest.strides() != &self.dst_strides[..]
+            || src.strides() != &self.src_strides[..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+
+    /// `dest = src`. Allocation-free for ranks at most [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).
+    pub fn execute<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        src: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, src)?;
+        match &self.fused {
+            Some(layout) => {
+                apply_fused_pair(
+                    dest,
+                    src,
+                    layout,
+                    |dst, value| *dst = value,
+                    |value: T| value,
+                );
+                Ok(())
+            }
+            None => copy_into(&mut dest.as_view_mut(), &src.as_view()),
+        }
+    }
+
+    /// `dest = scale * src`. Allocation-free for ranks at most
+    /// [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).
+    pub fn execute_scale<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        src: &RawStridedRef<'_, T>,
+        scale: T,
+    ) -> Result<()>
+    where
+        T: Copy + Mul<T, Output = T> + MaybeSendSync,
+    {
+        self.check_call(dest, src)?;
+        match &self.fused {
+            Some(layout) => {
+                apply_fused_pair(
+                    dest,
+                    src,
+                    layout,
+                    |dst, value| *dst = value,
+                    |value: T| scale * value,
+                );
+                Ok(())
+            }
+            None => copy_scale(&mut dest.as_view_mut(), &src.as_view(), scale),
+        }
+    }
+
+    /// `dest = conj(src)`. Allocation-free for ranks at most
+    /// [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).
+    pub fn execute_conj<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        src: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + ElementOpApply + MaybeSendSync,
+    {
+        self.check_call(dest, src)?;
+        match &self.fused {
+            Some(layout) => {
+                apply_fused_pair(
+                    dest,
+                    src,
+                    layout,
+                    |dst, value| *dst = value,
+                    |value: T| value.conj(),
+                );
+                Ok(())
+            }
+            None => copy_conj(&mut dest.as_view_mut(), &src.as_view()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_complex::{Complex32, Complex64};
+
+    /// Reference: the per-call raw kernel (which itself is differential-tested
+    /// against the view kernels in raw_ops.rs).
+    fn plan_matches_direct<T>(
+        dims: &[usize],
+        dst_strides: &[isize],
+        src_strides: &[isize],
+        src: &[T],
+    ) where
+        T: Copy
+            + PartialEq
+            + core::fmt::Debug
+            + Default
+            + Mul<T, Output = T>
+            + ElementOpApply
+            + MaybeSendSync
+            + num_traits::One,
+    {
+        let len = src.len();
+        let plan = CopyPlan::compile(dims, dst_strides, src_strides).unwrap();
+
+        let mut expected = vec![T::default(); len];
+        {
+            let mut dest = RawStridedMut::new(&mut expected, dims, dst_strides, 0).unwrap();
+            let source = RawStridedRef::new(src, dims, src_strides, 0).unwrap();
+            crate::copy_scale_raw(&mut dest, &source, T::one()).unwrap();
+        }
+
+        let mut actual = vec![T::default(); len];
+        {
+            let mut dest = RawStridedMut::new(&mut actual, dims, dst_strides, 0).unwrap();
+            let source = RawStridedRef::new(src, dims, src_strides, 0).unwrap();
+            plan.execute(&mut dest, &source).unwrap();
+        }
+        assert_eq!(actual, expected);
+    }
+
+    fn fill_f64(len: usize) -> Vec<f64> {
+        (0..len).map(|value| value as f64 - 2.5).collect()
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_rank0() {
+        plan_matches_direct::<f64>(&[], &[], &[], &[7.0]);
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_rank1() {
+        plan_matches_direct::<f64>(&[5], &[1], &[1], &fill_f64(5));
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_rank2_transposed() {
+        plan_matches_direct::<f64>(&[3, 4], &[1, 3], &[4, 1], &fill_f64(12));
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_rank4() {
+        plan_matches_direct::<f64>(&[2, 3, 2, 2], &[12, 4, 2, 1], &[1, 2, 6, 12], &fill_f64(24));
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_rank8() {
+        let dims = [2usize; 8];
+        let dst: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
+        let src: Vec<isize> = (0..8).rev().map(|axis| 1isize << axis).collect();
+        plan_matches_direct::<f64>(&dims, &dst, &src, &fill_f64(256));
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_zero_size() {
+        plan_matches_direct::<f64>(&[2, 0, 3], &[3, 3, 1], &[1, 6, 2], &fill_f64(6));
+    }
+
+    #[test]
+    fn plan_copy_matches_direct_f32_and_complex() {
+        let dims = [2usize, 3];
+        let dst = [1isize, 2];
+        let src = [3isize, 1];
+        plan_matches_direct::<f32>(&dims, &dst, &src, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let complex: Vec<Complex32> = (0..6)
+            .map(|value| Complex32::new(value as f32, -(value as f32)))
+            .collect();
+        plan_matches_direct::<Complex32>(&dims, &dst, &src, &complex);
+        let complex: Vec<Complex64> = (0..6)
+            .map(|value| Complex64::new(value as f64, 1.0 - value as f64))
+            .collect();
+        plan_matches_direct::<Complex64>(&dims, &dst, &src, &complex);
+    }
+
+    #[test]
+    fn plan_copy_negative_stride_matches_view_kernel() {
+        // Negative source stride: src viewed reversed, offset at the end.
+        let dims = [4usize];
+        let src_strides = [-1isize];
+        let dst_strides = [1isize];
+        let src = [1.0f64, 2.0, 3.0, 4.0];
+        let plan = CopyPlan::compile(&dims, &dst_strides, &src_strides).unwrap();
+
+        let mut actual = [0.0f64; 4];
+        let mut dest = RawStridedMut::new(&mut actual, &dims, &dst_strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &src_strides, 3).unwrap();
+        plan.execute(&mut dest, &source).unwrap();
+        assert_eq!(actual, [4.0, 3.0, 2.0, 1.0]);
+    }
+
+    #[test]
+    fn plan_execute_scale_and_conj() {
+        let dims = [2usize, 2];
+        let strides = [2isize, 1];
+        let src = [
+            Complex64::new(1.0, 2.0),
+            Complex64::new(-3.0, 4.0),
+            Complex64::new(0.5, -1.0),
+            Complex64::new(2.0, 0.0),
+        ];
+        let plan = CopyPlan::compile(&dims, &strides, &strides).unwrap();
+
+        let mut scaled = [Complex64::default(); 4];
+        let mut dest = RawStridedMut::new(&mut scaled, &dims, &strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+        plan.execute_scale(&mut dest, &source, Complex64::new(2.0, 0.0))
+            .unwrap();
+        assert_eq!(scaled[1], Complex64::new(-6.0, 8.0));
+
+        let mut conjugated = [Complex64::default(); 4];
+        let mut dest = RawStridedMut::new(&mut conjugated, &dims, &strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+        plan.execute_conj(&mut dest, &source).unwrap();
+        assert_eq!(conjugated[0], Complex64::new(1.0, -2.0));
+        assert_eq!(conjugated[3], Complex64::new(2.0, 0.0));
+    }
+
+    #[test]
+    fn plan_rank_above_limit_falls_back_to_view_kernels() {
+        let dims = [2usize; 9];
+        let dst: Vec<isize> = (0..9).map(|axis| 1isize << axis).collect();
+        let src: Vec<isize> = (0..9).rev().map(|axis| 1isize << axis).collect();
+        let source_data = fill_f64(512);
+        let plan = CopyPlan::compile(&dims, &dst, &src).unwrap();
+        assert!(plan.fused.is_none());
+
+        let mut expected = vec![0.0f64; 512];
+        {
+            let mut dest = RawStridedMut::new(&mut expected, &dims, &dst, 0).unwrap();
+            let source = RawStridedRef::new(&source_data, &dims, &src, 0).unwrap();
+            crate::copy_scale_raw(&mut dest, &source, 1.0).unwrap();
+        }
+        let mut actual = vec![0.0f64; 512];
+        let mut dest = RawStridedMut::new(&mut actual, &dims, &dst, 0).unwrap();
+        let source = RawStridedRef::new(&source_data, &dims, &src, 0).unwrap();
+        plan.execute(&mut dest, &source).unwrap();
+        assert_eq!(actual, expected);
+
+        // Fallback also serves scale and conj.
+        let mut scaled = vec![0.0f64; 512];
+        let mut dest = RawStridedMut::new(&mut scaled, &dims, &dst, 0).unwrap();
+        plan.execute_scale(&mut dest, &source, 2.0).unwrap();
+        assert_eq!(scaled[0], 2.0 * actual[0]);
+        let mut conjugated = vec![0.0f64; 512];
+        let mut dest = RawStridedMut::new(&mut conjugated, &dims, &dst, 0).unwrap();
+        plan.execute_conj(&mut dest, &source).unwrap();
+        assert_eq!(conjugated, actual);
+    }
+
+    #[test]
+    fn compile_rejects_length_mismatch() {
+        let err = CopyPlan::compile(&[2, 3], &[3, 1], &[1]).unwrap_err();
+        assert!(matches!(err, StridedError::StrideLengthMismatch));
+        let err = CopyPlan::compile(&[2, 3], &[3], &[1, 2]).unwrap_err();
+        assert!(matches!(err, StridedError::StrideLengthMismatch));
+    }
+
+    #[test]
+    fn compile_rejects_extent_overflow() {
+        let err = CopyPlan::compile(&[usize::MAX, 2], &[1, 1], &[1, 1]).unwrap_err();
+        assert!(matches!(err, StridedError::OffsetOverflow));
+    }
+
+    #[test]
+    fn compile_rejects_non_injective_destination() {
+        // Two logical columns land on the same offsets: forbidden overlap in
+        // the mutable destination.
+        let err = CopyPlan::compile(&[2, 2], &[1, 0], &[2, 1]).unwrap_err();
+        assert!(matches!(err, StridedError::NonInjectiveOutputLayout));
+        // Broadcast-like (stride 0) source layouts remain allowed.
+        CopyPlan::compile(&[2, 2], &[2, 1], &[0, 1]).unwrap();
+    }
+
+    #[test]
+    fn execute_rejects_layout_drift() {
+        let dims = [2usize, 3];
+        let strides = [3isize, 1];
+        let plan = CopyPlan::compile(&dims, &strides, &strides).unwrap();
+        let src = fill_f64(6);
+        let mut dst = vec![0.0f64; 6];
+
+        // Different dims than compiled.
+        let other_dims = [3usize, 2];
+        let other_strides = [2isize, 1];
+        let mut dest = RawStridedMut::new(&mut dst, &other_dims, &other_strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &other_dims, &other_strides, 0).unwrap();
+        let err = plan.execute(&mut dest, &source).unwrap_err();
+        assert!(matches!(err, StridedError::PlanLayoutMismatch));
+
+        // Same dims, different source strides.
+        let column_major = [1isize, 2];
+        let mut dest = RawStridedMut::new(&mut dst, &dims, &strides, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &column_major, 0).unwrap();
+        let err = plan.execute_scale(&mut dest, &source, 1.0).unwrap_err();
+        assert!(matches!(err, StridedError::PlanLayoutMismatch));
+
+        // Same dims, different destination strides.
+        let mut dest = RawStridedMut::new(&mut dst, &dims, &column_major, 0).unwrap();
+        let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+        let err = plan.execute_conj(&mut dest, &source).unwrap_err();
+        assert!(matches!(err, StridedError::PlanLayoutMismatch));
+    }
+
+    #[test]
+    fn identity_layout_uses_single_fused_axis() {
+        let plan = CopyPlan::compile(&[2, 3, 4], &[12, 4, 1], &[12, 4, 1]).unwrap();
+        let fused = plan.fused.expect("rank 3 stays on the fused path");
+        assert_eq!(fused.rank, 1);
+        assert_eq!(fused.dims[0], 24);
+    }
+}

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -395,7 +395,7 @@ fn validate_destination_layout<T>(dest: &StridedViewMut<'_, T>) -> Result<()> {
     }
 }
 
-fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
+pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
     if dims.len() != strides.len() {
         return false;
     }

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -67,6 +67,7 @@ mod maybe_sync;
 pub use maybe_sync::{MaybeSend, MaybeSendSync, MaybeSync};
 
 // View-based operation modules
+mod copy_plan;
 mod map_view;
 mod ops_view;
 mod outer_product;
@@ -114,6 +115,11 @@ pub use ops_view::{
 pub use raw_ops::{
     axpy_conj_raw, axpy_raw, copy_scale_conj_raw, copy_scale_raw, RAW_FUSED_RANK_LIMIT,
 };
+
+// ============================================================================
+// Prepared (compile-once, execute-many) plans
+// ============================================================================
+pub use copy_plan::CopyPlan;
 
 // ============================================================================
 // Reduce operations

--- a/strided-kernel/src/raw_ops.rs
+++ b/strided-kernel/src/raw_ops.rs
@@ -17,15 +17,18 @@ use crate::maybe_sync::MaybeSendSync;
 /// Maximum rank fused on the stack before falling back to the view kernels.
 pub const RAW_FUSED_RANK_LIMIT: usize = 8;
 
+/// Stack-allocated fused stride pair (dims ordered by destination stride,
+/// adjacent contiguous axes merged). Built once and replayed by both the
+/// per-call raw kernels and the prepared [`crate::CopyPlan`].
 #[derive(Clone, Copy, Debug)]
-struct FusedPairLayout {
-    rank: usize,
-    dims: [usize; RAW_FUSED_RANK_LIMIT],
-    dst_strides: [isize; RAW_FUSED_RANK_LIMIT],
-    src_strides: [isize; RAW_FUSED_RANK_LIMIT],
+pub(crate) struct FusedPairLayout {
+    pub(crate) rank: usize,
+    pub(crate) dims: [usize; RAW_FUSED_RANK_LIMIT],
+    pub(crate) dst_strides: [isize; RAW_FUSED_RANK_LIMIT],
+    pub(crate) src_strides: [isize; RAW_FUSED_RANK_LIMIT],
 }
 
-fn fuse_pair_layout(
+pub(crate) fn fuse_pair_layout(
     dims: &[usize],
     dst_strides: &[isize],
     src_strides: &[isize],
@@ -85,7 +88,7 @@ fn fuse_pair_layout(
     Some(layout)
 }
 
-fn apply_fused_pair<D, S, Apply, Op>(
+pub(crate) fn apply_fused_pair<D, S, Apply, Op>(
     dst: &mut RawStridedMut<'_, D>,
     src: &RawStridedRef<'_, S>,
     layout: &FusedPairLayout,

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -1,0 +1,88 @@
+//! Asserts the zero-allocation contract of `CopyPlan::execute*` for ranks at
+//! most `RAW_FUSED_RANK_LIMIT`.
+//!
+//! This lives in its own integration-test binary because it installs a
+//! counting global allocator; keeping it isolated avoids counting noise from
+//! unrelated tests.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use num_complex::Complex64;
+use strided_kernel::{CopyPlan, RawStridedMut, RawStridedRef};
+
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn count_allocations(run: impl FnOnce()) -> usize {
+    let before = ALLOCATIONS.load(Ordering::SeqCst);
+    run();
+    ALLOCATIONS.load(Ordering::SeqCst) - before
+}
+
+// One test function: the counter is process-global, so concurrently running
+// sibling tests would leak their setup allocations into the counted window.
+#[test]
+fn execute_is_allocation_free_up_to_rank_limit() {
+    // Rank 8 (the RAW_FUSED_RANK_LIMIT boundary), permuted strides so fusion
+    // cannot collapse everything into one contiguous run.
+    let dims = [2usize; 8];
+    let dst_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
+    let src_strides: Vec<isize> = (0..8).rev().map(|axis| 1isize << axis).collect();
+    let src: Vec<f64> = (0..256).map(|value| value as f64).collect();
+    let mut dst = vec![0.0f64; 256];
+
+    let plan = CopyPlan::compile(&dims, &dst_strides, &src_strides).unwrap();
+    let mut dest = RawStridedMut::new(&mut dst, &dims, &dst_strides, 0).unwrap();
+    let source = RawStridedRef::new(&src, &dims, &src_strides, 0).unwrap();
+
+    // Warm up (first call may fault pages but must not allocate either).
+    plan.execute(&mut dest, &source).unwrap();
+
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&mut dest, &source).unwrap();
+            plan.execute_scale(&mut dest, &source, 2.0).unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "execute/execute_scale must not allocate");
+
+    let dims = [4usize, 4];
+    let strides = [1isize, 4];
+    let src: Vec<Complex64> = (0..16)
+        .map(|value| Complex64::new(value as f64, -(value as f64)))
+        .collect();
+    let mut dst = vec![Complex64::default(); 16];
+
+    let plan = CopyPlan::compile(&dims, &strides, &strides).unwrap();
+    let mut dest = RawStridedMut::new(&mut dst, &dims, &strides, 0).unwrap();
+    let source = RawStridedRef::new(&src, &dims, &strides, 0).unwrap();
+    plan.execute_conj(&mut dest, &source).unwrap();
+
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute_conj(&mut dest, &source).unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "execute_conj must not allocate");
+}

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -74,6 +74,10 @@ pub enum StridedError {
     /// Mutable output layout maps multiple logical elements to the same memory offset.
     #[error("mutable output layout is not injective")]
     NonInjectiveOutputLayout,
+
+    /// Runtime view layout does not match the layout a prepared plan was compiled for.
+    #[error("view layout does not match the compiled plan")]
+    PlanLayoutMismatch,
 }
 
 /// Result type for strided array operations.


### PR DESCRIPTION
# Add compiled CopyPlan for prepared strided copies

## Summary

Stage 1 of #139: a prepared, reusable copy plan over the raw borrowed-layout kernels from #140. `CopyPlan::compile` runs the layout planning once (validation + fused-pair layout); `execute` / `execute_scale` / `execute_conj` replay it against `RawStridedRef` / `RawStridedMut` with zero heap allocations for rank ≤ 8.

```rust
let plan = CopyPlan::compile(dims, dst_strides, src_strides)?; // plan once
plan.execute(dst_raw, src_raw)?;                               // zero-alloc, repeatable
plan.execute_scale(dst_raw, src_raw, alpha)?;
```

## Design

- **Layering**: `execute` is exactly "#140 minus the per-call planning" — it reuses the same `pub(crate)` fused-pair machinery (`fuse_pair_layout` / `apply_fused_pair`), so there is no second copy-kernel implementation. Rank > 8 falls back to the view kernels (the explicit-fallback rule; this is the only allocating path).
- **Validation split**: `compile` proves layout compatibility (rank agreement, extent-product overflow, destination injectivity via the existing `is_injective_layout`); `execute*` re-checks only the per-call facts (the supplied views must carry exactly the compiled layout — `PlanLayoutMismatch` otherwise). Buffer bounds are already proven by `RawStridedRef/Mut` construction.
- **Public surface kept minimal**: only `CopyPlan` + its methods and the new `StridedError::PlanLayoutMismatch` variant become public; all planning internals stay `pub(crate)`.

`MapPlan` / `ReducePlan` (stages 2–3 of #139) are deliberately not included; this PR proves the API shape on the smallest reviewable slice.

## Tests

- Differential plan-vs-direct (byte-identical against the #140 raw kernels): rank 0/1/2/4/8, zero-size dims, identity layout (asserts single fused axis), transposed and negative-stride layouts, rank-9 fallback, f32/f64/c32/c64, scale and conj semantics.
- Compile rejections (length mismatch, extent overflow, non-injective destination; broadcast source allowed) and execute-time layout-drift rejection (dims / dst strides / src strides).
- Zero-allocation contract: a counting global allocator asserts `execute` / `execute_scale` / `execute_conj` perform no heap allocations at rank 8, on both the default and `parallel` features.

`cargo test --workspace` green (incl. `--features parallel`), `cargo fmt --check` clean, `cargo doc --no-deps` warning-free, per-file coverage ≥ 80% (copy_plan.rs 99.3%).