### PR TITLE
Minimize faer features for strided einsum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ approx = "0.5"
 cblas-inject = "0.1"
 cblas-sys = "0.2"
 criterion = "0.5"
-faer = "0.24"
+faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 faer-traits = "0.24"
 mdarray = "0.8.0"
 ndarray = "0.17"

--- a/strided-einsum2/tests/feature_contract.rs
+++ b/strided-einsum2/tests/feature_contract.rs
@@ -1,0 +1,14 @@
+#[test]
+fn workspace_faer_dependency_uses_only_dense_runtime_features() {
+    let manifest = include_str!("../../Cargo.toml");
+    let faer_line = manifest
+        .lines()
+        .find(|line| line.starts_with("faer = "))
+        .expect("workspace must declare faer");
+
+    assert!(
+        faer_line.contains("default-features = false"),
+        "faer defaults pull sparse, npy, and rand dependencies: {faer_line}"
+    );
+    assert!(faer_line.contains("features = [\"std\", \"rayon\"]"));
+}


### PR DESCRIPTION
## Summary

- disable faer's broad default feature set at the strided-rs workspace boundary
- retain only the `std` and `rayon` features required by `strided-einsum2`
- add a dependency contract test preventing `npy`, sparse, and rand features from returning

This is the upstream dependency fix required by tensor4all/tenferro-rs#1397. `strided-einsum2` remains the owner of strided dot-general execution; the change only narrows its provider dependency.

## Verification

- `cargo test --workspace`
- `cargo test -p strided-einsum2 --no-default-features --features faer,parallel --no-run`
- `cargo fmt --all --check`
- `cargo tree -p strided-einsum2` contains no `npyz`, `py_literal`, `pest`, sparse, or faer rand dependencies
