### PR TITLE
Declare BSD-3-Clause in strided-perm license for the HPTT-derived module

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ element type, thread count, and a minimal reproducer when possible.
 This crate is inspired by and ports functionality from:
 - [Strided.jl](https://github.com/Jutho/Strided.jl) by Jutho
 - [StridedViews.jl](https://github.com/Jutho/StridedViews.jl) by Jutho
+- [HPTT](https://github.com/springer13/hptt) by Paul Springer, Tong Su, and
+  Paolo Bientinesi, whose transpose algorithm `strided-perm` reimplements
 - [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl) for
   `strided-opteinsum` design ideas and reference test-case patterns
 
@@ -105,4 +107,7 @@ Licensed under either of:
 - Apache License, Version 2.0 (`LICENSE-APACHE`)
 - MIT license (`LICENSE-MIT`)
 
-See `NOTICE` for upstream attribution (Strided.jl / StridedViews.jl are MIT-licensed).
+See `NOTICE` for upstream attribution (Strided.jl / StridedViews.jl are
+MIT-licensed) and `THIRD-PARTY-LICENSES` for the HPTT attribution; the
+`strided-perm` crate is licensed as `(MIT OR Apache-2.0) AND BSD-3-Clause`
+because its transpose module is derived from HPTT (BSD-3-Clause).

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -6,9 +6,12 @@ HPTT — High-Performance Tensor Transpose
 https://github.com/springer13/hptt
 ================================================================================
 
-The strided-perm/src/hptt/ module implements an algorithm based on the HPTT
-library by Paul Springer, Tong Su, and Paolo Bientinesi. This is an
-independent Rust reimplementation; no C++ source code was copied.
+The strided-perm/src/hptt/ module reimplements in Rust the algorithm of the
+HPTT library by Paul Springer, Tong Su, and Paolo Bientinesi, following the
+structure of the original C++ implementation (see the file-level comments in
+strided-perm/src/hptt/ for the correspondence). The strided-perm crate is
+therefore licensed as "(MIT OR Apache-2.0) AND BSD-3-Clause"; the BSD-3-Clause
+license of HPTT is reproduced below.
 
 Reference:
   Paul Springer, Tong Su, and Paolo Bientinesi.

--- a/strided-perm/Cargo.toml
+++ b/strided-perm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "strided-perm"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
 authors.workspace = true
 repository.workspace = true
 description = "Cache-efficient tensor permutation / transpose (HPTT-inspired)."

--- a/strided-perm/README.md
+++ b/strided-perm/README.md
@@ -43,3 +43,15 @@ copy_into_par(&mut dst.view_mut(), &src.view()).unwrap();
 
 Benchmarks live in
 [`strided-rs-benchmark-suite`](https://github.com/tensor4all/strided-rs-benchmark-suite).
+
+## Acknowledgments and License
+
+The transpose engine in `src/hptt/` reimplements the algorithm of
+[HPTT](https://github.com/springer13/hptt) by Paul Springer, Tong Su, and
+Paolo Bientinesi, following the structure of the original C++ implementation
+(P. Springer, T. Su, P. Bientinesi, "HPTT: A High-Performance Tensor
+Transposition C++ Library", ARRAY 2017). HPTT is licensed under BSD-3-Clause
+(Copyright 2018 Paul Springer); see `THIRD-PARTY-LICENSES` at the workspace
+root for the full text.
+
+This crate is therefore licensed as `(MIT OR Apache-2.0) AND BSD-3-Clause`.


### PR DESCRIPTION
## Summary

The transpose engine in `strided-perm/src/hptt/` follows the structure of HPTT's C++ implementation closely (module comments map to specific `transpose.cpp` line ranges), while HPTT's SIMD kernels, autotuning plan search, and parallelism heuristics were not ported. To stay on the safe side of the derived-work question:

- `strided-perm` `license` field changed from the workspace `MIT OR Apache-2.0` to the SPDX expression `(MIT OR Apache-2.0) AND BSD-3-Clause` (validated with `cargo metadata`)
- `THIRD-PARTY-LICENSES`: the HPTT entry claimed "This is an independent Rust reimplementation; no C++ source code was copied", which overstated independence given the line-range correspondence comments. Replaced with an accurate description that also explains the license split.

The BSD-3-Clause text ("Copyright 2018 Paul Springer") and the ARRAY 2017 paper citation were already in `THIRD-PARTY-LICENSES`, so the substantive BSD compliance was in place; this PR aligns the claims and the package metadata with it. Upstream HPTT was verified to be fully BSD-3-Clause with no LGPL remnants (the LGPLv3 period in its history was cleaned up by the final upstream commit in 2022).

Text and metadata only; no code changes.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test --workspace` (all green)
- [x] `cargo metadata` parses the new SPDX expression
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)