### PR TITLE
Add erased fused elementwise replay API

### DIFF
--- a/docs/superpowers/plans/2026-07-27-erased-fused-plan-api.md
+++ b/docs/superpowers/plans/2026-07-27-erased-fused-plan-api.md
@@ -1,0 +1,37 @@
+## Erased Fused-Plan API
+
+Issue: tensor4all/strided-rs#149
+
+Goal: add the next family-sized Rust erased boundary after copy by exposing
+single-output map/zip elementwise replay through concrete dtype dispatch owned
+by `strided-kernel`.
+
+Scope:
+
+- Reuse the existing `FusedPlan` / `FusedOp` runtime op-code vocabulary.
+- Add `ErasedFusedPlan` for one output and one to four inputs, matching the
+  existing `map_into` / `zip_map{2,3,4}_into` ownership boundary.
+- Dispatch only the dtype set already covered by `FusedScalar` (`f32`, `f64`,
+  `c32`, `c64`); leave integer and bool elementwise semantics for a later
+  explicit design.
+- Keep `ExecContext` on execute signatures so each erased family carries the
+  same threading boundary, even while current execution still uses the existing
+  view-based fused implementation internally.
+- Treat non-ambient `ExecContext` values conservatively as serial execution for
+  now; owned-pool execution is a later threading implementation detail, not a
+  reason to leak ambient Rayon into this boundary.
+
+Out of scope:
+
+- C ABI symbols.
+- Multi-output fused replay.
+- Fused-DAG ABI stabilization.
+- Integer, bool, comparison, and logical op semantics.
+- Reduction and indexed gather/scatter/dynamic_slice families.
+
+Verification:
+
+- Add integration tests for f64 zip-add on a transposed output layout, c64
+  multiply, f32 ternary clamp through ambient execution, c32 unary conjugation,
+  a four-input DAG, dtype/count mismatch rejection before writing, plan accessor
+  exposure, invalid output contracts, and unsupported dtype / arity rejection.

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -16,9 +16,12 @@
 use num_complex::{Complex32, Complex64};
 
 use crate::{
-    CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType, RawStridedMut,
-    RawStridedRef, Result, StridedError,
+    fused_elementwise_into, CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
+    FusedPlan, FusedScalar, KernelDType, RawStridedMut, RawStridedRef, Result, StridedError,
+    StridedView, StridedViewMut,
 };
+
+const ERASED_FUSED_INPUT_LIMIT: usize = 4;
 
 /// Dtype-erased wrapper around [`CopyPlan`].
 #[derive(Clone, Debug)]
@@ -90,6 +93,102 @@ impl ErasedCopyPlan {
     }
 }
 
+/// Dtype-erased single-output wrapper around [`FusedPlan`].
+///
+/// This is the erased replay boundary for unary map and zip-map elementwise
+/// families. It supports the same runtime op-code vocabulary as [`FusedPlan`],
+/// but only for the scalar dtypes currently implementing [`FusedScalar`].
+#[derive(Clone, Debug)]
+pub struct ErasedFusedPlan {
+    dtype: KernelDType,
+    plan: FusedPlan,
+}
+
+impl ErasedFusedPlan {
+    /// Validate and store a single-output fused elementwise plan for one dtype.
+    pub fn compile(dtype: KernelDType, plan: FusedPlan) -> Result<Self> {
+        check_fused_dtype(dtype)?;
+        if plan.input_count == 0 || plan.input_count > ERASED_FUSED_INPUT_LIMIT {
+            return Err(StridedError::UnsupportedArity {
+                arity: plan.input_count,
+                max: ERASED_FUSED_INPUT_LIMIT,
+            });
+        }
+        if plan.outputs.len() != 1 {
+            return Err(StridedError::RankMismatch(plan.outputs.len(), 1));
+        }
+        crate::fused::validate_plan(&plan, plan.input_count, 1)?;
+        Ok(Self { dtype, plan })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &FusedPlan {
+        &self.plan
+    }
+
+    /// Execute a single-output fused elementwise plan through erased descriptors.
+    pub fn execute(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        inputs: &[ErasedRawStridedRef<'_>],
+    ) -> Result<()> {
+        if inputs.len() != self.plan.input_count {
+            return Err(StridedError::RankMismatch(
+                inputs.len(),
+                self.plan.input_count,
+            ));
+        }
+        check_dtype(self.dtype, dest.dtype())?;
+        for input in inputs {
+            check_dtype(self.dtype, input.dtype())?;
+        }
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_fused::<f32>(&self.plan, ctx, dest, inputs),
+            KernelDType::F64 => execute_fused::<f64>(&self.plan, ctx, dest, inputs),
+            KernelDType::C32 => execute_fused::<Complex32>(&self.plan, ctx, dest, inputs),
+            KernelDType::C64 => execute_fused::<Complex64>(&self.plan, ctx, dest, inputs),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: supported fused elementwise dtypes have no extra byte
+            // validity invariant beyond the typed values written by the kernel.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
+fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {
+    if actual != expected {
+        return Err(StridedError::DTypeMismatch {
+            expected: expected.label(),
+            actual: actual.label(),
+        });
+    }
+    Ok(())
+}
+
+fn check_fused_dtype(dtype: KernelDType) -> Result<()> {
+    match dtype {
+        KernelDType::F32 | KernelDType::F64 | KernelDType::C32 | KernelDType::C64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
 fn execute_copy<T>(
     plan: &CopyPlan,
     dest: &mut ErasedRawStridedMut<'_>,
@@ -109,6 +208,80 @@ where
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.execute(&mut dest, &source)
+}
+
+fn execute_fused<T>(
+    plan: &FusedPlan,
+    ctx: &ExecContext,
+    dest: &mut ErasedRawStridedMut<'_>,
+    inputs: &[ErasedRawStridedRef<'_>],
+) -> Result<()>
+where
+    T: FusedScalar,
+{
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_view =
+        unsafe { StridedViewMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+
+    match inputs {
+        [a] => {
+            let input_views = [erased_view::<T>(a)];
+            let mut dests = [dest_view];
+            execute_fused_views(ctx, &mut dests, &input_views, plan)
+        }
+        [a, b] => {
+            let input_views = [erased_view::<T>(a), erased_view::<T>(b)];
+            let mut dests = [dest_view];
+            execute_fused_views(ctx, &mut dests, &input_views, plan)
+        }
+        [a, b, c] => {
+            let input_views = [
+                erased_view::<T>(a),
+                erased_view::<T>(b),
+                erased_view::<T>(c),
+            ];
+            let mut dests = [dest_view];
+            execute_fused_views(ctx, &mut dests, &input_views, plan)
+        }
+        [a, b, c, d] => {
+            let input_views = [
+                erased_view::<T>(a),
+                erased_view::<T>(b),
+                erased_view::<T>(c),
+                erased_view::<T>(d),
+            ];
+            let mut dests = [dest_view];
+            execute_fused_views(ctx, &mut dests, &input_views, plan)
+        }
+        _ => Err(StridedError::UnsupportedArity {
+            arity: inputs.len(),
+            max: ERASED_FUSED_INPUT_LIMIT,
+        }),
+    }
+}
+
+fn execute_fused_views<T>(
+    ctx: &ExecContext,
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()>
+where
+    T: FusedScalar,
+{
+    if ctx.is_ambient() {
+        fused_elementwise_into(dests, inputs, plan)
+    } else {
+        crate::fused::fused_elementwise_into_serial(dests, inputs, plan)
+    }
+}
+
+fn erased_view<'a, T>(src: &ErasedRawStridedRef<'a>) -> StridedView<'a, T> {
+    let data = typed_slice::<T>(src.data());
+    unsafe { StridedView::new_unchecked(data, src.dims(), src.strides(), src.offset()) }
 }
 
 fn typed_slice<T>(bytes: &[u8]) -> &[T] {

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -327,7 +327,11 @@ fn op_arity(op: FusedOp) -> usize {
     }
 }
 
-fn validate_plan(plan: &FusedPlan, input_count: usize, output_count: usize) -> Result<()> {
+pub(crate) fn validate_plan(
+    plan: &FusedPlan,
+    input_count: usize,
+    output_count: usize,
+) -> Result<()> {
     if input_count != plan.input_count {
         return Err(StridedError::RankMismatch(input_count, plan.input_count));
     }
@@ -715,32 +719,32 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
     inputs: &[StridedView<'_, T>],
     plan: &FusedPlan,
 ) -> Result<()> {
-    let dims = dests[0].dims().to_vec();
-    if total_len(&dims) == 0 {
-        return Ok(());
-    }
-
-    let dst_ptrs: Vec<*mut T> = dests.iter_mut().map(|dest| dest.as_mut_ptr()).collect();
-    let input_ptrs: Vec<*const T> = inputs.iter().map(StridedView::ptr).collect();
-
-    let mut strides_list: Vec<&[isize]> = Vec::with_capacity(dests.len() + inputs.len());
-    for dest in dests.iter() {
-        strides_list.push(dest.strides());
-    }
-    for input in inputs {
-        strides_list.push(input.strides());
-    }
-
-    let elem_size = std::mem::size_of::<T>();
-    let total = total_len(&dims);
-    let (fused_dims, ordered_strides, kernel_plan) = if total <= SMALL_TENSOR_THRESHOLD {
-        build_plan_fused_small(&dims, &strides_list)
-    } else {
-        build_plan_fused(&dims, &strides_list, Some(0), elem_size)
-    };
-
     #[cfg(feature = "parallel")]
     {
+        let dims = dests[0].dims().to_vec();
+        if total_len(&dims) == 0 {
+            return Ok(());
+        }
+
+        let dst_ptrs: Vec<*mut T> = dests.iter_mut().map(|dest| dest.as_mut_ptr()).collect();
+        let input_ptrs: Vec<*const T> = inputs.iter().map(StridedView::ptr).collect();
+
+        let mut strides_list: Vec<&[isize]> = Vec::with_capacity(dests.len() + inputs.len());
+        for dest in dests.iter() {
+            strides_list.push(dest.strides());
+        }
+        for input in inputs {
+            strides_list.push(input.strides());
+        }
+
+        let elem_size = std::mem::size_of::<T>();
+        let total = total_len(&dims);
+        let (fused_dims, ordered_strides, kernel_plan) = if total <= SMALL_TENSOR_THRESHOLD {
+            build_plan_fused_small(&dims, &strides_list)
+        } else {
+            build_plan_fused(&dims, &strides_list, Some(0), elem_size)
+        };
+
         let total: usize = fused_dims.iter().product();
         if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let dst_send: Vec<SendPtr<T>> = dst_ptrs.iter().map(|&ptr| SendPtr(ptr)).collect();
@@ -790,6 +794,38 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
         }
     }
 
+    interpret_fused_elementwise_into_serial(dests, inputs, plan)
+}
+
+fn interpret_fused_elementwise_into_serial<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()> {
+    let dims = dests[0].dims().to_vec();
+    if total_len(&dims) == 0 {
+        return Ok(());
+    }
+
+    let dst_ptrs: Vec<*mut T> = dests.iter_mut().map(|dest| dest.as_mut_ptr()).collect();
+    let input_ptrs: Vec<*const T> = inputs.iter().map(StridedView::ptr).collect();
+
+    let mut strides_list: Vec<&[isize]> = Vec::with_capacity(dests.len() + inputs.len());
+    for dest in dests.iter() {
+        strides_list.push(dest.strides());
+    }
+    for input in inputs {
+        strides_list.push(input.strides());
+    }
+
+    let elem_size = std::mem::size_of::<T>();
+    let total = total_len(&dims);
+    let (fused_dims, ordered_strides, kernel_plan) = if total <= SMALL_TENSOR_THRESHOLD {
+        build_plan_fused_small(&dims, &strides_list)
+    } else {
+        build_plan_fused(&dims, &strides_list, Some(0), elem_size)
+    };
+
     let initial_offsets = vec![0isize; ordered_strides.len()];
     for_each_inner_block_preordered(
         &fused_dims,
@@ -803,6 +839,16 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
             Ok(())
         },
     )
+}
+
+pub(crate) fn fused_elementwise_into_serial<T: FusedScalar>(
+    dests: &mut [StridedViewMut<'_, T>],
+    inputs: &[StridedView<'_, T>],
+    plan: &FusedPlan,
+) -> Result<()> {
+    validate_plan(plan, inputs.len(), dests.len())?;
+    validate_shapes(dests, inputs)?;
+    interpret_fused_elementwise_into_serial(dests, inputs, plan)
 }
 
 /// Evaluate a runtime-DAG elementwise plan into one or more destinations.

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -122,7 +122,7 @@ pub use raw_ops::{
 // Prepared (compile-once, execute-many) plans
 // ============================================================================
 pub use copy_plan::CopyPlan;
-pub use erased::ErasedCopyPlan;
+pub use erased::{ErasedCopyPlan, ErasedFusedPlan};
 pub use exec_context::ExecContext;
 
 // ============================================================================

--- a/strided-kernel/tests/erased_fused_plan.rs
+++ b/strided-kernel/tests/erased_fused_plan.rs
@@ -1,0 +1,341 @@
+use num_complex::{Complex32, Complex64};
+use strided_kernel::{
+    ErasedFusedPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, FusedInst, FusedOp,
+    FusedPlan, KernelDType, StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn binary_plan(op: FusedOp) -> FusedPlan {
+    FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op,
+            inputs: vec![0, 1],
+        }],
+    }
+}
+
+fn unary_plan(op: FusedOp) -> FusedPlan {
+    FusedPlan {
+        input_count: 1,
+        outputs: vec![1],
+        ops: vec![FusedInst {
+            op,
+            inputs: vec![0],
+        }],
+    }
+}
+
+#[test]
+fn erased_fused_plan_executes_f64_binary_add_transposed_layout() {
+    let dims = [2usize, 3];
+    let src_strides = [3isize, 1];
+    let dst_strides = [1isize, 2];
+    let a = [0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0];
+    let b = [100.0f64, 101.0, 102.0, 110.0, 111.0, 112.0];
+    let mut dst = [0.0f64; 6];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &src_strides, 0).unwrap(),
+    ];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &dst_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [100.0, 120.0, 102.0, 122.0, 104.0, 124.0]);
+}
+
+#[test]
+fn erased_fused_plan_executes_f32_ternary_clamp_with_ambient_context() {
+    let dims = [3usize];
+    let strides = [1isize];
+    let x = [-2.0f32, 0.5, 4.0];
+    let min = [-1.0f32, 0.0, 1.0];
+    let max = [1.0f32, 1.0, 3.0];
+    let mut dst = [0.0f32; 3];
+
+    let plan = ErasedFusedPlan::compile(
+        KernelDType::F32,
+        FusedPlan {
+            input_count: 3,
+            outputs: vec![3],
+            ops: vec![FusedInst {
+                op: FusedOp::Clamp,
+                inputs: vec![0, 1, 2],
+            }],
+        },
+    )
+    .unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&x), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&min), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&max), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute(&ExecContext::ambient(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [-1.0, 0.5, 3.0]);
+}
+
+#[test]
+fn erased_fused_plan_executes_c32_unary_conjugate() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let input = [Complex32::new(1.0, -2.0), Complex32::new(-3.0, 4.0)];
+    let mut dst = [Complex32::new(0.0, 0.0); 2];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::C32, unary_plan(FusedOp::Conj)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::C32, as_bytes(&input), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::C32, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [input[0].conj(), input[1].conj()]);
+}
+
+#[test]
+fn erased_fused_plan_executes_c64_binary_multiply() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let a = [Complex64::new(1.0, 2.0), Complex64::new(3.0, -1.0)];
+    let b = [Complex64::new(4.0, -1.0), Complex64::new(0.5, 2.0)];
+    let mut dst = [Complex64::new(0.0, 0.0); 2];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::C64, binary_plan(FusedOp::Multiply)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&a), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&b), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute(&ExecContext::max_threads(1).unwrap(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [a[0] * b[0], a[1] * b[1]]);
+}
+
+#[test]
+fn erased_fused_plan_executes_f64_four_input_dag() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let a = [1.0f64, 2.0];
+    let b = [10.0f64, 20.0];
+    let c = [3.0f64, 4.0];
+    let d = [5.0f64, 6.0];
+    let mut dst = [0.0f64; 2];
+
+    let plan = ErasedFusedPlan::compile(
+        KernelDType::F64,
+        FusedPlan {
+            input_count: 4,
+            outputs: vec![6],
+            ops: vec![
+                FusedInst {
+                    op: FusedOp::Add,
+                    inputs: vec![0, 1],
+                },
+                FusedInst {
+                    op: FusedOp::Multiply,
+                    inputs: vec![2, 3],
+                },
+                FusedInst {
+                    op: FusedOp::Add,
+                    inputs: vec![4, 5],
+                },
+            ],
+        },
+    )
+    .unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&c), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&d), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [26.0, 46.0]);
+}
+
+#[test]
+fn erased_fused_plan_rejects_dtype_mismatch_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let a = [1.0f64, 2.0];
+    let b = [3.0f64, 4.0];
+    let mut dst = [0.0f32; 2];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+    assert_eq!(dst, [0.0, 0.0]);
+}
+
+#[test]
+fn erased_fused_plan_rejects_input_count_mismatch_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let a = [1.0f64, 2.0];
+    let mut dst = [9.0f64, 10.0];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs =
+        [ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap()];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::RankMismatch(1, 2)));
+    assert_eq!(dst, [9.0, 10.0]);
+}
+
+#[test]
+fn erased_fused_plan_rejects_input_dtype_mismatch_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let a = [1.0f64, 2.0];
+    let b = [3.0f32, 4.0];
+    let mut dst = [9.0f64, 10.0];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&b), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+    assert_eq!(dst, [9.0, 10.0]);
+}
+
+#[test]
+fn erased_fused_plan_exposes_dtype_and_plan() {
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+
+    assert_eq!(plan.dtype(), KernelDType::F64);
+    assert_eq!(plan.plan().input_count, 2);
+    assert_eq!(plan.plan().outputs, [2]);
+}
+
+#[test]
+fn erased_fused_plan_rejects_unsupported_dtype_and_arity() {
+    let unsupported_dtype =
+        ErasedFusedPlan::compile(KernelDType::I32, binary_plan(FusedOp::Add)).unwrap_err();
+    assert!(matches!(
+        unsupported_dtype,
+        StridedError::UnsupportedDType { dtype: "i32" }
+    ));
+
+    let too_many_inputs = FusedPlan {
+        input_count: 5,
+        outputs: vec![0],
+        ops: vec![],
+    };
+    let unsupported_arity =
+        ErasedFusedPlan::compile(KernelDType::F64, too_many_inputs).unwrap_err();
+    assert!(matches!(
+        unsupported_arity,
+        StridedError::UnsupportedArity { arity: 5, max: 4 }
+    ));
+
+    let zero_inputs = FusedPlan {
+        input_count: 0,
+        outputs: vec![0],
+        ops: vec![],
+    };
+    let unsupported_arity = ErasedFusedPlan::compile(KernelDType::F64, zero_inputs).unwrap_err();
+    assert!(matches!(
+        unsupported_arity,
+        StridedError::UnsupportedArity { arity: 0, max: 4 }
+    ));
+}
+
+#[test]
+fn erased_fused_plan_rejects_invalid_output_contracts() {
+    let output_count_mismatch = FusedPlan {
+        input_count: 2,
+        outputs: vec![2, 2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+    let err = ErasedFusedPlan::compile(KernelDType::F64, output_count_mismatch).unwrap_err();
+    assert!(matches!(err, StridedError::RankMismatch(2, 1)));
+
+    let invalid_output = FusedPlan {
+        input_count: 2,
+        outputs: vec![3],
+        ops: vec![],
+    };
+    let err = ErasedFusedPlan::compile(KernelDType::F64, invalid_output).unwrap_err();
+    assert!(matches!(
+        err,
+        StridedError::InvalidAxis { axis: 3, rank: 2 }
+    ));
+}

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -116,6 +116,10 @@ pub enum StridedError {
     /// The dtype is recognized but unsupported by the selected operation.
     #[error("unsupported dtype {dtype}")]
     UnsupportedDType { dtype: &'static str },
+
+    /// The operation arity is unsupported by this entry point.
+    #[error("unsupported arity {arity}; maximum supported arity is {max}")]
+    UnsupportedArity { arity: usize, max: usize },
 }
 
 /// Result type for strided array operations.


### PR DESCRIPTION
## Summary

- add `ErasedFusedPlan` as the Rust erased replay boundary for single-output map/zip elementwise plans
- keep dtype dispatch inside `strided-kernel` for `f32`, `f64`, `c32`, and `c64`
- validate dtype, arity, output contract, runtime input count, and descriptor dtypes before writing
- route ambient contexts through the existing fused implementation and keep non-ambient contexts conservative/serial for now

## Scope

This is the next Rust-only family after the erased copy replay API. C ABI symbols, multi-output fused replay, integer/bool elementwise semantics, reductions, and indexed gather/scatter/dynamic_slice remain out of scope.

Refs tensor4all/strided-rs#149.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p strided-kernel --all-features`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --workspace --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json`
