### PR TITLE
Add erased full-reduction replay API

### DIFF
--- a/docs/superpowers/plans/2026-07-27-erased-reduce-plan-api.md
+++ b/docs/superpowers/plans/2026-07-27-erased-reduce-plan-api.md
@@ -1,0 +1,39 @@
+## Erased Reduce-Plan API
+
+Issue: tensor4all/strided-rs#149
+
+Goal: add the next family-sized Rust erased boundary after copy and map/zip by
+exposing full-reduction replay through concrete dtype dispatch owned by
+`strided-kernel`.
+
+Scope:
+
+- Add a small `ReduceOp` vocabulary for full reductions with unambiguous
+  identities: `Sum` and `Product`.
+- Add `ErasedReducePlan` for full-tensor reductions into a scalar output
+  descriptor.
+- Support the numeric dtype set whose `Sum` and `Product` semantics are already
+  clear at this boundary: `f32`, `f64`, `i32`, `i64`, `c32`, and `c64`.
+- Keep output dtype equal to input dtype. Dtype promotion remains a tensor
+  runtime concern.
+- Keep `ExecContext` on execute signatures. `Ambient` preserves the existing
+  view-based behavior; non-ambient contexts use a serial reduce helper so this
+  erased boundary does not read ambient Rayon state.
+- Validate dtype equality, source layout identity, and scalar output shape
+  before writing.
+
+Out of scope:
+
+- C ABI symbols.
+- Axis and multi-axis reductions.
+- `Maximum`, `Minimum`, boolean, comparison, and dtype-promotion semantics.
+- New performance tuning beyond build-isolating the dtype dispatch.
+- tenferro dependency migration.
+
+Verification:
+
+- Add integration tests for f64 sum on a transposed layout, c64 product, i32
+  ambient sum, the remaining supported dtype dispatch arms, empty-input identity
+  behavior, dtype/layout mismatch rejection before writing, scalar output shape
+  validation, unsupported bool dtype rejection, and compile-time layout
+  validation.

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -13,7 +13,10 @@
 //! Mutable erased descriptors only re-scan value-constrained dtypes, currently
 //! `bool`, after their raw bytes have escaped through `data_mut`.
 
+use core::ops::{Add, Mul};
+
 use num_complex::{Complex32, Complex64};
+use num_traits::{One, Zero};
 
 use crate::{
     fused_elementwise_into, CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
@@ -104,6 +107,27 @@ pub struct ErasedFusedPlan {
     plan: FusedPlan,
 }
 
+/// Runtime reduction operation for dtype-erased full reductions.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReduceOp {
+    Sum,
+    Product,
+}
+
+/// Dtype-erased full-reduction wrapper.
+///
+/// This is the erased replay boundary for full-tensor reductions whose result
+/// is one scalar. It supports only operations with an unambiguous identity value
+/// in the selected dtype.
+#[derive(Clone, Debug)]
+pub struct ErasedReducePlan {
+    dtype: KernelDType,
+    op: ReduceOp,
+    dims: Vec<usize>,
+    src_strides: Vec<isize>,
+}
+
 impl ErasedFusedPlan {
     /// Validate and store a single-output fused elementwise plan for one dtype.
     pub fn compile(dtype: KernelDType, plan: FusedPlan) -> Result<Self> {
@@ -170,6 +194,77 @@ impl ErasedFusedPlan {
     }
 }
 
+impl ErasedReducePlan {
+    /// Validate and store a full-reduction plan for one dtype and source layout.
+    pub fn compile(
+        dtype: KernelDType,
+        op: ReduceOp,
+        dims: &[usize],
+        src_strides: &[isize],
+    ) -> Result<Self> {
+        check_reduce_dtype(dtype)?;
+        if dims.len() != src_strides.len() {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        checked_total_len(dims)?;
+        Ok(Self {
+            dtype,
+            op,
+            dims: dims.to_vec(),
+            src_strides: src_strides.to_vec(),
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn op(&self) -> ReduceOp {
+        self.op
+    }
+
+    /// Execute a full reduction into a scalar erased output descriptor.
+    pub fn execute(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        src: &ErasedRawStridedRef<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, src.dtype())?;
+        if src.dims() != self.dims.as_slice() || src.strides() != self.src_strides.as_slice() {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        let dest_len = checked_total_len(dest.dims())?;
+        if dest_len != 1 {
+            return Err(StridedError::RankMismatch(dest_len, 1));
+        }
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_reduce::<f32>(self.op, ctx, dest, src),
+            KernelDType::F64 => execute_reduce::<f64>(self.op, ctx, dest, src),
+            KernelDType::I32 => execute_reduce::<i32>(self.op, ctx, dest, src),
+            KernelDType::I64 => execute_reduce::<i64>(self.op, ctx, dest, src),
+            KernelDType::C32 => execute_reduce::<Complex32>(self.op, ctx, dest, src),
+            KernelDType::C64 => execute_reduce::<Complex64>(self.op, ctx, dest, src),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: supported reduction dtypes have no extra byte validity
+            // invariant beyond the typed scalar written by the kernel.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
 fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {
     if actual != expected {
         return Err(StridedError::DTypeMismatch {
@@ -187,6 +282,29 @@ fn check_fused_dtype(dtype: KernelDType) -> Result<()> {
             dtype: dtype.label(),
         }),
     }
+}
+
+fn check_reduce_dtype(dtype: KernelDType) -> Result<()> {
+    match dtype {
+        KernelDType::F32
+        | KernelDType::F64
+        | KernelDType::I32
+        | KernelDType::I64
+        | KernelDType::C32
+        | KernelDType::C64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
+fn checked_total_len(dims: &[usize]) -> Result<usize> {
+    if dims.is_empty() {
+        return Ok(1);
+    }
+    dims.iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or(StridedError::OffsetOverflow)
 }
 
 fn execute_copy<T>(
@@ -208,6 +326,62 @@ where
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.execute(&mut dest, &source)
+}
+
+fn execute_reduce<T>(
+    op: ReduceOp,
+    ctx: &ExecContext,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+{
+    let source = erased_view::<T>(src);
+    let value = if ctx.is_ambient() {
+        crate::reduce(
+            &source,
+            |value| value,
+            |a, b| reduce_values(op, a, b),
+            reduce_identity(op),
+        )?
+    } else {
+        crate::reduce_view::reduce_serial(
+            &source,
+            |value| value,
+            |a, b| reduce_values(op, a, b),
+            reduce_identity(op),
+        )?
+    };
+
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    unsafe {
+        *dest_data.as_mut_ptr().offset(dest_offset) = value;
+    }
+    Ok(())
+}
+
+#[inline]
+fn reduce_identity<T>(op: ReduceOp) -> T
+where
+    T: One + Zero,
+{
+    match op {
+        ReduceOp::Sum => T::zero(),
+        ReduceOp::Product => T::one(),
+    }
+}
+
+#[inline]
+fn reduce_values<T>(op: ReduceOp, a: T, b: T) -> T
+where
+    T: Add<Output = T> + Mul<Output = T>,
+{
+    match op {
+        ReduceOp::Sum => a + b,
+        ReduceOp::Product => a * b,
+    }
 }
 
 fn execute_fused<T>(

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -122,7 +122,7 @@ pub use raw_ops::{
 // Prepared (compile-once, execute-many) plans
 // ============================================================================
 pub use copy_plan::CopyPlan;
-pub use erased::{ErasedCopyPlan, ErasedFusedPlan};
+pub use erased::{ErasedCopyPlan, ErasedFusedPlan, ErasedReducePlan, ReduceOp};
 pub use exec_context::ExecContext;
 
 // ============================================================================

--- a/strided-kernel/src/reduce_view.rs
+++ b/strided-kernel/src/reduce_view.rs
@@ -1,9 +1,8 @@
 //! Reduce operations on dynamic-rank strided views.
 
-#[cfg(feature = "parallel")]
-use crate::kernel::same_contiguous_layout;
 use crate::kernel::{
-    build_plan_fused, for_each_inner_block_preordered, sequential_contiguous_layout, total_len,
+    build_plan_fused, for_each_inner_block_preordered, same_contiguous_layout,
+    sequential_contiguous_layout, total_len,
 };
 use crate::maybe_sync::{MaybeSendSync, MaybeSync};
 use crate::simd;
@@ -30,11 +29,45 @@ where
     R: Fn(U, U) -> U + MaybeSync,
     U: Clone + MaybeSendSync,
 {
+    reduce_impl(src, map_fn, reduce_fn, init, true)
+}
+
+pub(crate) fn reduce_serial<T: Copy + MaybeSendSync, Op: ElementOp<T>, M, R, U>(
+    src: &StridedView<T, Op>,
+    map_fn: M,
+    reduce_fn: R,
+    init: U,
+) -> Result<U>
+where
+    M: Fn(T) -> U + MaybeSync,
+    R: Fn(U, U) -> U + MaybeSync,
+    U: Clone + MaybeSendSync,
+{
+    reduce_impl(src, map_fn, reduce_fn, init, false)
+}
+
+fn reduce_impl<T: Copy + MaybeSendSync, Op: ElementOp<T>, M, R, U>(
+    src: &StridedView<T, Op>,
+    map_fn: M,
+    reduce_fn: R,
+    init: U,
+    allow_ambient_parallel: bool,
+) -> Result<U>
+where
+    M: Fn(T) -> U + MaybeSync,
+    R: Fn(U, U) -> U + MaybeSync,
+    U: Clone + MaybeSendSync,
+{
     let src_ptr = src.ptr();
     let src_dims = src.dims();
     let src_strides = src.strides();
 
-    if sequential_contiguous_layout(src_dims, &[src_strides]).is_some() {
+    let contiguous = if allow_ambient_parallel {
+        sequential_contiguous_layout(src_dims, &[src_strides])
+    } else {
+        same_contiguous_layout(src_dims, &[src_strides])
+    };
+    if contiguous.is_some() {
         let len = total_len(src_dims);
         let src = unsafe { std::slice::from_raw_parts(src_ptr, len) };
         return Ok(simd::dispatch_if_large(len, || {
@@ -52,7 +85,8 @@ where
     #[cfg(feature = "parallel")]
     {
         let total = total_len(src_dims);
-        if total > MINTHREADLENGTH
+        if allow_ambient_parallel
+            && total > MINTHREADLENGTH
             && rayon::current_num_threads() > 1
             && same_contiguous_layout(src_dims, &[src_strides]).is_some()
         {
@@ -84,7 +118,7 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        if allow_ambient_parallel && total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
             let nthreads = rayon::current_num_threads();
             // False sharing avoidance: space output slots by cache line size
             let spacing = (64 / std::mem::size_of::<U>()).max(1);

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -1,0 +1,267 @@
+use num_complex::{Complex32, Complex64};
+use strided_kernel::{
+    ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ExecContext, KernelDType, ReduceOp,
+    StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+#[test]
+fn erased_reduce_plan_executes_f64_sum_transposed_layout() {
+    let dims = [2usize, 3];
+    let src_strides = [1isize, 2];
+    let input = [0.0f64, 10.0, 1.0, 11.0, 2.0, 12.0];
+    let mut output = [0.0f64];
+
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &src_strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &src_strides, 0)
+            .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [36.0]);
+}
+
+#[test]
+fn erased_reduce_plan_executes_c64_product() {
+    let dims = [3usize];
+    let strides = [1isize];
+    let input = [
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, -1.0),
+        Complex64::new(0.5, 1.0),
+    ];
+    let mut output = [Complex64::new(0.0, 0.0)];
+
+    let plan =
+        ErasedReducePlan::compile(KernelDType::C64, ReduceOp::Product, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::max_threads(1).unwrap(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [input[0] * input[1] * input[2]]);
+}
+
+#[test]
+fn erased_reduce_plan_executes_i32_sum_with_ambient_context() {
+    let dims = [4usize];
+    let strides = [1isize];
+    let input = [1i32, -2, 3, 4];
+    let mut output = [0i32];
+
+    let plan = ErasedReducePlan::compile(KernelDType::I32, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::ambient(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [6]);
+}
+
+#[test]
+fn erased_reduce_plan_executes_remaining_supported_dtype_set() {
+    let dims = [2usize];
+    let strides = [1isize];
+
+    let input_f32 = [1.5f32, 2.5];
+    let mut output_f32 = [0.0f32];
+    let plan = ErasedReducePlan::compile(KernelDType::F32, ReduceOp::Sum, &dims, &strides).unwrap();
+    assert_eq!(plan.dtype(), KernelDType::F32);
+    assert_eq!(plan.op(), ReduceOp::Sum);
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&input_f32), &dims, &strides, 0)
+            .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F32,
+        as_bytes_mut(&mut output_f32),
+        &[1],
+        &[1],
+        0,
+    )
+    .unwrap();
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    assert_eq!(output_f32, [4.0]);
+
+    let input_i64 = [2i64, -3];
+    let mut output_i64 = [0i64];
+    let plan =
+        ErasedReducePlan::compile(KernelDType::I64, ReduceOp::Product, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&input_i64), &dims, &strides, 0)
+            .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::I64, as_bytes_mut(&mut output_i64), &[], &[], 0)
+            .unwrap();
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    assert_eq!(output_i64, [-6]);
+
+    let input_c32 = [Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)];
+    let mut output_c32 = [Complex32::new(0.0, 0.0)];
+    let plan =
+        ErasedReducePlan::compile(KernelDType::C32, ReduceOp::Product, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::C32, as_bytes(&input_c32), &dims, &strides, 0)
+            .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::C32, as_bytes_mut(&mut output_c32), &[], &[], 0)
+            .unwrap();
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    assert_eq!(output_c32, [input_c32[0] * input_c32[1]]);
+}
+
+#[test]
+fn erased_reduce_plan_empty_input_returns_operation_identity() {
+    let dims = [0usize, 3];
+    let strides = [1isize, 0];
+    let input: [f64; 0] = [];
+    let mut sum_output = [9.0f64];
+    let mut product_output = [9.0f64];
+
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut sum_dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut sum_output), &[], &[], 0)
+            .unwrap();
+    let mut product_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut product_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides)
+        .unwrap()
+        .execute(&ExecContext::serial(), &mut sum_dest, &source)
+        .unwrap();
+    ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &dims, &strides)
+        .unwrap()
+        .execute(&ExecContext::serial(), &mut product_dest, &source)
+        .unwrap();
+
+    assert_eq!(sum_output, [0.0]);
+    assert_eq!(product_output, [1.0]);
+}
+
+#[test]
+fn erased_reduce_plan_rejects_dtype_mismatch_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let input = [1.0f64, 2.0];
+    let mut output = [9.0f32];
+
+    let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+    assert_eq!(output, [9.0]);
+}
+
+#[test]
+fn erased_reduce_plan_rejects_layout_mismatch_before_writing() {
+    let compiled_dims = [2usize, 2];
+    let compiled_strides = [1isize, 2];
+    let runtime_strides = [2isize, 1];
+    let input = [1.0f64, 2.0, 3.0, 4.0];
+    let mut output = [9.0f64];
+
+    let plan = ErasedReducePlan::compile(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &compiled_dims,
+        &compiled_strides,
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &compiled_dims,
+        &runtime_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::PlanLayoutMismatch));
+    assert_eq!(output, [9.0]);
+}
+
+#[test]
+fn erased_reduce_plan_rejects_non_scalar_output_and_unsupported_dtype() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let input = [1.0f64, 2.0];
+    let mut output = [9.0f64, 10.0];
+
+    let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[2], &[1], 0)
+            .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap_err();
+    assert!(matches!(err, StridedError::RankMismatch(2, 1)));
+    assert_eq!(output, [9.0, 10.0]);
+
+    let unsupported =
+        ErasedReducePlan::compile(KernelDType::Bool, ReduceOp::Sum, &dims, &strides).unwrap_err();
+    assert!(matches!(
+        unsupported,
+        StridedError::UnsupportedDType { dtype: "bool" }
+    ));
+}
+
+#[test]
+fn erased_reduce_plan_rejects_invalid_compile_layout() {
+    let err =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &[2, 3], &[1]).unwrap_err();
+
+    assert!(matches!(err, StridedError::StrideLengthMismatch));
+}


### PR DESCRIPTION
## Summary

- add `ReduceOp` and `ErasedReducePlan` for dtype-erased full reductions into scalar output descriptors
- dispatch `Sum`/`Product` for `f32`, `f64`, `i32`, `i64`, `c32`, and `c64` inside `strided-kernel`
- keep non-ambient `ExecContext` execution serial so erased replay does not read ambient Rayon state
- validate dtype equality, source layout identity, scalar output shape, and unsupported dtype cases before writing

## Scope

This PR covers full-tensor reductions only. C ABI symbols, axis/multi-axis reductions, `Maximum`/`Minimum`, bool reductions, dtype promotion, and tenferro adoption are intentionally out of scope.

Refs tensor4all/strided-rs#149.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p strided-kernel --test erased_reduce_plan`
- `cargo test -p strided-kernel --all-features`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --workspace --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json`
