### PR TITLE
Add erased gather replay API

### DIFF
--- a/docs/superpowers/plans/2026-07-27-erased-gather-plan-api.md
+++ b/docs/superpowers/plans/2026-07-27-erased-gather-plan-api.md
@@ -1,0 +1,36 @@
+# Erased Gather Plan API
+
+## Scope
+
+Add the Rust-side indexed-read family boundary to `strided-kernel`:
+
+- `GatherSpec` models the gather vocabulary shared with tenferro/XLA-style indexing:
+  `offset_dims`, `collapsed_slice_dims`, `start_index_map`, `index_vector_dim`,
+  and `slice_sizes`.
+- `GatherPlan` owns the generic prepared traversal over raw strided value and
+  index descriptors.
+- `ErasedGatherPlan` owns the dtype-concrete replay boundary so downstream
+  crates can call pre-instantiated value/index dtype combinations.
+- Value dtypes: `f32`, `f64`, `i32`, `i64`, `bool`, `c32`, `c64`.
+- Index dtypes: `i32`, `i64`.
+
+## Contracts
+
+- Plan compilation validates shape vocabulary, stride/rank agreement, output
+  shape, output injectivity, and total-size overflow.
+- Runtime replay checks descriptor dtype and layout identity before writing.
+- Negative and oversized gather starts clamp to the valid window-start range,
+  matching tenferro's existing CPU gather behavior.
+- `ExecContext` is part of the erased replay signature. The first gather
+  implementation is serial; the parameter prevents accidental ambient-thread
+  ownership from being frozen into the boundary.
+- Rank <= 8 replay scratch is stack-backed; higher ranks may allocate scratch.
+
+## Out Of Scope
+
+- C ABI symbols and ABI layout stabilization.
+- tenferro adoption or pin bump.
+- scatter/update semantics, because duplicate indices and write conflicts need
+  a separate determinism/overlap contract.
+- `dynamic_slice`, because it is a fixed-window copy without index-buffer
+  descriptor vocabulary. It should be handled as a later read-family sibling.

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -20,8 +20,8 @@ use num_traits::{One, Zero};
 
 use crate::{
     fused_elementwise_into, CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
-    FusedPlan, FusedScalar, KernelDType, RawStridedMut, RawStridedRef, Result, StridedError,
-    StridedView, StridedViewMut,
+    FusedPlan, FusedScalar, GatherIndex, GatherPlan, GatherSpec, KernelDType, RawStridedMut,
+    RawStridedRef, Result, StridedError, StridedView, StridedViewMut,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -126,6 +126,17 @@ pub struct ErasedReducePlan {
     op: ReduceOp,
     dims: Vec<usize>,
     src_strides: Vec<isize>,
+}
+
+/// Dtype-erased gather wrapper.
+///
+/// This is the erased replay boundary for indexed reads. Value buffers use the
+/// configured value dtype, while the index descriptor must use `i32` or `i64`.
+#[derive(Clone, Debug)]
+pub struct ErasedGatherPlan {
+    dtype: KernelDType,
+    index_dtype: KernelDType,
+    plan: GatherPlan,
 }
 
 impl ErasedFusedPlan {
@@ -265,6 +276,130 @@ impl ErasedReducePlan {
     }
 }
 
+impl ErasedGatherPlan {
+    /// Validate and store a gather plan for one value dtype, index dtype, and layout set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile(
+        dtype: KernelDType,
+        index_dtype: KernelDType,
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        index_dims: &[usize],
+        index_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        spec: GatherSpec,
+    ) -> Result<Self> {
+        check_index_dtype(index_dtype)?;
+        check_gather_value_dtype(dtype)?;
+        Ok(Self {
+            dtype,
+            index_dtype,
+            plan: GatherPlan::compile(
+                operand_dims,
+                operand_strides,
+                index_dims,
+                index_strides,
+                dest_dims,
+                dest_strides,
+                spec,
+            )?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn index_dtype(&self) -> KernelDType {
+        self.index_dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &GatherPlan {
+        &self.plan
+    }
+
+    /// Execute an indexed read into an erased output descriptor.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        operand: &ErasedRawStridedRef<'_>,
+        start_indices: &ErasedRawStridedRef<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        check_dtype(self.index_dtype, start_indices.dtype())?;
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => dispatch_gather_index::<f32>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::F64 => dispatch_gather_index::<f64>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::I32 => dispatch_gather_index::<i32>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::I64 => dispatch_gather_index::<i64>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::Bool => dispatch_gather_index::<bool>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::C32 => dispatch_gather_index::<Complex32>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            KernelDType::C64 => dispatch_gather_index::<Complex64>(
+                &self.plan,
+                self.index_dtype,
+                dest,
+                operand,
+                start_indices,
+            ),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: gather writes values read from a descriptor with the
+            // same dtype and already-validated byte representation.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
 fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {
     if actual != expected {
         return Err(StridedError::DTypeMismatch {
@@ -290,6 +425,30 @@ fn check_reduce_dtype(dtype: KernelDType) -> Result<()> {
         | KernelDType::F64
         | KernelDType::I32
         | KernelDType::I64
+        | KernelDType::C32
+        | KernelDType::C64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
+fn check_index_dtype(dtype: KernelDType) -> Result<()> {
+    match dtype {
+        KernelDType::I32 | KernelDType::I64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
+fn check_gather_value_dtype(dtype: KernelDType) -> Result<()> {
+    match dtype {
+        KernelDType::F32
+        | KernelDType::F64
+        | KernelDType::I32
+        | KernelDType::I64
+        | KernelDType::Bool
         | KernelDType::C32
         | KernelDType::C64 => Ok(()),
         _ => Err(StridedError::UnsupportedDType {
@@ -435,6 +594,62 @@ where
             max: ERASED_FUSED_INPUT_LIMIT,
         }),
     }
+}
+
+fn dispatch_gather_index<T>(
+    plan: &GatherPlan,
+    index_dtype: KernelDType,
+    dest: &mut ErasedRawStridedMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+    start_indices: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    match index_dtype {
+        KernelDType::I32 => execute_gather::<T, i32>(plan, dest, operand, start_indices),
+        KernelDType::I64 => execute_gather::<T, i64>(plan, dest, operand, start_indices),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: index_dtype.label(),
+        }),
+    }
+}
+
+fn execute_gather<T, I>(
+    plan: &GatherPlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+    start_indices: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+    I: GatherIndex,
+{
+    let operand_data = typed_slice::<T>(operand.data());
+    let index_data = typed_slice::<I>(start_indices.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let index_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            index_data,
+            start_indices.dims(),
+            start_indices.strides(),
+            start_indices.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute(&mut dest_ref, &operand_ref, &index_ref)
 }
 
 fn execute_fused_views<T>(

--- a/strided-kernel/src/gather_plan.rs
+++ b/strided-kernel/src/gather_plan.rs
@@ -1,0 +1,425 @@
+//! Prepared gather plans over raw strided value and index layouts.
+//!
+//! This module owns the generic indexed-read traversal used by the erased
+//! replay layer. It models the XLA/tenferro gather shape vocabulary, but keeps
+//! tensor allocation, dtype promotion, and frontend error policy outside
+//! `strided-kernel`.
+
+use crate::{
+    MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError, RAW_FUSED_RANK_LIMIT,
+};
+
+#[cfg(feature = "parallel")]
+type AxisVec<T> = smallvec::SmallVec<[T; RAW_FUSED_RANK_LIMIT]>;
+#[cfg(not(feature = "parallel"))]
+type AxisVec<T> = Vec<T>;
+
+/// Gather configuration shared by generic and erased replay.
+///
+/// The fields follow the usual gather vocabulary:
+///
+/// - `start_index_map[component]` names the operand axis controlled by a
+///   component in the index vector;
+/// - `collapsed_slice_dims` names operand axes whose slice size is one and
+///   which do not appear as output window axes;
+/// - `offset_dims` names output axes that represent window offsets;
+/// - output axes not in `offset_dims` are batch axes from `start_indices`;
+/// - `index_vector_dim == start_indices_rank` represents scalar index vectors.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GatherSpec {
+    pub offset_dims: Vec<usize>,
+    pub collapsed_slice_dims: Vec<usize>,
+    pub start_index_map: Vec<usize>,
+    pub index_vector_dim: usize,
+    pub slice_sizes: Vec<usize>,
+}
+
+/// Index scalar types accepted by [`GatherPlan`].
+pub trait GatherIndex: Copy + MaybeSendSync {
+    fn to_i64(self) -> i64;
+}
+
+impl GatherIndex for i32 {
+    #[inline]
+    fn to_i64(self) -> i64 {
+        i64::from(self)
+    }
+}
+
+impl GatherIndex for i64 {
+    #[inline]
+    fn to_i64(self) -> i64 {
+        self
+    }
+}
+
+/// A compiled gather traversal for one value layout, index layout, and output layout.
+#[derive(Clone, Debug)]
+pub struct GatherPlan {
+    operand_dims: AxisVec<usize>,
+    operand_strides: AxisVec<isize>,
+    index_dims: AxisVec<usize>,
+    index_strides: AxisVec<isize>,
+    dest_dims: AxisVec<usize>,
+    dest_strides: AxisVec<isize>,
+    spec: GatherSpec,
+    batch_shape: AxisVec<usize>,
+    out_axis_to_operand_dim: AxisVec<Option<usize>>,
+}
+
+impl GatherPlan {
+    /// Compile a gather plan for fixed operand, index, and destination layouts.
+    pub fn compile(
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        index_dims: &[usize],
+        index_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        spec: GatherSpec,
+    ) -> Result<Self> {
+        if operand_dims.len() != operand_strides.len()
+            || index_dims.len() != index_strides.len()
+            || dest_dims.len() != dest_strides.len()
+        {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        checked_total_len(operand_dims)?;
+        checked_total_len(index_dims)?;
+        checked_total_len(dest_dims)?;
+        if !crate::fused::is_injective_layout(dest_dims, dest_strides) {
+            return Err(StridedError::NonInjectiveOutputLayout);
+        }
+
+        let operand_rank = operand_dims.len();
+        if spec.slice_sizes.len() != operand_rank {
+            return Err(StridedError::RankMismatch(
+                spec.slice_sizes.len(),
+                operand_rank,
+            ));
+        }
+        validate_unique_axes(&spec.collapsed_slice_dims, operand_rank)?;
+        validate_unique_axes(&spec.start_index_map, operand_rank)?;
+        if spec.index_vector_dim > index_dims.len() {
+            return Err(StridedError::InvalidAxis {
+                axis: spec.index_vector_dim,
+                rank: index_dims.len() + 1,
+            });
+        }
+
+        for (axis, (&window, &dim)) in spec.slice_sizes.iter().zip(operand_dims.iter()).enumerate()
+        {
+            if window > dim {
+                return Err(StridedError::InvalidAxis {
+                    axis,
+                    rank: operand_rank,
+                });
+            }
+        }
+        for &axis in &spec.collapsed_slice_dims {
+            if spec.slice_sizes[axis] != 1 {
+                return Err(StridedError::InvalidAxis {
+                    axis,
+                    rank: operand_rank,
+                });
+            }
+        }
+
+        let index_vector_size = if spec.index_vector_dim == index_dims.len() {
+            1
+        } else {
+            index_dims[spec.index_vector_dim]
+        };
+        if index_vector_size != spec.start_index_map.len() {
+            return Err(StridedError::RankMismatch(
+                index_vector_size,
+                spec.start_index_map.len(),
+            ));
+        }
+
+        let window_dims = operand_window_dims(operand_rank, &spec.collapsed_slice_dims);
+        if spec.offset_dims.len() != window_dims.len() {
+            return Err(StridedError::RankMismatch(
+                spec.offset_dims.len(),
+                window_dims.len(),
+            ));
+        }
+
+        let batch_shape = index_batch_shape(index_dims, spec.index_vector_dim);
+        let out_rank = batch_shape.len() + spec.offset_dims.len();
+        validate_unique_axes(&spec.offset_dims, out_rank)?;
+
+        let mut out_axis_to_operand_dim: AxisVec<Option<usize>> =
+            (0..out_rank).map(|_| None).collect();
+        for (offset_axis, &out_axis) in spec.offset_dims.iter().enumerate() {
+            out_axis_to_operand_dim[out_axis] = Some(window_dims[offset_axis]);
+        }
+
+        let mut expected_dest_dims: AxisVec<usize> = AxisVec::with_capacity(out_rank);
+        let mut batch_axis = 0usize;
+        for &operand_dim in &out_axis_to_operand_dim {
+            match operand_dim {
+                Some(axis) => expected_dest_dims.push(spec.slice_sizes[axis]),
+                None => {
+                    expected_dest_dims.push(batch_shape[batch_axis]);
+                    batch_axis += 1;
+                }
+            }
+        }
+        if dest_dims != &expected_dest_dims[..] {
+            return Err(StridedError::ShapeMismatch(
+                dest_dims.to_vec(),
+                expected_dest_dims.to_vec(),
+            ));
+        }
+
+        Ok(Self {
+            operand_dims: operand_dims.into(),
+            operand_strides: operand_strides.into(),
+            index_dims: index_dims.into(),
+            index_strides: index_strides.into(),
+            dest_dims: dest_dims.into(),
+            dest_strides: dest_strides.into(),
+            spec,
+            batch_shape,
+            out_axis_to_operand_dim,
+        })
+    }
+
+    #[inline]
+    pub fn spec(&self) -> &GatherSpec {
+        &self.spec
+    }
+
+    #[inline]
+    pub fn dest_dims(&self) -> &[usize] {
+        &self.dest_dims
+    }
+
+    /// Execute the prepared gather traversal.
+    pub fn execute<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        start_indices: &RawStridedRef<'_, I>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+        I: GatherIndex,
+    {
+        self.check_call(dest, operand, start_indices)?;
+        let total = checked_total_len(&self.dest_dims)?;
+        if total == 0 {
+            return Ok(());
+        }
+
+        let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+        let mut batch_idx_storage = CoordScratch::new(self.batch_shape.len());
+        let mut operand_idx_storage = CoordScratch::new(self.operand_dims.len());
+        let mut window_offsets_storage = CoordScratch::new(self.operand_dims.len());
+        let out_idx = out_idx_storage.as_mut_slice();
+        let batch_idx = batch_idx_storage.as_mut_slice();
+        let operand_idx = operand_idx_storage.as_mut_slice();
+        let window_offsets = window_offsets_storage.as_mut_slice();
+
+        let dest_offset_base = dest.offset();
+        let dest_strides = dest.strides();
+        let operand_offset_base = operand.offset();
+        let operand_strides = operand.strides();
+        let index_offset_base = start_indices.offset();
+        let index_strides = start_indices.strides();
+        let operand_data = operand.data();
+        let index_data = start_indices.data();
+        let dest_data = dest.data_mut();
+
+        for _ in 0..total {
+            window_offsets.fill(0);
+            let mut batch_axis = 0usize;
+            for (out_axis, &operand_dim) in self.out_axis_to_operand_dim.iter().enumerate() {
+                match operand_dim {
+                    Some(axis) => window_offsets[axis] = out_idx[out_axis],
+                    None => {
+                        batch_idx[batch_axis] = out_idx[out_axis];
+                        batch_axis += 1;
+                    }
+                }
+            }
+
+            operand_idx.fill(0);
+            for (component, &operand_dim) in self.spec.start_index_map.iter().enumerate() {
+                let start = self.index_component(
+                    start_indices.dims(),
+                    index_strides,
+                    index_offset_base,
+                    index_data,
+                    &batch_idx,
+                    component,
+                )?;
+                operand_idx[operand_dim] = self.clamp_window_start(start, operand_dim);
+            }
+            for axis in 0..operand_idx.len() {
+                operand_idx[axis] += window_offsets[axis];
+            }
+
+            let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, &out_idx)?;
+            let operand_offset =
+                checked_strided_offset(operand_offset_base, operand_strides, &operand_idx)?;
+            unsafe {
+                *dest_data.as_mut_ptr().offset(dest_offset) =
+                    *operand_data.as_ptr().offset(operand_offset);
+            }
+            advance_col_major_index(out_idx, &self.dest_dims);
+        }
+        Ok(())
+    }
+
+    fn check_call<T, I>(
+        &self,
+        dest: &RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        start_indices: &RawStridedRef<'_, I>,
+    ) -> Result<()> {
+        if dest.dims() != &self.dest_dims[..]
+            || dest.strides() != &self.dest_strides[..]
+            || operand.dims() != &self.operand_dims[..]
+            || operand.strides() != &self.operand_strides[..]
+            || start_indices.dims() != &self.index_dims[..]
+            || start_indices.strides() != &self.index_strides[..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+
+    fn index_component<I>(
+        &self,
+        index_dims: &[usize],
+        index_strides: &[isize],
+        index_offset_base: isize,
+        index_data: &[I],
+        batch_idx: &[usize],
+        component: usize,
+    ) -> Result<i64>
+    where
+        I: GatherIndex,
+    {
+        let mut offset = index_offset_base;
+        let mut batch_axis = 0usize;
+        for axis in 0..index_dims.len() {
+            let coord = if axis == self.spec.index_vector_dim {
+                component
+            } else {
+                let coord = batch_idx[batch_axis];
+                batch_axis += 1;
+                coord
+            };
+            offset = checked_offset_add(offset, index_strides[axis], coord)?;
+        }
+        Ok(unsafe { *index_data.as_ptr().offset(offset) }.to_i64())
+    }
+
+    #[inline]
+    fn clamp_window_start(&self, start: i64, operand_dim: usize) -> usize {
+        let dim_size = self.operand_dims[operand_dim];
+        let window_size = self.spec.slice_sizes[operand_dim];
+        let max_start = dim_size.saturating_sub(window_size) as i64;
+        start.clamp(0, max_start) as usize
+    }
+}
+
+fn validate_unique_axes(axes: &[usize], rank: usize) -> Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(StridedError::InvalidAxis { axis, rank });
+        }
+        if seen[axis] {
+            return Err(StridedError::InvalidAxis { axis, rank });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn operand_window_dims(rank: usize, collapsed_slice_dims: &[usize]) -> AxisVec<usize> {
+    (0..rank)
+        .filter(|axis| !collapsed_slice_dims.contains(axis))
+        .collect()
+}
+
+fn index_batch_shape(index_dims: &[usize], index_vector_dim: usize) -> AxisVec<usize> {
+    if index_vector_dim == index_dims.len() {
+        return index_dims.into();
+    }
+    index_dims
+        .iter()
+        .enumerate()
+        .filter_map(|(axis, &dim)| (axis != index_vector_dim).then_some(dim))
+        .collect()
+}
+
+fn checked_total_len(dims: &[usize]) -> Result<usize> {
+    if dims.is_empty() {
+        return Ok(1);
+    }
+    dims.iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or(StridedError::OffsetOverflow)
+}
+
+fn checked_strided_offset(base: isize, strides: &[isize], index: &[usize]) -> Result<isize> {
+    let mut offset = base;
+    for (&stride, &coord) in strides.iter().zip(index.iter()) {
+        offset = checked_offset_add(offset, stride, coord)?;
+    }
+    Ok(offset)
+}
+
+fn checked_offset_add(base: isize, stride: isize, coord: usize) -> Result<isize> {
+    let coord = isize::try_from(coord).map_err(|_| StridedError::OffsetOverflow)?;
+    let scaled = stride
+        .checked_mul(coord)
+        .ok_or(StridedError::OffsetOverflow)?;
+    base.checked_add(scaled).ok_or(StridedError::OffsetOverflow)
+}
+
+fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
+    for axis in 0..index.len() {
+        index[axis] += 1;
+        if index[axis] < shape[axis] {
+            return;
+        }
+        index[axis] = 0;
+    }
+}
+
+struct CoordScratch {
+    inline: [usize; RAW_FUSED_RANK_LIMIT],
+    heap: Option<Vec<usize>>,
+    len: usize,
+}
+
+impl CoordScratch {
+    fn new(len: usize) -> Self {
+        if len <= RAW_FUSED_RANK_LIMIT {
+            Self {
+                inline: [0; RAW_FUSED_RANK_LIMIT],
+                heap: None,
+                len,
+            }
+        } else {
+            Self {
+                inline: [0; RAW_FUSED_RANK_LIMIT],
+                heap: Some(vec![0; len]),
+                len,
+            }
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [usize] {
+        match &mut self.heap {
+            Some(heap) => heap,
+            None => &mut self.inline[..self.len],
+        }
+    }
+}

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -57,6 +57,7 @@
 mod block;
 mod fuse;
 mod fused;
+mod gather_plan;
 mod kernel;
 mod order;
 mod simd;
@@ -122,8 +123,9 @@ pub use raw_ops::{
 // Prepared (compile-once, execute-many) plans
 // ============================================================================
 pub use copy_plan::CopyPlan;
-pub use erased::{ErasedCopyPlan, ErasedFusedPlan, ErasedReducePlan, ReduceOp};
+pub use erased::{ErasedCopyPlan, ErasedFusedPlan, ErasedGatherPlan, ErasedReducePlan, ReduceOp};
 pub use exec_context::ExecContext;
+pub use gather_plan::{GatherIndex, GatherPlan, GatherSpec};
 
 // ============================================================================
 // Reduce operations

--- a/strided-kernel/tests/erased_gather_plan.rs
+++ b/strided-kernel/tests/erased_gather_plan.rs
@@ -1,0 +1,421 @@
+use num_complex::{Complex32, Complex64};
+use strided_kernel::{
+    ErasedGatherPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, GatherSpec,
+    KernelDType, StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+#[test]
+fn erased_gather_plan_executes_f64_column_gather_with_i64_indices() {
+    let operand_dims = [3usize, 4];
+    let operand_strides = [1isize, 3];
+    let index_dims = [2usize, 1];
+    let index_strides = [1isize, 2];
+    let dest_dims = [2usize, 3];
+    let dest_strides = [1isize, 2];
+    let operand = [
+        0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0, 20.0, 21.0, 22.0, 30.0, 31.0, 32.0,
+    ];
+    let indices = [2i64, 0];
+    let mut dest = [0.0f64; 6];
+    let spec = GatherSpec {
+        offset_dims: vec![1],
+        collapsed_slice_dims: vec![1],
+        start_index_map: vec![1],
+        index_vector_dim: 1,
+        slice_sizes: vec![3, 1],
+    };
+
+    let plan = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        spec,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&operand),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let index_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&indices),
+        &index_dims,
+        &index_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(
+        &ExecContext::serial(),
+        &mut dest_ref,
+        &operand_ref,
+        &index_ref,
+    )
+    .unwrap();
+
+    assert_eq!(dest, [20.0, 0.0, 21.0, 1.0, 22.0, 2.0]);
+}
+
+#[test]
+fn erased_gather_plan_executes_f32_windows_with_i32_indices_and_clamping() {
+    let operand_dims = [4usize];
+    let operand_strides = [1isize];
+    let index_dims = [3usize];
+    let index_strides = [1isize];
+    let dest_dims = [3usize, 2];
+    let dest_strides = [1isize, 3];
+    let operand = [10.0f32, 11.0, 12.0, 13.0];
+    let indices = [-1i32, 2, 99];
+    let mut dest = [0.0f32; 6];
+    let spec = GatherSpec {
+        offset_dims: vec![1],
+        collapsed_slice_dims: vec![],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![2],
+    };
+
+    let plan = ErasedGatherPlan::compile(
+        KernelDType::F32,
+        KernelDType::I32,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        spec,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::F32,
+        as_bytes(&operand),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let index_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&indices),
+        &index_dims,
+        &index_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F32,
+        as_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(
+        &ExecContext::max_threads(1).unwrap(),
+        &mut dest_ref,
+        &operand_ref,
+        &index_ref,
+    )
+    .unwrap();
+
+    assert_eq!(dest, [10.0, 12.0, 12.0, 11.0, 13.0, 13.0]);
+}
+
+fn assert_supported_take<T>(dtype: KernelDType, input: &[T])
+where
+    T: Copy + core::fmt::Debug + Default + PartialEq,
+{
+    let operand_dims = [input.len()];
+    let operand_strides = [1isize];
+    let index_dims = [2usize];
+    let index_strides = [1isize];
+    let dest_dims = [2usize];
+    let dest_strides = [1isize];
+    let indices = [1i64, 0];
+    let mut output = vec![T::default(); 2];
+    let spec = GatherSpec {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    };
+
+    let plan = ErasedGatherPlan::compile(
+        dtype,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        spec,
+    )
+    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::new(dtype, as_bytes(input), &operand_dims, &operand_strides, 0)
+            .unwrap();
+    let index_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&indices),
+        &index_dims,
+        &index_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        dtype,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(
+        &ExecContext::ambient(),
+        &mut dest_ref,
+        &operand_ref,
+        &index_ref,
+    )
+    .unwrap();
+
+    assert_eq!(output, vec![input[1], input[0]]);
+}
+
+#[test]
+fn erased_gather_plan_executes_supported_value_dtype_set() {
+    assert_supported_take(KernelDType::F64, &[1.0f64, 2.0]);
+    assert_supported_take(KernelDType::I32, &[1i32, 2]);
+    assert_supported_take(KernelDType::I64, &[1i64, 2]);
+    assert_supported_take(KernelDType::Bool, &[false, true]);
+    assert_supported_take(
+        KernelDType::C32,
+        &[Complex32::new(1.0, -1.0), Complex32::new(2.0, 3.0)],
+    );
+    assert_supported_take(
+        KernelDType::C64,
+        &[Complex64::new(1.0, -1.0), Complex64::new(2.0, 3.0)],
+    );
+}
+
+#[test]
+fn erased_gather_plan_rejects_dtype_and_layout_mismatch_before_writing() {
+    let operand_dims = [2usize];
+    let strides = [1isize];
+    let index_dims = [1usize];
+    let dest_dims = [1usize];
+    let operand = [1.0f64, 2.0];
+    let indices = [0i64];
+    let mut output = [9.0f32];
+    let spec = GatherSpec {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    };
+
+    let plan = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &operand_dims,
+        &strides,
+        &index_dims,
+        &strides,
+        &dest_dims,
+        &strides,
+        spec,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&operand),
+        &operand_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    let index_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&indices),
+        &index_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F32,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let err = plan
+        .execute(
+            &ExecContext::serial(),
+            &mut dest_ref,
+            &operand_ref,
+            &index_ref,
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+    assert_eq!(output, [9.0]);
+
+    let bad_index_ref =
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&indices), &[1], &[0], 0).unwrap();
+    let mut output = [9.0f64];
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    let err = plan
+        .execute(
+            &ExecContext::serial(),
+            &mut dest_ref,
+            &operand_ref,
+            &bad_index_ref,
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::PlanLayoutMismatch));
+    assert_eq!(output, [9.0]);
+}
+
+#[test]
+fn erased_gather_plan_rejects_invalid_compile_specs() {
+    let operand_dims = [2usize, 3];
+    let operand_strides = [1isize, 2];
+    let index_dims = [2usize];
+    let index_strides = [1isize];
+    let dest_dims = [2usize];
+    let dest_strides = [1isize];
+
+    let unsupported_index_dtype = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::F64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        GatherSpec {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0, 1],
+            start_index_map: vec![0],
+            index_vector_dim: 1,
+            slice_sizes: vec![1, 1],
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        unsupported_index_dtype,
+        StridedError::UnsupportedDType { dtype: "f64" }
+    ));
+
+    let bad_dest_shape = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &[3],
+        &[1],
+        GatherSpec {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0, 1],
+            start_index_map: vec![0],
+            index_vector_dim: 1,
+            slice_sizes: vec![1, 1],
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(bad_dest_shape, StridedError::ShapeMismatch(_, _)));
+
+    let duplicate_axis = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        GatherSpec {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0, 0],
+            start_index_map: vec![0],
+            index_vector_dim: 1,
+            slice_sizes: vec![1, 1],
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(duplicate_axis, StridedError::InvalidAxis { .. }));
+
+    let oversized_window = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &index_dims,
+        &index_strides,
+        &dest_dims,
+        &dest_strides,
+        GatherSpec {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0, 1],
+            start_index_map: vec![0],
+            index_vector_dim: 1,
+            slice_sizes: vec![1, 4],
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(oversized_window, StridedError::InvalidAxis { .. }));
+}


### PR DESCRIPTION
## Summary
- Add `GatherSpec`/`GatherPlan` for prepared indexed-read traversal over raw strided value and index descriptors.
- Add `ErasedGatherPlan` with value dtype dispatch and `i32`/`i64` index dtype dispatch.
- Document the scope split: C ABI, tenferro adoption, scatter/update, and dynamic_slice stay out of this PR.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p strided-kernel --test erased_gather_plan`
- `cargo test -p strided-kernel --all-features`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --workspace --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json`

## Notes
- Gather replay is serial for now but keeps `ExecContext` in the erased execute signature so thread ownership remains explicit at the boundary.
- Rank <= 8 gather replay scratch is stack-backed; higher ranks may allocate scratch.