### PR TITLE
AGENTS.md: load shared tensor4all-agent-rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Before acting, read the latest shared tensor4all agent rules from the
+[`tensor4all-agent-rules`](https://github.com/tensor4all/tensor4all-agent-rules)
+repository. Start from:
+
+- `https://github.com/tensor4all/tensor4all-agent-rules/blob/main/rules/index.md`
+
+If internet access is unavailable or the remote cannot be resolved, use the
+sibling checkout:
+
+- `../tensor4all-agent-rules/rules/index.md`
+
+Load only the common, Rust, performance, numerical, docs, or benchmark rule
+files relevant to the task. In particular, `rules/common/provenance.md`
+applies whenever code is written while referencing third-party code.
+
 ## Project Overview
 
 strided-rs is a Rust library providing cache-optimized kernels for strided multidimensional array operations. It is a **port of Julia's Strided.jl/StridedViews.jl libraries**, currently built on top of the `mdarray` crate.


### PR DESCRIPTION
Adds the standard shared-rules preamble (same as tensor4all-rs and tenferro-rs), pointing agents at tensor4all-agent-rules including the new `rules/common/provenance.md` (provenance comments, copyright for ports, scientific credit). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)