### PR TITLE
Add erased copy plan replay API

### DIFF
--- a/docs/superpowers/plans/2026-07-27-erased-copy-plan-api.md
+++ b/docs/superpowers/plans/2026-07-27-erased-copy-plan-api.md
@@ -1,0 +1,29 @@
+## Erased Copy-Plan API
+
+Issue: tensor4all/strided-rs#149
+
+Goal: add the first non-generic replay boundary for tenferro CPU-kernel migration by wrapping the existing `CopyPlan` in a dtype-erased, dtype-concrete dispatch layer owned by `strided-kernel`.
+
+Scope:
+
+- Add a small public dtype enum for the scalar set needed by tensor callers.
+- Add borrowed byte-slice raw descriptors with element-based dims, strides, and offsets.
+- Add an erased copy plan that stores a `CopyPlan` plus dtype and dispatches to pre-instantiated concrete functions inside `strided-kernel`.
+- Pass an explicit `ExecContext` through the erased replay boundary, even while copy replay itself stays serial, so downstream runtimes do not rely on ambient thread-pool state.
+- Validate dtype equality, byte length divisibility, and pointer alignment before constructing typed raw views.
+- Keep `KernelDType` non-exhaustive and make bool byte revalidation dirty-bit based rather than scanning output buffers on every replay.
+- Keep `CopyPlan::execute<T>` unchanged for existing Rust users.
+
+Out of scope:
+
+- C ABI symbols.
+- Thread-pool handles, affinity controls, and execution-scope ownership for the later C ABI.
+- scale/conj erased operations.
+- indexed gather/scatter/dynamic_slice kernels.
+- tenferro dependency migration.
+- new performance tuning beyond preserving the existing prepared-copy zero-allocation path.
+
+Verification:
+
+- Add integration tests for transposed f64 copy, dtype mismatch rejection, supported dtype dispatch, and allocation-free replay for rank <= `RAW_FUSED_RANK_LIMIT`.
+- Run targeted `strided-kernel` tests first, then workspace tests.

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -1,0 +1,137 @@
+//! Dtype-erased prepared kernel entry points.
+//!
+//! These wrappers keep dtype-specific monomorphization inside `strided-kernel`
+//! so downstream runtime crates can replay prepared kernels through stable,
+//! non-generic entry points.
+//!
+//! C ABI symbols are intentionally out of scope here. A future ABI layer must
+//! pass an explicit execution context, preserve the non-overlap contract for
+//! descriptors used by one replay call, and validate ABI dtype tags before
+//! constructing these Rust descriptors.
+//!
+//! The safe Rust descriptor constructors validate dtype byte layout up front.
+//! Mutable erased descriptors only re-scan value-constrained dtypes, currently
+//! `bool`, after their raw bytes have escaped through `data_mut`.
+
+use num_complex::{Complex32, Complex64};
+
+use crate::{
+    CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType, RawStridedMut,
+    RawStridedRef, Result, StridedError,
+};
+
+/// Dtype-erased wrapper around [`CopyPlan`].
+#[derive(Clone, Debug)]
+pub struct ErasedCopyPlan {
+    dtype: KernelDType,
+    plan: CopyPlan,
+}
+
+impl ErasedCopyPlan {
+    /// Compile a copy plan for one dtype and layout pair.
+    pub fn compile(
+        dtype: KernelDType,
+        dims: &[usize],
+        dst_strides: &[isize],
+        src_strides: &[isize],
+    ) -> Result<Self> {
+        Ok(Self {
+            dtype,
+            plan: CopyPlan::compile(dims, dst_strides, src_strides)?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    /// `dest = src` through a non-generic dtype-erased replay boundary.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        src: &ErasedRawStridedRef<'_>,
+    ) -> Result<()> {
+        self.check_dtype(dest.dtype())?;
+        self.check_dtype(src.dtype())?;
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_copy::<f32>(&self.plan, dest, src),
+            KernelDType::F64 => execute_copy::<f64>(&self.plan, dest, src),
+            KernelDType::I32 => execute_copy::<i32>(&self.plan, dest, src),
+            KernelDType::I64 => execute_copy::<i64>(&self.plan, dest, src),
+            KernelDType::Bool => execute_copy::<bool>(&self.plan, dest, src),
+            KernelDType::C32 => execute_copy::<Complex32>(&self.plan, dest, src),
+            KernelDType::C64 => execute_copy::<Complex64>(&self.plan, dest, src),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: `execute_copy` only writes values produced from the
+            // already-validated source descriptor for the same dtype.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+
+    fn check_dtype(&self, actual: KernelDType) -> Result<()> {
+        if actual != self.dtype {
+            return Err(StridedError::DTypeMismatch {
+                expected: self.dtype.label(),
+                actual: actual.label(),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn execute_copy<T>(
+    plan: &CopyPlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let source_data = typed_slice::<T>(src.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let source = unsafe {
+        RawStridedRef::new_unchecked(source_data, src.dims(), src.strides(), src.offset())
+    };
+    let mut dest =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute(&mut dest, &source)
+}
+
+fn typed_slice<T>(bytes: &[u8]) -> &[T] {
+    if bytes.is_empty() {
+        return &[];
+    }
+    unsafe {
+        core::slice::from_raw_parts(
+            bytes.as_ptr().cast::<T>(),
+            bytes.len() / core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn typed_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            if bytes.is_empty() {
+                core::ptr::NonNull::<T>::dangling().as_ptr()
+            } else {
+                bytes.as_mut_ptr().cast::<T>()
+            },
+            bytes.len() / core::mem::size_of::<T>(),
+        )
+    }
+}

--- a/strided-kernel/src/exec_context.rs
+++ b/strided-kernel/src/exec_context.rs
@@ -1,0 +1,125 @@
+//! Execution policy passed through erased kernel replay boundaries.
+//!
+//! `ExecContext` is explicit even for kernels that are currently serial so
+//! downstream runtimes do not accidentally bake ambient thread-pool state into
+//! their prepared-kernel ABI.
+
+use core::num::NonZeroUsize;
+
+use crate::{Result, StridedError};
+
+/// Caller-selected execution policy for prepared kernel replay.
+///
+/// This type intentionally hides its representation so future replay families
+/// can add provider-owned pools or scheduling scopes without forcing downstream
+/// crates to pattern-match a closed enum.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExecContext {
+    kind: ExecContextKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExecContextKind {
+    Serial,
+    MaxThreads(NonZeroUsize),
+    Ambient,
+}
+
+impl ExecContext {
+    /// Execute without entering a parallel worker pool.
+    #[inline]
+    pub const fn serial() -> Self {
+        Self {
+            kind: ExecContextKind::Serial,
+        }
+    }
+
+    /// Execute with an operation-local upper bound on worker threads.
+    #[inline]
+    pub fn max_threads(max_threads: usize) -> Result<Self> {
+        match NonZeroUsize::new(max_threads) {
+            Some(max_threads) => Ok(Self {
+                kind: ExecContextKind::MaxThreads(max_threads),
+            }),
+            None => Err(StridedError::InvalidThreadBudget { max_threads }),
+        }
+    }
+
+    /// Execute using the ambient runtime policy.
+    ///
+    /// This is useful for direct `strided-kernel` users. Runtime crates that
+    /// own CPU resources should prefer [`ExecContext::serial`] or
+    /// [`ExecContext::max_threads`] so thread ownership remains explicit.
+    #[inline]
+    pub const fn ambient() -> Self {
+        Self {
+            kind: ExecContextKind::Ambient,
+        }
+    }
+
+    /// Returns `true` when this context requires serial execution.
+    #[inline]
+    pub fn is_serial(&self) -> bool {
+        matches!(self.kind, ExecContextKind::Serial)
+    }
+
+    /// Returns `true` when this context delegates to ambient runtime policy.
+    #[inline]
+    pub fn is_ambient(&self) -> bool {
+        matches!(self.kind, ExecContextKind::Ambient)
+    }
+
+    /// Returns the configured worker-thread upper bound, if any.
+    #[inline]
+    pub fn max_threads_limit(&self) -> Option<NonZeroUsize> {
+        match self.kind {
+            ExecContextKind::MaxThreads(max_threads) => Some(max_threads),
+            ExecContextKind::Serial | ExecContextKind::Ambient => None,
+        }
+    }
+}
+
+impl Default for ExecContext {
+    #[inline]
+    fn default() -> Self {
+        Self::serial()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExecContext;
+    use crate::StridedError;
+
+    #[test]
+    fn serial_context_has_no_thread_limit() {
+        let ctx = ExecContext::serial();
+
+        assert!(ctx.is_serial());
+        assert!(!ctx.is_ambient());
+        assert_eq!(ctx.max_threads_limit(), None);
+        assert_eq!(ExecContext::default(), ctx);
+    }
+
+    #[test]
+    fn bounded_context_rejects_zero_and_exposes_limit() {
+        let ctx = ExecContext::max_threads(4).unwrap();
+
+        assert!(!ctx.is_serial());
+        assert!(!ctx.is_ambient());
+        assert_eq!(ctx.max_threads_limit().map(|value| value.get()), Some(4));
+        assert!(matches!(
+            ExecContext::max_threads(0).unwrap_err(),
+            StridedError::InvalidThreadBudget { max_threads: 0 }
+        ));
+    }
+
+    #[test]
+    fn ambient_context_has_no_thread_limit() {
+        let ctx = ExecContext::ambient();
+
+        assert!(!ctx.is_serial());
+        assert!(ctx.is_ambient());
+        assert_eq!(ctx.max_threads_limit(), None);
+    }
+}

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -68,6 +68,8 @@ pub use maybe_sync::{MaybeSend, MaybeSendSync, MaybeSync};
 
 // View-based operation modules
 mod copy_plan;
+mod erased;
+mod exec_context;
 mod map_view;
 mod ops_view;
 mod outer_product;
@@ -80,8 +82,8 @@ mod reduce_view;
 pub use strided_view::view;
 pub use strided_view::{
     col_major_strides, row_major_strides, Adjoint, ComposableElementOp, Compose, Conj, ElementOp,
-    ElementOpApply, Identity, RawStridedMut, RawStridedRef, Result, StridedArray, StridedError,
-    StridedView, StridedViewMut, Transpose,
+    ElementOpApply, ErasedRawStridedMut, ErasedRawStridedRef, Identity, KernelDType, RawStridedMut,
+    RawStridedRef, Result, StridedArray, StridedError, StridedView, StridedViewMut, Transpose,
 };
 
 // ============================================================================
@@ -120,6 +122,8 @@ pub use raw_ops::{
 // Prepared (compile-once, execute-many) plans
 // ============================================================================
 pub use copy_plan::CopyPlan;
+pub use erased::ErasedCopyPlan;
+pub use exec_context::ExecContext;
 
 // ============================================================================
 // Reduce operations

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -9,7 +9,10 @@ use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use num_complex::Complex64;
-use strided_kernel::{CopyPlan, RawStridedMut, RawStridedRef};
+use strided_kernel::{
+    CopyPlan, ErasedCopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType,
+    RawStridedMut, RawStridedRef,
+};
 
 struct CountingAllocator;
 
@@ -38,6 +41,24 @@ fn count_allocations(run: impl FnOnce()) -> usize {
     let before = ALLOCATIONS.load(Ordering::SeqCst);
     run();
     ALLOCATIONS.load(Ordering::SeqCst) - before
+}
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
 }
 
 // One test function: the counter is process-global, so concurrently running
@@ -85,4 +106,33 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "execute_conj must not allocate");
+
+    let dims = [2usize; 8];
+    let dst_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
+    let src_strides: Vec<isize> = (0..8).rev().map(|axis| 1isize << axis).collect();
+    let src: Vec<f64> = (0..256).map(|value| value as f64).collect();
+    let mut dst = vec![0.0f64; 256];
+
+    let plan =
+        ErasedCopyPlan::compile(KernelDType::F64, &dims, &dst_strides, &src_strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &src_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &dst_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &source)
+                .unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "erased execute must not allocate");
 }

--- a/strided-kernel/tests/erased_copy_plan.rs
+++ b/strided-kernel/tests/erased_copy_plan.rs
@@ -1,0 +1,213 @@
+use core::fmt::Debug;
+
+use num_complex::{Complex32, Complex64};
+use strided_kernel::{
+    ErasedCopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType,
+    StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+#[test]
+fn erased_copy_plan_executes_f64_transposed_layout() {
+    let dims = [2usize, 3];
+    let src_strides = [3isize, 1];
+    let dst_strides = [1isize, 2];
+    let src = [0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0];
+    let mut dst = [0.0f64; 6];
+
+    let plan =
+        ErasedCopyPlan::compile(KernelDType::F64, &dims, &dst_strides, &src_strides).unwrap();
+    {
+        let source =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &src_strides, 0)
+                .unwrap();
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut dst),
+            &dims,
+            &dst_strides,
+            0,
+        )
+        .unwrap();
+
+        plan.execute(&ExecContext::serial(), &mut dest, &source)
+            .unwrap();
+    }
+
+    assert_eq!(dst, [0.0, 10.0, 1.0, 11.0, 2.0, 12.0]);
+}
+
+#[test]
+fn erased_copy_plan_rejects_dtype_mismatch() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let src = [1.0f64, 2.0];
+    let mut dst = [0.0f32; 2];
+
+    let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap_err();
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+}
+
+fn assert_supported_copy<T>(dtype: KernelDType, input: &[T])
+where
+    T: Copy + Debug + Default + PartialEq,
+{
+    let dims = [input.len()];
+    let strides = [1isize];
+    let mut output = vec![T::default(); input.len()];
+
+    let plan = ErasedCopyPlan::compile(dtype, &dims, &strides, &strides).unwrap();
+    {
+        let source = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let mut dest =
+            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut output), &dims, &strides, 0).unwrap();
+        plan.execute(&ExecContext::serial(), &mut dest, &source)
+            .unwrap();
+    }
+
+    assert_eq!(output, input);
+}
+
+#[test]
+fn erased_copy_plan_executes_supported_scalar_set() {
+    assert_supported_copy(KernelDType::F32, &[1.0f32, -2.0, 3.5]);
+    assert_supported_copy(KernelDType::F64, &[1.0f64, -2.0, 3.5]);
+    assert_supported_copy(KernelDType::I32, &[1i32, -2, 3]);
+    assert_supported_copy(KernelDType::I64, &[1i64, -2, 3]);
+    assert_supported_copy(KernelDType::Bool, &[true, false, true]);
+    assert_supported_copy(
+        KernelDType::C32,
+        &[Complex32::new(1.0, -2.0), Complex32::new(3.5, 4.0)],
+    );
+    assert_supported_copy(
+        KernelDType::C64,
+        &[Complex64::new(1.0, -2.0), Complex64::new(3.5, 4.0)],
+    );
+}
+
+#[test]
+fn erased_raw_descriptors_reject_invalid_byte_layouts() {
+    let dims = [1usize];
+    let strides = [1isize];
+    let bytes = [0u8; 9];
+
+    let err = ErasedRawStridedRef::new(KernelDType::F64, &bytes, &dims, &strides, 0).unwrap_err();
+    assert!(matches!(err, StridedError::ByteLengthMismatch { .. }));
+
+    let aligned = [0.0f64; 2];
+    let aligned_bytes = as_bytes(&aligned);
+    let misaligned = &aligned_bytes[1..1 + core::mem::size_of::<f64>()];
+    let err =
+        ErasedRawStridedRef::new(KernelDType::F64, misaligned, &dims, &strides, 0).unwrap_err();
+    assert!(matches!(err, StridedError::DataAlignmentMismatch { .. }));
+
+    let invalid_bool = [2u8];
+    let err =
+        ErasedRawStridedRef::new(KernelDType::Bool, &invalid_bool, &dims, &strides, 0).unwrap_err();
+    assert!(matches!(err, StridedError::InvalidBoolByte { value: 2 }));
+}
+
+#[test]
+fn erased_copy_plan_revalidates_bool_output_bytes_before_replay() {
+    let dims = [1usize];
+    let strides = [1isize];
+    let source_bytes = [1u8];
+    let mut dest_bytes = [0u8];
+
+    let plan = ErasedCopyPlan::compile(KernelDType::Bool, &dims, &strides, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::Bool, &source_bytes, &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::Bool, &mut dest_bytes, &dims, &strides, 0).unwrap();
+
+    dest.data_mut()[0] = 2;
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap_err();
+    assert!(matches!(err, StridedError::InvalidBoolByte { value: 2 }));
+}
+
+#[test]
+fn erased_copy_plan_accepts_explicit_execution_contexts() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let src = [3.0f64, 4.0];
+    let mut serial_dst = [0.0f64; 2];
+    let mut bounded_dst = [0.0f64; 2];
+    let mut ambient_dst = [0.0f64; 2];
+
+    let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &strides, 0).unwrap();
+
+    {
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut serial_dst),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ExecContext::serial(), &mut dest, &source)
+            .unwrap();
+    }
+    {
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut bounded_dst),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        let ctx = ExecContext::max_threads(1).unwrap();
+        plan.execute(&ctx, &mut dest, &source).unwrap();
+    }
+    {
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut ambient_dst),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ExecContext::ambient(), &mut dest, &source)
+            .unwrap();
+    }
+
+    assert!(matches!(
+        ExecContext::max_threads(0).unwrap_err(),
+        StridedError::InvalidThreadBudget { max_threads: 0 }
+    ));
+    assert_eq!(serial_dst, src);
+    assert_eq!(bounded_dst, src);
+    assert_eq!(ambient_dst, src);
+}

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -33,7 +33,9 @@ pub use element_op::{
 // ============================================================================
 // View-based types
 // ============================================================================
-pub use raw::{RawStridedMut, RawStridedRef};
+pub use raw::{
+    ErasedRawStridedMut, ErasedRawStridedRef, KernelDType, RawStridedMut, RawStridedRef,
+};
 pub use view::{col_major_strides, row_major_strides, StridedArray, StridedView, StridedViewMut};
 
 // ============================================================================
@@ -78,6 +80,42 @@ pub enum StridedError {
     /// Runtime view layout does not match the layout a prepared plan was compiled for.
     #[error("view layout does not match the compiled plan")]
     PlanLayoutMismatch,
+
+    /// Runtime dtype does not match the dtype a prepared plan was compiled for.
+    #[error("dtype mismatch: expected {expected}, got {actual}")]
+    DTypeMismatch {
+        expected: &'static str,
+        actual: &'static str,
+    },
+
+    /// A byte buffer length is not a whole number of dtype elements.
+    #[error(
+        "byte length {byte_len} is not a multiple of element size {element_size} for dtype {dtype}"
+    )]
+    ByteLengthMismatch {
+        dtype: &'static str,
+        byte_len: usize,
+        element_size: usize,
+    },
+
+    /// A byte buffer pointer does not satisfy the dtype alignment.
+    #[error("data pointer for dtype {dtype} is not aligned to {alignment} bytes")]
+    DataAlignmentMismatch {
+        dtype: &'static str,
+        alignment: usize,
+    },
+
+    /// A byte buffer for `bool` contains a value that is not a valid Rust bool.
+    #[error("invalid bool byte value {value}")]
+    InvalidBoolByte { value: u8 },
+
+    /// An execution context requested an invalid worker-thread budget.
+    #[error("invalid thread budget {max_threads}")]
+    InvalidThreadBudget { max_threads: usize },
+
+    /// The dtype is recognized but unsupported by the selected operation.
+    #[error("unsupported dtype {dtype}")]
+    UnsupportedDType { dtype: &'static str },
 }
 
 /// Result type for strided array operations.

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -7,7 +7,271 @@
 
 use crate::element_op::Identity;
 use crate::view::validate_bounds;
-use crate::{Result, StridedView, StridedViewMut};
+use num_complex::{Complex32, Complex64};
+
+use crate::{Result, StridedError, StridedView, StridedViewMut};
+
+/// Dtypes supported by dtype-erased kernel entry points.
+///
+/// The enum is intentionally limited to the scalar set currently used by the
+/// tensor runtime callers. Later FFI layers should map their ABI dtype tags to
+/// this enum before dispatching into prepared kernels.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(u8)]
+pub enum KernelDType {
+    F32 = 1,
+    F64 = 2,
+    I32 = 3,
+    I64 = 4,
+    Bool = 5,
+    C32 = 6,
+    C64 = 7,
+}
+
+impl KernelDType {
+    #[inline]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+            Self::I32 => "i32",
+            Self::I64 => "i64",
+            Self::Bool => "bool",
+            Self::C32 => "c32",
+            Self::C64 => "c64",
+        }
+    }
+
+    #[inline]
+    pub const fn size_of(self) -> usize {
+        match self {
+            Self::F32 => core::mem::size_of::<f32>(),
+            Self::F64 => core::mem::size_of::<f64>(),
+            Self::I32 => core::mem::size_of::<i32>(),
+            Self::I64 => core::mem::size_of::<i64>(),
+            Self::Bool => core::mem::size_of::<bool>(),
+            Self::C32 => core::mem::size_of::<Complex32>(),
+            Self::C64 => core::mem::size_of::<Complex64>(),
+        }
+    }
+
+    #[inline]
+    pub const fn alignment(self) -> usize {
+        match self {
+            Self::F32 => core::mem::align_of::<f32>(),
+            Self::F64 => core::mem::align_of::<f64>(),
+            Self::I32 => core::mem::align_of::<i32>(),
+            Self::I64 => core::mem::align_of::<i64>(),
+            Self::Bool => core::mem::align_of::<bool>(),
+            Self::C32 => core::mem::align_of::<Complex32>(),
+            Self::C64 => core::mem::align_of::<Complex64>(),
+        }
+    }
+
+    #[inline]
+    pub const fn requires_valid_byte_values(self) -> bool {
+        matches!(self, Self::Bool)
+    }
+}
+
+fn validate_erased_buffer(dtype: KernelDType, data: &[u8]) -> Result<usize> {
+    let element_size = dtype.size_of();
+    if data.len() % element_size != 0 {
+        return Err(StridedError::ByteLengthMismatch {
+            dtype: dtype.label(),
+            byte_len: data.len(),
+            element_size,
+        });
+    }
+
+    let element_count = data.len() / element_size;
+    if element_count == 0 {
+        return Ok(0);
+    }
+
+    let alignment = dtype.alignment();
+    if data.as_ptr() as usize % alignment != 0 {
+        return Err(StridedError::DataAlignmentMismatch {
+            dtype: dtype.label(),
+            alignment,
+        });
+    }
+    if dtype.requires_valid_byte_values() {
+        if let Some(&value) = data.iter().find(|&&value| value > 1) {
+            return Err(StridedError::InvalidBoolByte { value });
+        }
+    }
+    Ok(element_count)
+}
+
+/// Borrowed dtype-erased raw strided input layout.
+///
+/// `dims`, `strides`, and `offset` are expressed in dtype elements, not bytes.
+#[derive(Clone, Copy, Debug)]
+pub struct ErasedRawStridedRef<'a> {
+    dtype: KernelDType,
+    data: &'a [u8],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a> ErasedRawStridedRef<'a> {
+    /// Create a byte-backed erased input descriptor after validating dtype byte
+    /// length, alignment, rank/stride agreement, and reachable element bounds.
+    pub fn new(
+        dtype: KernelDType,
+        data: &'a [u8],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let element_count = validate_erased_buffer(dtype, data)?;
+        validate_bounds(element_count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Re-check the current byte buffer against the descriptor dtype.
+    ///
+    /// This is normally redundant after construction, but callers that can
+    /// mutate a sibling output descriptor's bytes may need a cheap way to
+    /// re-establish dtype byte validity before typed replay.
+    pub fn validate_data(&self) -> Result<()> {
+        validate_erased_buffer(self.dtype, self.data).map(|_| ())
+    }
+}
+
+/// Borrowed dtype-erased raw strided output layout.
+///
+/// `dims`, `strides`, and `offset` are expressed in dtype elements, not bytes.
+#[derive(Debug)]
+pub struct ErasedRawStridedMut<'a> {
+    dtype: KernelDType,
+    data: &'a mut [u8],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+    needs_data_revalidation: bool,
+}
+
+impl<'a> ErasedRawStridedMut<'a> {
+    /// Create a byte-backed erased output descriptor after validating dtype
+    /// byte length, alignment, rank/stride agreement, and reachable element
+    /// bounds.
+    pub fn new(
+        dtype: KernelDType,
+        data: &'a mut [u8],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let element_count = validate_erased_buffer(dtype, data)?;
+        validate_bounds(element_count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            dims,
+            strides,
+            offset,
+            needs_data_revalidation: false,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn data(&self) -> &[u8] {
+        self.data
+    }
+
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        if self.dtype.requires_valid_byte_values() {
+            self.needs_data_revalidation = true;
+        }
+        self.data
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Re-check the current byte buffer against the descriptor dtype.
+    ///
+    /// This guards safe replay when callers mutate bytes through
+    /// [`ErasedRawStridedMut::data_mut`] after construction.
+    pub fn validate_data(&self) -> Result<()> {
+        validate_erased_buffer(self.dtype, self.data).map(|_| ())
+    }
+
+    /// Re-check dtype byte validity only when mutable bytes escaped since the
+    /// last validation.
+    pub fn validate_data_if_needed(&mut self) -> Result<()> {
+        if self.needs_data_revalidation {
+            self.validate_data()?;
+            self.needs_data_revalidation = false;
+        }
+        Ok(())
+    }
+
+    /// Mark the current byte buffer as satisfying this descriptor's dtype
+    /// value invariants.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure every byte sequence in `data` is valid for
+    /// `dtype`. This matters for `bool`, where Rust requires stored values to
+    /// be exactly `0` or `1` before a typed `bool` slice is formed.
+    pub unsafe fn assume_data_valid(&mut self) {
+        self.needs_data_revalidation = false;
+    }
+}
 
 /// Borrowed raw strided input layout.
 ///


### PR DESCRIPTION
## Summary

Refs #149.

This PR adds the first Rust-only erased replay boundary for upstreaming tenferro CPU kernels into `strided-kernel`:

- adds `KernelDType` and byte-backed erased raw strided descriptors with dtype, alignment, byte-length, bounds, and bool-byte validation
- adds `ErasedCopyPlan`, wrapping the existing `CopyPlan` and dispatching to pre-instantiated concrete copy replay functions inside `strided-kernel`
- preserves the existing generic `CopyPlan` API for current Rust callers
- adds tests for transposed f64 copy, dtype mismatch, supported scalar dispatch, invalid byte descriptors, bool revalidation, and allocation-free erased replay

Out of scope for this PR: C ABI symbols, scale/conj erased operations, indexed kernels, and the tenferro dependency migration.

## Verification

- `cargo fmt --all --check`
- `cargo test -p strided-kernel --test erased_copy_plan`
- `cargo test --workspace`
- `cargo test -p strided-kernel --all-features`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
