### PR TITLE
Restore explicit strided execution policy

### DIFF
--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -76,6 +76,35 @@ The library automatically optimizes iteration order for cache efficiency:
 strided-kernel = { path = "../strided-kernel", features = ["parallel"] }
 ```
 
+The default `ExecutionPolicy::AmbientRayon` behavior uses the current installed
+Rayon pool (or the global pool). Explicit runtimes can bound strided-owned
+fanout without creating another pool:
+
+```rust
+use std::num::NonZeroUsize;
+use strided_kernel::{
+    map_into, with_execution_policy, ExecutionPolicy, StridedArray,
+};
+
+let source = StridedArray::<f64>::from_fn_col_major(&[4], |index| index[0] as f64);
+let mut destination = StridedArray::<f64>::col_major(&[4]);
+let max_threads = NonZeroUsize::new(2).unwrap();
+
+with_execution_policy(ExecutionPolicy::Rayon { max_threads }, || {
+    map_into(&mut destination.view_mut(), &source.view(), |value| value + 1.0).unwrap();
+});
+assert_eq!(destination.into_data(), vec![1.0, 2.0, 3.0, 4.0]);
+```
+
+`ExecutionPolicy` controls fanout, not CPU placement or pool construction.
+Nested strided operations inside a bounded worker partition run sequentially.
+The opaque parallel permutation-copy path is used under an explicit Rayon
+policy only when the installed pool size fits the requested budget; otherwise
+that copy falls back to its serial implementation because the external copy
+cannot be capped per call.
+The policy is worker-local; callbacks that depend on isolation from unrelated
+work must not invoke their own Rayon scheduling or yielding APIs.
+
 ## Benchmarks
 
 Run all benchmarks (single-threaded + multi-threaded, Rust + Julia):

--- a/strided-kernel/src/execution_policy.rs
+++ b/strided-kernel/src/execution_policy.rs
@@ -206,6 +206,78 @@ pub(crate) fn rayon_threads() -> usize {
     }
 }
 
+#[cfg(test)]
+mod default_tests {
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    #[test]
+    fn ambient_scope_returns_result_without_changing_state() {
+        let before = state();
+
+        let value = with_execution_policy(ExecutionPolicy::AmbientRayon, || {
+            let active = state();
+            assert_eq!(active.policy, before.policy);
+            assert_eq!(active.fanout_active, before.fanout_active);
+            17usize
+        });
+
+        let after = state();
+        assert_eq!(value, 17);
+        assert_eq!(after.policy, before.policy);
+        assert_eq!(after.fanout_active, before.fanout_active);
+    }
+
+    #[test]
+    fn explicit_scope_restores_state_after_return_and_panic() {
+        let before = state();
+        let two = NonZeroUsize::new(2).unwrap();
+
+        let value = with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            assert_eq!(state().policy, ExecutionPolicy::Rayon { max_threads: two });
+            23usize
+        });
+        assert_eq!(value, 23);
+        assert_eq!(state().policy, before.policy);
+        assert_eq!(state().fanout_active, before.fanout_active);
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            with_execution_policy(ExecutionPolicy::Sequential, || panic!("policy scope panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(state().policy, before.policy);
+        assert_eq!(state().fanout_active, before.fanout_active);
+    }
+
+    #[test]
+    fn nested_explicit_scopes_combine_conservatively() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let four = NonZeroUsize::new(4).unwrap();
+
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: four }, || {
+            assert_eq!(state().policy, ExecutionPolicy::Rayon { max_threads: four });
+
+            with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+                assert_eq!(state().policy, ExecutionPolicy::Rayon { max_threads: two });
+            });
+            assert_eq!(state().policy, ExecutionPolicy::Rayon { max_threads: four });
+
+            with_execution_policy(ExecutionPolicy::Sequential, || {
+                assert_eq!(state().policy, ExecutionPolicy::Sequential);
+            });
+            assert_eq!(state().policy, ExecutionPolicy::Rayon { max_threads: four });
+        });
+
+        with_execution_policy(ExecutionPolicy::Sequential, || {
+            with_execution_policy(ExecutionPolicy::Rayon { max_threads: four }, || {
+                assert_eq!(state().policy, ExecutionPolicy::Sequential);
+            });
+        });
+        assert_eq!(state().policy, ExecutionPolicy::AmbientRayon);
+        assert!(!state().fanout_active);
+    }
+}
+
 #[cfg(all(test, feature = "parallel"))]
 mod tests {
     use super::*;

--- a/strided-kernel/src/execution_policy.rs
+++ b/strided-kernel/src/execution_policy.rs
@@ -1,0 +1,282 @@
+use core::cell::Cell;
+use core::num::NonZeroUsize;
+
+/// Controls how a strided operation may use CPU threads.
+///
+/// This policy controls fanout only. It does not create a Rayon pool or choose
+/// CPU placement; callers that need placement control should install the
+/// operation in their chosen executor and then select [`Self::Sequential`] or
+/// [`Self::Rayon`].
+///
+/// The policy applies to fanout owned by `strided-kernel`. A bounded worker
+/// partition runs nested strided operations sequentially so nested operations
+/// cannot multiply the outer budget. The scope is worker-local, not a
+/// task-local Rayon context, and is not propagated to threads or Rayon tasks
+/// created by user callbacks.
+///
+/// User callbacks that rely on policy isolation must not enter their own Rayon
+/// scheduling or yield boundary (`join`, `scope`, `spawn`, and similar APIs).
+/// At such a callback-owned boundary, Rayon may execute unrelated work on the
+/// waiting worker while its worker-local policy is active. `strided-kernel`
+/// suspends the policy at every scheduler boundary it owns, but cannot do so
+/// for arbitrary scheduling performed inside a callback.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutionPolicy {
+    /// Preserve the compatibility behavior of using all threads in the current
+    /// installed Rayon pool, or the global pool when no pool is installed.
+    ///
+    /// Explicit runtimes should prefer [`Self::Sequential`] or [`Self::Rayon`].
+    AmbientRayon,
+    /// Execute entirely on the calling thread with zero Rayon fanout.
+    Sequential,
+    /// Use the currently installed Rayon pool while limiting the operation to
+    /// at most `max_threads` concurrent partitions.
+    ///
+    /// Without the `parallel` feature, operations remain sequential.
+    Rayon { max_threads: NonZeroUsize },
+}
+
+thread_local! {
+    static ACTIVE_POLICY: Cell<ExecutionPolicy> = const { Cell::new(ExecutionPolicy::AmbientRayon) };
+    static ACTIVE_FANOUT: Cell<bool> = const { Cell::new(false) };
+}
+
+fn restrict(outer: ExecutionPolicy, inner: ExecutionPolicy) -> ExecutionPolicy {
+    match (outer, inner) {
+        (ExecutionPolicy::Sequential, _) | (_, ExecutionPolicy::Sequential) => {
+            ExecutionPolicy::Sequential
+        }
+        (ExecutionPolicy::AmbientRayon, policy) | (policy, ExecutionPolicy::AmbientRayon) => policy,
+        (
+            ExecutionPolicy::Rayon { max_threads: outer },
+            ExecutionPolicy::Rayon { max_threads: inner },
+        ) => ExecutionPolicy::Rayon {
+            max_threads: outer.min(inner),
+        },
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ExecutionState {
+    policy: ExecutionPolicy,
+    fanout_active: bool,
+}
+
+struct StateGuard {
+    previous: ExecutionState,
+}
+
+impl Drop for StateGuard {
+    fn drop(&mut self) {
+        set_state(self.previous);
+    }
+}
+
+fn state() -> ExecutionState {
+    ExecutionState {
+        policy: ACTIVE_POLICY.with(Cell::get),
+        fanout_active: ACTIVE_FANOUT.with(Cell::get),
+    }
+}
+
+fn set_state(state: ExecutionState) {
+    ACTIVE_POLICY.with(|active| active.set(state.policy));
+    ACTIVE_FANOUT.with(|active| active.set(state.fanout_active));
+}
+
+#[cfg(feature = "parallel")]
+fn with_state<R>(next: ExecutionState, operation: impl FnOnce() -> R) -> R {
+    let previous = state();
+    set_state(next);
+    let _guard = StateGuard { previous };
+    operation()
+}
+
+/// Execute `operation` under an explicit strided-kernel execution policy.
+///
+/// Nested scopes combine conservatively: sequential execution dominates and
+/// nested Rayon budgets use the smaller limit. The previous policy is restored
+/// even if `operation` panics.
+///
+/// The contract covers strided operations and their library-owned fanout. It
+/// does not turn Rayon worker-local state into task-local state. In particular,
+/// callbacks should not invoke Rayon scheduling or yielding APIs if they depend
+/// on isolation from unrelated work; see [`ExecutionPolicy`] for details.
+///
+/// # Examples
+///
+/// ```rust
+/// use strided_kernel::{
+///     map_into, with_execution_policy, ExecutionPolicy, StridedArray,
+/// };
+///
+/// let source = StridedArray::<f64>::from_fn_col_major(&[3], |index| index[0] as f64);
+/// let mut destination = StridedArray::<f64>::col_major(&[3]);
+/// with_execution_policy(ExecutionPolicy::Sequential, || {
+///     map_into(&mut destination.view_mut(), &source.view(), |value| value + 1.0)
+///         .unwrap();
+/// });
+/// assert_eq!(destination.into_data(), vec![1.0, 2.0, 3.0]);
+/// ```
+#[inline]
+pub fn with_execution_policy<R>(policy: ExecutionPolicy, operation: impl FnOnce() -> R) -> R {
+    let policy = match policy {
+        ExecutionPolicy::AmbientRayon => return operation(),
+        policy => policy,
+    };
+    let previous = state();
+    set_state(ExecutionState {
+        policy: restrict(previous.policy, policy),
+        fanout_active: previous.fanout_active,
+    });
+    let _guard = StateGuard { previous };
+    operation()
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn active_policy() -> ExecutionPolicy {
+    ACTIVE_POLICY.with(Cell::get)
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn fanout_active() -> bool {
+    ACTIVE_FANOUT.with(Cell::get)
+}
+
+#[cfg(feature = "parallel")]
+#[inline(always)]
+pub(crate) fn with_owned_execution<R>(
+    policy: ExecutionPolicy,
+    fanout_active: bool,
+    operation: impl FnOnce() -> R,
+) -> R {
+    match policy {
+        ExecutionPolicy::AmbientRayon => operation(),
+        ExecutionPolicy::Sequential | ExecutionPolicy::Rayon { .. } => {
+            let previous = state();
+            with_state(
+                ExecutionState {
+                    policy: restrict(previous.policy, policy),
+                    fanout_active: previous.fanout_active || fanout_active,
+                },
+                operation,
+            )
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn with_scheduler_suspended<R>(operation: impl FnOnce() -> R) -> R {
+    with_state(
+        ExecutionState {
+            policy: ExecutionPolicy::AmbientRayon,
+            fanout_active: false,
+        },
+        operation,
+    )
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn permutation_copy_parallel_eligible(
+    policy: ExecutionPolicy,
+    fanout_active: bool,
+    current_pool_threads: usize,
+) -> bool {
+    if fanout_active || current_pool_threads <= 1 {
+        return false;
+    }
+    match policy {
+        ExecutionPolicy::AmbientRayon => true,
+        ExecutionPolicy::Sequential => false,
+        ExecutionPolicy::Rayon { max_threads } => current_pool_threads <= max_threads.get(),
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn rayon_threads() -> usize {
+    if fanout_active() {
+        return 1;
+    }
+    match active_policy() {
+        ExecutionPolicy::Sequential => 1,
+        ExecutionPolicy::AmbientRayon => crate::threading::current_pool_threads(),
+        ExecutionPolicy::Rayon { max_threads } => {
+            crate::threading::current_pool_threads().min(max_threads.get())
+        }
+    }
+}
+
+#[cfg(all(test, feature = "parallel"))]
+mod tests {
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    #[test]
+    fn permutation_copy_parallel_eligibility_is_deterministic() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let four = NonZeroUsize::new(4).unwrap();
+
+        assert!(permutation_copy_parallel_eligible(
+            ExecutionPolicy::Rayon { max_threads: two },
+            false,
+            2,
+        ));
+        assert!(permutation_copy_parallel_eligible(
+            ExecutionPolicy::Rayon { max_threads: four },
+            false,
+            2,
+        ));
+        assert!(!permutation_copy_parallel_eligible(
+            ExecutionPolicy::Rayon { max_threads: two },
+            false,
+            4,
+        ));
+        assert!(!permutation_copy_parallel_eligible(
+            ExecutionPolicy::Rayon { max_threads: two },
+            true,
+            2,
+        ));
+        assert!(!permutation_copy_parallel_eligible(
+            ExecutionPolicy::Sequential,
+            false,
+            2,
+        ));
+        assert!(permutation_copy_parallel_eligible(
+            ExecutionPolicy::AmbientRayon,
+            false,
+            2,
+        ));
+    }
+
+    #[test]
+    fn scheduler_panic_restores_owned_policy_and_fanout_state() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let policy = ExecutionPolicy::Rayon { max_threads: two };
+
+        with_execution_policy(policy, || {
+            with_owned_execution(policy, true, || {
+                let panic = catch_unwind(AssertUnwindSafe(|| {
+                    with_scheduler_suspended(|| panic!("scheduler boundary panic"));
+                }));
+                assert!(panic.is_err());
+                assert_eq!(active_policy(), policy);
+                assert!(fanout_active());
+            });
+        });
+        assert_eq!(active_policy(), ExecutionPolicy::AmbientRayon);
+        assert!(!fanout_active());
+    }
+
+    #[test]
+    fn leaf_panic_restores_ambient_policy_and_inactive_fanout() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let policy = ExecutionPolicy::Rayon { max_threads: two };
+
+        let panic = catch_unwind(AssertUnwindSafe(|| {
+            with_owned_execution(policy, true, || panic!("owned leaf panic"));
+        }));
+        assert!(panic.is_err());
+        assert_eq!(active_policy(), ExecutionPolicy::AmbientRayon);
+        assert!(!fanout_active());
+    }
+}

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -746,7 +746,8 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
         };
 
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send: Vec<SendPtr<T>> = dst_ptrs.iter().map(|&ptr| SendPtr(ptr)).collect();
             let input_send: Vec<SendPtr<T>> = input_ptrs
                 .iter()
@@ -755,8 +756,6 @@ fn interpret_fused_elementwise_into<T: FusedScalar>(
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; ordered_strides.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &kernel_plan.block,

--- a/strided-kernel/src/kernel.rs
+++ b/strided-kernel/src/kernel.rs
@@ -616,7 +616,7 @@ pub(crate) fn total_len(dims: &[usize]) -> usize {
 pub(crate) fn use_sequential_fast_path(total: usize) -> bool {
     #[cfg(feature = "parallel")]
     {
-        total <= crate::threading::MINTHREADLENGTH || rayon::current_num_threads() <= 1
+        total <= crate::threading::MINTHREADLENGTH || crate::execution_policy::rayon_threads() <= 1
     }
     #[cfg(not(feature = "parallel"))]
     {

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -10,6 +10,8 @@
 //! - [`StridedArray`]: Owned strided multidimensional array
 //! - [`ElementOp`] trait and implementations ([`Identity`], [`Conj`], [`Transpose`], [`Adjoint`]):
 //!   Type-level element operations applied lazily on access
+//! - [`ExecutionPolicy`] / [`with_execution_policy`]: optional bounds on
+//!   strided-owned CPU fanout without creating a Rayon pool
 //!
 //! # Primary API (view-based, Julia-compatible)
 //!
@@ -55,16 +57,17 @@
 //! - Contiguous arrays use fast paths bypassing the blocking machinery
 
 mod block;
+mod execution_policy;
 mod fuse;
 mod fused;
 mod gather_plan;
 mod kernel;
 mod order;
 mod simd;
-#[cfg(feature = "parallel")]
 mod threading;
 
 mod maybe_sync;
+pub use execution_policy::{with_execution_policy, ExecutionPolicy};
 pub use maybe_sync::{MaybeSend, MaybeSendSync, MaybeSync};
 
 // View-based operation modules

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -583,10 +583,9 @@ fn try_contiguous_range_mul<
 
     #[cfg(feature = "parallel")]
     {
-        let nthreads = rayon::current_num_threads();
+        let nthreads = crate::execution_policy::rayon_threads();
         if nthreads > 1 {
-            use crate::threading::SendPtr;
-            use rayon::prelude::*;
+            use crate::threading::{parallel_for_each, SendPtr};
 
             let dst = SendPtr(dst_ptr);
             let a = SendPtr(a_ptr as *mut A);
@@ -596,39 +595,41 @@ fn try_contiguous_range_mul<
                 let chunk_len = total.div_ceil(nthreads);
                 let nchunks = total.div_ceil(chunk_len);
 
-                (0..nchunks).into_par_iter().for_each(|chunk| {
-                    let start = chunk * chunk_len;
-                    let end = (start + chunk_len).min(total);
-                    let mut index = start;
+                parallel_for_each(0..nchunks, nthreads, &|chunks| {
+                    for chunk in chunks {
+                        let start = chunk * chunk_len;
+                        let end = (start + chunk_len).min(total);
+                        let mut index = start;
 
-                    while index < end {
-                        let in_inner = index % inner_len;
-                        let len = (inner_len - in_inner).min(end - index);
-                        let a_offset = strided_offset_for_contiguous_linear_index(
-                            dims,
-                            a_strides,
-                            &plan.axis_order,
-                            index,
-                        );
-                        let b_offset = strided_offset_for_contiguous_linear_index(
-                            dims,
-                            b_strides,
-                            &plan.axis_order,
-                            index,
-                        );
-
-                        unsafe {
-                            inner_loop_mul2::<D, A, B>(
-                                dst.as_ptr().add(index),
-                                1,
-                                a.as_const().offset(a_offset),
-                                plan.a_fast_stride,
-                                b.as_const().offset(b_offset),
-                                plan.b_fast_stride,
-                                len,
+                        while index < end {
+                            let in_inner = index % inner_len;
+                            let len = (inner_len - in_inner).min(end - index);
+                            let a_offset = strided_offset_for_contiguous_linear_index(
+                                dims,
+                                a_strides,
+                                &plan.axis_order,
+                                index,
                             );
+                            let b_offset = strided_offset_for_contiguous_linear_index(
+                                dims,
+                                b_strides,
+                                &plan.axis_order,
+                                index,
+                            );
+
+                            unsafe {
+                                inner_loop_mul2::<D, A, B>(
+                                    dst.as_ptr().add(index),
+                                    1,
+                                    a.as_const().offset(a_offset),
+                                    plan.a_fast_stride,
+                                    b.as_const().offset(b_offset),
+                                    plan.b_fast_stride,
+                                    len,
+                                );
+                            }
+                            index += len;
                         }
-                        index += len;
                     }
                 });
 
@@ -638,27 +639,34 @@ fn try_contiguous_range_mul<
             let groups_per_chunk = outer_groups.div_ceil(nthreads);
             let nchunks = outer_groups.div_ceil(groups_per_chunk);
 
-            (0..nchunks).into_par_iter().for_each(|chunk| {
-                let group_start = chunk * groups_per_chunk;
-                let group_end = (group_start + groups_per_chunk).min(outer_groups);
-                let mut cursor =
-                    ContiguousMulOuterCursor::new(dims, a_strides, b_strides, &plan, group_start);
+            parallel_for_each(0..nchunks, nthreads, &|chunks| {
+                for chunk in chunks {
+                    let group_start = chunk * groups_per_chunk;
+                    let group_end = (group_start + groups_per_chunk).min(outer_groups);
+                    let mut cursor = ContiguousMulOuterCursor::new(
+                        dims,
+                        a_strides,
+                        b_strides,
+                        &plan,
+                        group_start,
+                    );
 
-                for group in group_start..group_end {
-                    let index = group * block_len;
-                    unsafe {
-                        run_contiguous_mul_row_block::<D, A, B>(
-                            dst.as_ptr(),
-                            a.as_const(),
-                            b.as_const(),
-                            &plan,
-                            index,
-                            total,
-                            cursor.a_offset,
-                            cursor.b_offset,
-                        );
+                    for group in group_start..group_end {
+                        let index = group * block_len;
+                        unsafe {
+                            run_contiguous_mul_row_block::<D, A, B>(
+                                dst.as_ptr(),
+                                a.as_const(),
+                                b.as_const(),
+                                &plan,
+                                index,
+                                total,
+                                cursor.a_offset,
+                                cursor.b_offset,
+                            );
+                        }
+                        cursor.advance();
                     }
-                    cursor.advance();
                 }
             });
 
@@ -890,15 +898,14 @@ pub fn map_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut A);
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -1000,7 +1007,8 @@ pub fn zip_map2_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -1008,8 +1016,6 @@ pub fn zip_map2_into<
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -1120,7 +1126,8 @@ fn mul_identity_into_raw<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -1128,8 +1135,6 @@ fn mul_identity_into_raw<
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -1365,7 +1370,8 @@ pub fn zip_map3_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -1374,8 +1380,6 @@ pub fn zip_map3_into<
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -1519,7 +1523,8 @@ pub fn zip_map4_into<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             use crate::threading::SendPtr;
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
@@ -1529,8 +1534,6 @@ pub fn zip_map4_into<
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,

--- a/strided-kernel/src/ops_view.rs
+++ b/strided-kernel/src/ops_view.rs
@@ -20,9 +20,6 @@ use crate::fuse::compute_costs;
 use crate::threading::{
     for_each_inner_block_with_offsets, mapreduce_threaded, SendPtr, MINTHREADLENGTH,
 };
-#[cfg(feature = "parallel")]
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
-
 // ============================================================================
 // Stride-specialized inner loop helpers for ops_view
 //
@@ -243,12 +240,12 @@ pub fn copy_into<T: Copy + MaybeSendSync, Op: ElementOp<T>>(
 
 /// Copy elements from `src` to `dst`, optimized for col-major destination.
 ///
-/// Delegates to `strided_perm::copy_into_col_major` for the actual work.
+/// Delegates to the centralized permutation-copy dispatch for the actual work.
 pub fn copy_into_col_major<T: Copy + MaybeSendSync>(
     dst: &mut StridedViewMut<T>,
     src: &StridedView<T>,
 ) -> Result<()> {
-    strided_perm::copy_into_col_major(dst, src)
+    crate::threading::copy_into_col_major(dst, src)
 }
 
 /// Element-wise addition: `dest[i] += src[i]`.
@@ -291,14 +288,13 @@ pub fn add<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -393,14 +389,13 @@ pub fn mul<
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -498,14 +493,13 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst_ptr);
             let src_send = SendPtr(src_ptr as *mut S);
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -612,15 +606,14 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst_ptr);
             let a_send = SendPtr(a_ptr as *mut A);
             let b_send = SendPtr(b_ptr as *mut B);
 
             let costs = compute_costs(&ordered_strides);
             let initial_offsets = vec![0isize; strides_list.len()];
-            let nthreads = rayon::current_num_threads();
-
             return mapreduce_threaded(
                 &fused_dims,
                 &plan.block,
@@ -683,17 +676,17 @@ where
 fn parallel_simd_sum<T: Copy + Zero + Add<Output = T> + simd::MaybeSimdOps + Send + Sync>(
     src: &[T],
 ) -> Option<T> {
-    use rayon::prelude::*;
     // Check that T has SIMD support
     if T::try_simd_sum(&[]).is_none() {
         return None;
     }
-    let nthreads = rayon::current_num_threads();
-    let chunk_size = (src.len() + nthreads - 1) / nthreads;
-    let result = src
-        .par_chunks(chunk_size)
-        .map(|chunk| T::try_simd_sum(chunk).unwrap())
-        .reduce(|| T::zero(), |a, b| a + b);
+    let nthreads = crate::execution_policy::rayon_threads();
+    let result = crate::threading::parallel_map_reduce(
+        0..src.len(),
+        nthreads,
+        &|range| T::try_simd_sum(&src[range]).unwrap(),
+        &|left, right| left + right,
+    );
     Some(result)
 }
 
@@ -958,25 +951,30 @@ unsafe fn fill_2d<T: Copy + MaybeSendSync>(
     #[cfg(feature = "parallel")]
     {
         let total = dim0.saturating_mul(dim1);
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst);
             if dst_stride0.unsigned_abs() <= dst_stride1.unsigned_abs() {
-                (0..dim1).into_par_iter().for_each(|j| {
-                    let dst = dst_send.as_ptr();
-                    unsafe {
-                        let base = j as isize * dst_stride1;
-                        for i in 0..dim0 {
-                            *dst.offset(base + i as isize * dst_stride0) = value;
+                crate::threading::parallel_for_each(0..dim1, nthreads, &|columns| {
+                    for j in columns {
+                        let dst = dst_send.as_ptr();
+                        unsafe {
+                            let base = j as isize * dst_stride1;
+                            for i in 0..dim0 {
+                                *dst.offset(base + i as isize * dst_stride0) = value;
+                            }
                         }
                     }
                 });
             } else {
-                (0..dim0).into_par_iter().for_each(|i| {
-                    let dst = dst_send.as_ptr();
-                    unsafe {
-                        let base = i as isize * dst_stride0;
-                        for j in 0..dim1 {
-                            *dst.offset(base + j as isize * dst_stride1) = value;
+                crate::threading::parallel_for_each(0..dim0, nthreads, &|rows| {
+                    for i in rows {
+                        let dst = dst_send.as_ptr();
+                        unsafe {
+                            let base = i as isize * dst_stride0;
+                            for j in 0..dim1 {
+                                *dst.offset(base + j as isize * dst_stride1) = value;
+                            }
                         }
                     }
                 });
@@ -1097,37 +1095,40 @@ unsafe fn copy_transpose_scale_2d_f64_tiled_raw(
     #[cfg(feature = "parallel")]
     {
         let total = src_rows.saturating_mul(src_cols);
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst);
             let src_send = SendPtr(src as *mut f64);
             let row_tiles = row_full / TILE;
-            (0..row_tiles).into_par_iter().for_each(|tile_i| {
-                let i = tile_i * TILE;
-                let dst = dst_send.as_ptr();
-                let src = src_send.as_const();
-                unsafe {
-                    let mut j = 0;
-                    while j < col_full {
-                        transpose_scale_4x4_f64(
-                            dst,
-                            dst_stride0,
-                            dst_stride1,
-                            src,
-                            src_stride0,
-                            src_stride1,
-                            i,
-                            j,
-                            scale,
-                        );
-                        j += TILE;
-                    }
-                    for j in col_full..src_cols {
-                        for ii in i..i + TILE {
-                            *dst.offset(j as isize * dst_stride0 + ii as isize * dst_stride1) =
-                                scale
-                                    * *src.offset(
-                                        ii as isize * src_stride0 + j as isize * src_stride1,
-                                    );
+            crate::threading::parallel_for_each(0..row_tiles, nthreads, &|tiles| {
+                for tile_i in tiles {
+                    let i = tile_i * TILE;
+                    let dst = dst_send.as_ptr();
+                    let src = src_send.as_const();
+                    unsafe {
+                        let mut j = 0;
+                        while j < col_full {
+                            transpose_scale_4x4_f64(
+                                dst,
+                                dst_stride0,
+                                dst_stride1,
+                                src,
+                                src_stride0,
+                                src_stride1,
+                                i,
+                                j,
+                                scale,
+                            );
+                            j += TILE;
+                        }
+                        for j in col_full..src_cols {
+                            for ii in i..i + TILE {
+                                *dst.offset(j as isize * dst_stride0 + ii as isize * dst_stride1) =
+                                    scale
+                                        * *src.offset(
+                                            ii as isize * src_stride0 + j as isize * src_stride1,
+                                        );
+                            }
                         }
                     }
                 }
@@ -1331,37 +1332,40 @@ unsafe fn copy_transpose_scale_2d_identity_tiled_raw<T>(
     #[cfg(feature = "parallel")]
     {
         let total = src_rows.saturating_mul(src_cols);
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst);
             let src_send = SendPtr(src as *mut T);
             let row_tiles = row_full / TILE;
-            (0..row_tiles).into_par_iter().for_each(|tile_i| {
-                let i = tile_i * TILE;
-                let dst = dst_send.as_ptr();
-                let src = src_send.as_const();
-                unsafe {
-                    let mut j = 0;
-                    while j < col_full {
-                        transpose_scale_4x4_identity(
-                            dst,
-                            dst_stride0,
-                            dst_stride1,
-                            src,
-                            src_stride0,
-                            src_stride1,
-                            i,
-                            j,
-                            scale,
-                        );
-                        j += TILE;
-                    }
-                    for j in col_full..src_cols {
-                        for ii in i..i + TILE {
-                            *dst.offset(j as isize * dst_stride0 + ii as isize * dst_stride1) =
-                                scale
-                                    * *src.offset(
-                                        ii as isize * src_stride0 + j as isize * src_stride1,
-                                    );
+            crate::threading::parallel_for_each(0..row_tiles, nthreads, &|tiles| {
+                for tile_i in tiles {
+                    let i = tile_i * TILE;
+                    let dst = dst_send.as_ptr();
+                    let src = src_send.as_const();
+                    unsafe {
+                        let mut j = 0;
+                        while j < col_full {
+                            transpose_scale_4x4_identity(
+                                dst,
+                                dst_stride0,
+                                dst_stride1,
+                                src,
+                                src_stride0,
+                                src_stride1,
+                                i,
+                                j,
+                                scale,
+                            );
+                            j += TILE;
+                        }
+                        for j in col_full..src_cols {
+                            for ii in i..i + TILE {
+                                *dst.offset(j as isize * dst_stride0 + ii as isize * dst_stride1) =
+                                    scale
+                                        * *src.offset(
+                                            ii as isize * src_stride0 + j as isize * src_stride1,
+                                        );
+                            }
                         }
                     }
                 }
@@ -1460,34 +1464,39 @@ unsafe fn copy_transpose_scale_2d_loop<T>(
     #[cfg(feature = "parallel")]
     {
         let total = src_rows.saturating_mul(src_cols);
-        if total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
+        let nthreads = crate::execution_policy::rayon_threads();
+        if total > MINTHREADLENGTH && nthreads > 1 {
             let dst_send = SendPtr(dst);
             let src_send = SendPtr(src as *mut T);
             if dst_stride0.unsigned_abs() <= dst_stride1.unsigned_abs() {
-                (0..src_rows).into_par_iter().for_each(|i| {
-                    let dst = dst_send.as_ptr();
-                    let src = src_send.as_const();
-                    unsafe {
-                        for j in 0..src_cols {
-                            let value = (*src
-                                .offset(i as isize * src_stride0 + j as isize * src_stride1))
-                            .transpose();
-                            *dst.offset(j as isize * dst_stride0 + i as isize * dst_stride1) =
-                                scale * value;
+                crate::threading::parallel_for_each(0..src_rows, nthreads, &|rows| {
+                    for i in rows {
+                        let dst = dst_send.as_ptr();
+                        let src = src_send.as_const();
+                        unsafe {
+                            for j in 0..src_cols {
+                                let value = (*src
+                                    .offset(i as isize * src_stride0 + j as isize * src_stride1))
+                                .transpose();
+                                *dst.offset(j as isize * dst_stride0 + i as isize * dst_stride1) =
+                                    scale * value;
+                            }
                         }
                     }
                 });
             } else {
-                (0..src_cols).into_par_iter().for_each(|j| {
-                    let dst = dst_send.as_ptr();
-                    let src = src_send.as_const();
-                    unsafe {
-                        for i in 0..src_rows {
-                            let value = (*src
-                                .offset(i as isize * src_stride0 + j as isize * src_stride1))
-                            .transpose();
-                            *dst.offset(j as isize * dst_stride0 + i as isize * dst_stride1) =
-                                scale * value;
+                crate::threading::parallel_for_each(0..src_cols, nthreads, &|columns| {
+                    for j in columns {
+                        let dst = dst_send.as_ptr();
+                        let src = src_send.as_const();
+                        unsafe {
+                            for i in 0..src_rows {
+                                let value = (*src
+                                    .offset(i as isize * src_stride0 + j as isize * src_stride1))
+                                .transpose();
+                                *dst.offset(j as isize * dst_stride0 + i as isize * dst_stride1) =
+                                    scale * value;
+                            }
                         }
                     }
                 });
@@ -1565,11 +1574,10 @@ where
         let src_t = src.permute(&[1, 0])?;
         #[cfg(feature = "parallel")]
         {
-            if total_len(dest.dims()) > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
-                return strided_perm::copy_into_par(dest, &src_t);
-            }
+            return crate::threading::copy_permuted_with_active_policy(dest, &src_t);
         }
-        return strided_perm::copy_into(dest, &src_t);
+        #[cfg(not(feature = "parallel"))]
+        return crate::threading::copy_permuted_serial(dest, &src_t);
     }
 
     unsafe {
@@ -1635,6 +1643,126 @@ mod tiled_tests {
         for i in 0..rows {
             for j in 0..cols {
                 assert_eq!(out.get(&[j, i]), 2 * a.get(&[i, j]));
+            }
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn test_bounded_identity_tiled_transpose_uses_two_partitions_exactly_once() {
+        use std::num::NonZeroUsize;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+        use std::time::{Duration, Instant};
+
+        struct TileState {
+            active: AtomicUsize,
+            max_active: AtomicUsize,
+            released: AtomicBool,
+            coverage: Box<[AtomicUsize]>,
+        }
+
+        impl TileState {
+            fn observe(&self, index: usize) {
+                self.coverage[index].fetch_add(1, Ordering::SeqCst);
+                let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_active.fetch_max(active, Ordering::SeqCst);
+                if active >= 2 {
+                    self.released.store(true, Ordering::Release);
+                } else if !self.released.load(Ordering::Acquire) {
+                    let deadline = Instant::now() + Duration::from_secs(2);
+                    while !self.released.load(Ordering::Acquire) && Instant::now() < deadline {
+                        std::hint::spin_loop();
+                    }
+                }
+                self.active.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+
+        #[derive(Clone, Copy)]
+        struct TrackedTile {
+            index: usize,
+            value: usize,
+            state: &'static TileState,
+        }
+
+        impl std::ops::Mul for TrackedTile {
+            type Output = Self;
+
+            fn mul(self, rhs: Self) -> Self::Output {
+                self.state.observe(rhs.index);
+                Self {
+                    index: rhs.index,
+                    value: self.value * rhs.value,
+                    state: self.state,
+                }
+            }
+        }
+
+        const ROWS: usize = 257;
+        const COLS: usize = 129;
+        const LEN: usize = ROWS * COLS;
+        let state = Box::leak(Box::new(TileState {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            released: AtomicBool::new(false),
+            coverage: (0..LEN)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }));
+        let source: Vec<_> = (0..LEN)
+            .map(|index| TrackedTile {
+                index,
+                value: index + 1,
+                state,
+            })
+            .collect();
+        let mut destination = vec![
+            TrackedTile {
+                index: usize::MAX,
+                value: 0,
+                state,
+            };
+            LEN
+        ];
+        let scale = TrackedTile {
+            index: usize::MAX,
+            value: 3,
+            state,
+        };
+        let two = NonZeroUsize::new(2).unwrap();
+
+        crate::threading::test_pool(4).install(|| {
+            crate::with_execution_policy(
+                crate::ExecutionPolicy::Rayon { max_threads: two },
+                || unsafe {
+                    copy_transpose_scale_2d_identity_tiled_raw(
+                        destination.as_mut_ptr(),
+                        1,
+                        COLS as isize,
+                        source.as_ptr(),
+                        1,
+                        ROWS as isize,
+                        ROWS,
+                        COLS,
+                        scale,
+                    );
+                },
+            );
+        });
+
+        assert_eq!(state.max_active.load(Ordering::SeqCst), 2);
+        for (index, count) in state.coverage.iter().enumerate() {
+            assert_eq!(
+                count.load(Ordering::SeqCst),
+                1,
+                "tiled transpose source index {index} did not execute exactly once"
+            );
+        }
+        for i in 0..ROWS {
+            for j in 0..COLS {
+                let source_index = i + ROWS * j;
+                assert_eq!(destination[j + COLS * i].value, 3 * (source_index + 1));
             }
         }
     }

--- a/strided-kernel/src/reduce_view.rs
+++ b/strided-kernel/src/reduce_view.rs
@@ -79,33 +79,36 @@ where
         }));
     }
 
-    // Parallel contiguous fast path: split into rayon chunks with slice-based iteration.
+    // Parallel contiguous fast path: split into scheduler chunks with slice-based iteration.
     // This enables LLVM auto-vectorization on each chunk, unlike the general threaded path
     // which uses scalar pointer-offset loops.
     #[cfg(feature = "parallel")]
     {
         let total = total_len(src_dims);
-        if allow_ambient_parallel
-            && total > MINTHREADLENGTH
-            && rayon::current_num_threads() > 1
+        let nthreads = if allow_ambient_parallel {
+            crate::execution_policy::rayon_threads()
+        } else {
+            1
+        };
+        if total > MINTHREADLENGTH
+            && nthreads > 1
             && same_contiguous_layout(src_dims, &[src_strides]).is_some()
         {
             let src_slice = unsafe { std::slice::from_raw_parts(src_ptr, total) };
-            use rayon::prelude::*;
-            let nthreads = rayon::current_num_threads();
-            let chunk_size = (total + nthreads - 1) / nthreads;
-            let result = src_slice
-                .par_chunks(chunk_size)
-                .map(|chunk| {
-                    simd::dispatch_if_large(chunk.len(), || {
+            let result = crate::threading::parallel_map_reduce(
+                0..total,
+                nthreads,
+                &|range| {
+                    simd::dispatch_if_large(range.len(), || {
                         let mut acc = init.clone();
-                        for &val in chunk.iter() {
+                        for &val in &src_slice[range] {
                             acc = reduce_fn(acc, map_fn(Op::apply(val)));
                         }
                         acc
                     })
-                })
-                .reduce(|| init.clone(), |a, b| reduce_fn(a, b));
+                },
+                &|a, b| reduce_fn(a, b),
+            );
             return Ok(result);
         }
     }
@@ -118,8 +121,12 @@ where
     #[cfg(feature = "parallel")]
     {
         let total: usize = fused_dims.iter().product();
-        if allow_ambient_parallel && total > MINTHREADLENGTH && rayon::current_num_threads() > 1 {
-            let nthreads = rayon::current_num_threads();
+        let nthreads = if allow_ambient_parallel {
+            crate::execution_policy::rayon_threads()
+        } else {
+            1
+        };
+        if total > MINTHREADLENGTH && nthreads > 1 {
             // False sharing avoidance: space output slots by cache line size
             let spacing = (64 / std::mem::size_of::<U>()).max(1);
             let mut threadedout = vec![init.clone(); spacing * nthreads];
@@ -283,6 +290,9 @@ where
 
     let out_ptr = out.view_mut().as_mut_ptr();
 
+    // This remains a dedicated sequential traversal: each output owns a mutable
+    // reduction accumulator, which does not fit the current alias-safe strided
+    // fanout primitive without adding a separate reduction-output partitioner.
     let initial_offsets = vec![0isize; ordered_strides.len()];
     for_each_inner_block_preordered(
         &fused_dims,

--- a/strided-kernel/src/threading.rs
+++ b/strided-kernel/src/threading.rs
@@ -128,6 +128,43 @@ pub(crate) fn copy_permuted_serial<T: Copy + crate::MaybeSendSync>(
     strided_perm::copy_into(dest, src)
 }
 
+#[cfg(test)]
+mod default_tests {
+    use super::*;
+    use crate::StridedArray;
+
+    #[test]
+    fn copy_into_col_major_copies_from_non_col_major_source() {
+        let source =
+            StridedArray::<usize>::from_fn_row_major(&[3, 4], |index| index[0] * 10 + index[1]);
+        let mut destination = StridedArray::<usize>::col_major(&[3, 4]);
+
+        copy_into_col_major(&mut destination.view_mut(), &source.view()).unwrap();
+
+        for row in 0..3 {
+            for column in 0..4 {
+                assert_eq!(destination.get(&[row, column]), source.get(&[row, column]));
+            }
+        }
+    }
+
+    #[test]
+    fn copy_permuted_serial_copies_transposed_view() {
+        let source =
+            StridedArray::<usize>::from_fn_col_major(&[3, 4], |index| index[0] * 10 + index[1]);
+        let transposed = source.view().permute(&[1, 0]).unwrap();
+        let mut destination = StridedArray::<usize>::row_major(&[4, 3]);
+
+        copy_permuted_serial(&mut destination.view_mut(), &transposed).unwrap();
+
+        for row in 0..3 {
+            for column in 0..4 {
+                assert_eq!(destination.get(&[column, row]), source.get(&[row, column]));
+            }
+        }
+    }
+}
+
 #[cfg(feature = "parallel")]
 pub(crate) fn current_pool_threads() -> usize {
     rayon::current_num_threads()

--- a/strided-kernel/src/threading.rs
+++ b/strided-kernel/src/threading.rs
@@ -3,13 +3,19 @@
 //! Faithfully ports Julia Strided.jl's `_mapreduce_threaded!` recursive
 //! dimension-splitting strategy using `rayon::join`.
 
+#[cfg(feature = "parallel")]
 use smallvec::SmallVec;
+#[cfg(feature = "parallel")]
+use std::ops::Range;
 
+#[cfg(feature = "parallel")]
 use crate::kernel::for_each_inner_block_preordered;
+#[cfg(feature = "parallel")]
 use crate::Result;
 
 /// Stack-allocated Vec for dims/offsets in recursive threading.
 /// 8 elements covers up to 8-dimensional arrays (after fusion, typically 2-4).
+#[cfg(feature = "parallel")]
 type SVec<T> = SmallVec<[T; 8]>;
 
 /// A raw pointer wrapper that is `Send` + `Sync`.
@@ -18,19 +24,25 @@ type SVec<T> = SmallVec<[T; 8]>;
 /// The caller must guarantee that the pointed-to data is valid for the
 /// lifetime of any parallel operation and that no data races occur
 /// (e.g., different threads write to disjoint regions).
+#[cfg(feature = "parallel")]
 pub(crate) struct SendPtr<T>(pub(crate) *mut T);
 
+#[cfg(feature = "parallel")]
 impl<T> Clone for SendPtr<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
+#[cfg(feature = "parallel")]
 impl<T> Copy for SendPtr<T> {}
 
+#[cfg(feature = "parallel")]
 unsafe impl<T> Send for SendPtr<T> {}
+#[cfg(feature = "parallel")]
 unsafe impl<T> Sync for SendPtr<T> {}
 
+#[cfg(feature = "parallel")]
 impl<T> SendPtr<T> {
     pub(crate) fn as_ptr(self) -> *mut T {
         self.0
@@ -43,7 +55,141 @@ impl<T> SendPtr<T> {
 
 /// Minimum number of elements to justify multi-threaded execution.
 /// Matches Julia's `MINTHREADLENGTH = 1 << 15`.
+#[cfg(feature = "parallel")]
 pub(crate) const MINTHREADLENGTH: usize = 1 << 15;
+
+#[cfg(feature = "parallel")]
+fn join_with_policy<A, B, RA, RB>(policy: crate::ExecutionPolicy, left: A, right: B) -> (RA, RB)
+where
+    A: FnOnce() -> RA + Send,
+    B: FnOnce() -> RB + Send,
+    RA: Send,
+    RB: Send,
+{
+    match policy {
+        crate::ExecutionPolicy::AmbientRayon => rayon::join(left, right),
+        crate::ExecutionPolicy::Sequential | crate::ExecutionPolicy::Rayon { .. } => {
+            crate::execution_policy::with_scheduler_suspended(|| {
+                rayon::join(
+                    || crate::execution_policy::with_owned_execution(policy, false, left),
+                    || crate::execution_policy::with_owned_execution(policy, false, right),
+                )
+            })
+        }
+    }
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn parallel_map_reduce<R, Map, Reduce>(
+    range: Range<usize>,
+    nthreads: usize,
+    map: &Map,
+    reduce: &Reduce,
+) -> R
+where
+    R: Send,
+    Map: Fn(Range<usize>) -> R + Sync,
+    Reduce: Fn(R, R) -> R + Sync,
+{
+    parallel_map_reduce_with_policy(
+        range,
+        nthreads,
+        crate::execution_policy::active_policy(),
+        false,
+        map,
+        reduce,
+    )
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn parallel_for_each<F>(range: Range<usize>, nthreads: usize, operation: &F)
+where
+    F: Fn(Range<usize>) + Sync,
+{
+    parallel_map_reduce(
+        range,
+        nthreads,
+        &|subrange| operation(subrange),
+        &|(), ()| (),
+    );
+}
+
+pub(crate) fn copy_into_col_major<T: Copy + crate::MaybeSendSync>(
+    dest: &mut crate::StridedViewMut<T>,
+    src: &crate::StridedView<T>,
+) -> crate::Result<()> {
+    strided_perm::copy_into_col_major(dest, src)
+}
+
+pub(crate) fn copy_permuted_serial<T: Copy + crate::MaybeSendSync>(
+    dest: &mut crate::StridedViewMut<T>,
+    src: &crate::StridedView<T>,
+) -> crate::Result<()> {
+    strided_perm::copy_into(dest, src)
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn current_pool_threads() -> usize {
+    rayon::current_num_threads()
+}
+
+#[cfg(feature = "parallel")]
+fn with_permutation_copy_scheduler<R>(operation: impl FnOnce() -> R) -> R {
+    crate::execution_policy::with_scheduler_suspended(operation)
+}
+
+#[cfg(feature = "parallel")]
+pub(crate) fn copy_permuted_with_active_policy<T: Copy + crate::MaybeSendSync>(
+    dest: &mut crate::StridedViewMut<T>,
+    src: &crate::StridedView<T>,
+) -> crate::Result<()> {
+    let total = crate::kernel::total_len(dest.dims());
+    let current_pool_threads = current_pool_threads();
+    let parallel_eligible = crate::execution_policy::permutation_copy_parallel_eligible(
+        crate::execution_policy::active_policy(),
+        crate::execution_policy::fanout_active(),
+        current_pool_threads,
+    );
+    if total > MINTHREADLENGTH && parallel_eligible {
+        with_permutation_copy_scheduler(|| strided_perm::copy_into_par(dest, src))
+    } else {
+        copy_permuted_serial(dest, src)
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn parallel_map_reduce_with_policy<R, Map, Reduce>(
+    range: Range<usize>,
+    nthreads: usize,
+    policy: crate::ExecutionPolicy,
+    in_fanout: bool,
+    map: &Map,
+    reduce: &Reduce,
+) -> R
+where
+    R: Send,
+    Map: Fn(Range<usize>) -> R + Sync,
+    Reduce: Fn(R, R) -> R + Sync,
+{
+    let len = range.end - range.start;
+    if nthreads <= 1 || len <= 1 {
+        return crate::execution_policy::with_owned_execution(policy, in_fanout, || map(range));
+    }
+
+    let left_threads = nthreads / 2;
+    let right_threads = nthreads - left_threads;
+    let left_len = len * left_threads / nthreads;
+    let middle = range.start + left_len.max(1).min(len - 1);
+    let left_range = range.start..middle;
+    let right_range = middle..range.end;
+
+    let (left, right) = join_with_policy(
+        policy,
+        || parallel_map_reduce_with_policy(left_range, left_threads, policy, true, map, reduce),
+        || parallel_map_reduce_with_policy(right_range, right_threads, policy, true, map, reduce),
+    );
+    crate::execution_policy::with_owned_execution(policy, true, || reduce(left, right))
+}
 
 /// Recursive dimension-splitting parallel execution.
 ///
@@ -62,6 +208,7 @@ pub(crate) const MINTHREADLENGTH: usize = 1 << 15;
 ///
 /// The leaf function `f` receives `(dims, blocks, strides_list, offsets)` describing
 /// the sub-region to process.
+#[cfg(feature = "parallel")]
 pub(crate) fn mapreduce_threaded<F>(
     dims: &[usize],
     blocks: &[usize],
@@ -76,95 +223,126 @@ pub(crate) fn mapreduce_threaded<F>(
 where
     F: Fn(&[usize], &[usize], &[Vec<isize>], &[isize]) -> Result<()> + Sync,
 {
-    let total: usize = dims.iter().product();
-
-    // Base case: single thread or below threshold
-    if nthreads <= 1 || total <= MINTHREADLENGTH {
-        if spacing != 0 {
-            let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
-            spaced[0] += spacing * (taskindex as isize - 1);
-            return f(dims, blocks, strides_list, &spaced);
-        }
-        return f(dims, blocks, strides_list, offsets);
+    ThreadedMapReduce {
+        blocks,
+        strides_list,
+        costs,
+        spacing,
+        policy: crate::execution_policy::active_policy(),
+        operation: f,
     }
+    .run(dims, offsets, nthreads, taskindex, false)
+}
 
-    // Select split dimension: _lastargmax((dims .- 1) .* costs)
-    // Streaming argmax avoids allocating a scores Vec.
-    // Uses >= to match Julia's `_lastargmax` (ties broken by last index).
-    let (i, _) = dims.iter().zip(costs.iter()).enumerate().fold(
-        (0, isize::MIN),
-        |(best_i, best_v), (idx, (&d, &c))| {
-            let score = (d as isize - 1) * c;
-            if score >= best_v {
-                (idx, score)
-            } else {
-                (best_i, best_v)
+#[cfg(feature = "parallel")]
+struct ThreadedMapReduce<'a, F> {
+    blocks: &'a [usize],
+    strides_list: &'a [Vec<isize>],
+    costs: &'a [isize],
+    spacing: isize,
+    policy: crate::ExecutionPolicy,
+    operation: &'a F,
+}
+
+#[cfg(feature = "parallel")]
+impl<F> ThreadedMapReduce<'_, F>
+where
+    F: Fn(&[usize], &[usize], &[Vec<isize>], &[isize]) -> Result<()> + Sync,
+{
+    fn run(
+        &self,
+        dims: &[usize],
+        offsets: &[isize],
+        nthreads: usize,
+        taskindex: usize,
+        in_fanout: bool,
+    ) -> Result<()> {
+        let total: usize = dims.iter().product();
+
+        // Base case: single thread or below threshold
+        if nthreads <= 1 || total <= MINTHREADLENGTH {
+            if self.spacing != 0 {
+                let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
+                spaced[0] += self.spacing * (taskindex as isize - 1);
+                return crate::execution_policy::with_owned_execution(
+                    self.policy,
+                    in_fanout,
+                    || (self.operation)(dims, self.blocks, self.strides_list, &spaced),
+                );
             }
-        },
-    );
-
-    // Guard: costs[i] == 0 || dims[i] <= min(blocks[i], 1024)
-    if costs[i] == 0 || dims[i] <= blocks[i].min(1024) {
-        if spacing != 0 {
-            let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
-            spaced[0] += spacing * (taskindex as isize - 1);
-            return f(dims, blocks, strides_list, &spaced);
+            return crate::execution_policy::with_owned_execution(self.policy, in_fanout, || {
+                (self.operation)(dims, self.blocks, self.strides_list, offsets)
+            });
         }
-        return f(dims, blocks, strides_list, offsets);
+
+        // Select split dimension: _lastargmax((dims .- 1) .* costs)
+        // Streaming argmax avoids allocating a scores Vec.
+        // Uses >= to match Julia's `_lastargmax` (ties broken by last index).
+        let (i, _) = dims.iter().zip(self.costs.iter()).enumerate().fold(
+            (0, isize::MIN),
+            |(best_i, best_v), (idx, (&d, &c))| {
+                let score = (d as isize - 1) * c;
+                if score >= best_v {
+                    (idx, score)
+                } else {
+                    (best_i, best_v)
+                }
+            },
+        );
+
+        // Guard: costs[i] == 0 || dims[i] <= min(blocks[i], 1024)
+        if self.costs[i] == 0 || dims[i] <= self.blocks[i].min(1024) {
+            if self.spacing != 0 {
+                let mut spaced: SVec<isize> = SmallVec::from_slice(offsets);
+                spaced[0] += self.spacing * (taskindex as isize - 1);
+                return crate::execution_policy::with_owned_execution(
+                    self.policy,
+                    in_fanout,
+                    || (self.operation)(dims, self.blocks, self.strides_list, &spaced),
+                );
+            }
+            return crate::execution_policy::with_owned_execution(self.policy, in_fanout, || {
+                (self.operation)(dims, self.blocks, self.strides_list, offsets)
+            });
+        }
+
+        // Split dimension i in half
+        let di = dims[i];
+        let ndi = di / 2;
+        let nt_left = nthreads / 2;
+        let nt_right = nthreads - nt_left;
+
+        // Left half: dims[i] = ndi, same offsets
+        let mut left_dims: SVec<usize> = SmallVec::from_slice(dims);
+        left_dims[i] = ndi;
+
+        // Right half: dims[i] = di - ndi, offsets advanced by ndi * stride[i]
+        let mut right_dims: SVec<usize> = SmallVec::from_slice(dims);
+        right_dims[i] = di - ndi;
+        let mut right_offsets: SVec<isize> = SmallVec::from_slice(offsets);
+        for (k, strides) in self.strides_list.iter().enumerate() {
+            right_offsets[k] += ndi as isize * strides[i];
+        }
+
+        let left_offsets: SVec<isize> = SmallVec::from_slice(offsets);
+
+        let (r1, r2) = join_with_policy(
+            self.policy,
+            || self.run(&left_dims, &left_offsets, nt_left, taskindex, true),
+            || {
+                self.run(
+                    &right_dims,
+                    &right_offsets,
+                    nt_right,
+                    taskindex + nt_left,
+                    true,
+                )
+            },
+        );
+        r1?;
+        r2?;
+        Ok(())
     }
-
-    // Split dimension i in half
-    let di = dims[i];
-    let ndi = di / 2;
-    let nt_left = nthreads / 2;
-    let nt_right = nthreads - nt_left;
-
-    // Left half: dims[i] = ndi, same offsets
-    let mut left_dims: SVec<usize> = SmallVec::from_slice(dims);
-    left_dims[i] = ndi;
-
-    // Right half: dims[i] = di - ndi, offsets advanced by ndi * stride[i]
-    let mut right_dims: SVec<usize> = SmallVec::from_slice(dims);
-    right_dims[i] = di - ndi;
-    let mut right_offsets: SVec<isize> = SmallVec::from_slice(offsets);
-    for (k, strides) in strides_list.iter().enumerate() {
-        right_offsets[k] += ndi as isize * strides[i];
-    }
-
-    let left_offsets: SVec<isize> = SmallVec::from_slice(offsets);
-
-    // rayon::join for parallel left/right execution
-    let (r1, r2) = rayon::join(
-        || {
-            mapreduce_threaded(
-                &left_dims,
-                blocks,
-                strides_list,
-                &left_offsets,
-                costs,
-                nt_left,
-                spacing,
-                taskindex,
-                f,
-            )
-        },
-        || {
-            mapreduce_threaded(
-                &right_dims,
-                blocks,
-                strides_list,
-                &right_offsets,
-                costs,
-                nt_right,
-                spacing,
-                taskindex + nt_left,
-                f,
-            )
-        },
-    );
-    r1?;
-    r2?;
-    Ok(())
 }
 
 /// Execute the kernel on a sub-region defined by initial offsets.
@@ -172,6 +350,7 @@ where
 /// Delegates to `for_each_inner_block_preordered` which directly calls
 /// kernel functions with the initial offsets, avoiding redundant re-ordering
 /// and per-callback `Vec` allocation.
+#[cfg(feature = "parallel")]
 pub(crate) fn for_each_inner_block_with_offsets<F>(
     dims: &[usize],
     blocks: &[usize],
@@ -185,9 +364,51 @@ where
     for_each_inner_block_preordered(dims, blocks, strides_list, initial_offsets, f)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "parallel"))]
+pub(crate) fn test_pool(threads: usize) -> std::sync::Arc<rayon::ThreadPool> {
+    std::sync::Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .unwrap(),
+    )
+}
+
+#[cfg(all(test, feature = "parallel"))]
 mod tests {
     use super::*;
+    use crate::{with_execution_policy, ExecutionPolicy};
+    use std::num::NonZeroUsize;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    #[test]
+    fn permutation_copy_scheduler_is_ambient_and_panic_safe() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let policy = ExecutionPolicy::Rayon { max_threads: two };
+
+        with_execution_policy(policy, || {
+            let panic = std::panic::catch_unwind(|| {
+                with_permutation_copy_scheduler(|| {
+                    assert_eq!(
+                        crate::execution_policy::active_policy(),
+                        ExecutionPolicy::AmbientRayon
+                    );
+                    assert!(!crate::execution_policy::fanout_active());
+                    panic!("permutation scheduler boundary panic");
+                });
+            });
+            assert!(panic.is_err());
+            assert_eq!(crate::execution_policy::active_policy(), policy);
+            assert!(!crate::execution_policy::fanout_active());
+        });
+        assert_eq!(
+            crate::execution_policy::active_policy(),
+            ExecutionPolicy::AmbientRayon
+        );
+        assert!(!crate::execution_policy::fanout_active());
+    }
 
     /// Helper: compute lastargmax via streaming fold (same logic as in mapreduce_threaded).
     fn streaming_lastargmax(dims: &[usize], costs: &[isize]) -> usize {
@@ -307,5 +528,56 @@ mod tests {
         .unwrap();
         // offset[0] should be 8 * (3 - 1) = 16
         assert_eq!(received_offset.load(Ordering::SeqCst), 16);
+    }
+
+    #[test]
+    fn internal_join_wait_does_not_leak_policy_to_an_unrelated_ambient_job() {
+        let pool = test_pool(2);
+        let policy = ExecutionPolicy::Rayon {
+            max_threads: NonZeroUsize::new(2).unwrap(),
+        };
+        let right_release = Arc::new(AtomicBool::new(false));
+        let (right_started_tx, right_started_rx) = mpsc::channel();
+        let (observed_tx, observed_rx) = mpsc::channel();
+        let spawn_pool = Arc::clone(&pool);
+
+        pool.install(|| {
+            with_execution_policy(policy, || {
+                let task_right_release = Arc::clone(&right_release);
+                let waiting_right_release = Arc::clone(&right_release);
+                join_with_policy(
+                    policy,
+                    move || {
+                        right_started_rx
+                            .recv_timeout(Duration::from_secs(5))
+                            .unwrap();
+                        spawn_pool.spawn(move || {
+                            let observed =
+                                with_execution_policy(ExecutionPolicy::AmbientRayon, || {
+                                    (
+                                        crate::execution_policy::active_policy(),
+                                        crate::execution_policy::fanout_active(),
+                                    )
+                                });
+                            observed_tx.send(observed).unwrap();
+                            task_right_release.store(true, Ordering::Release);
+                        });
+                    },
+                    move || {
+                        right_started_tx.send(()).unwrap();
+                        while !waiting_right_release.load(Ordering::Acquire) {
+                            std::thread::yield_now();
+                        }
+                    },
+                );
+
+                assert_eq!(crate::execution_policy::active_policy(), policy);
+                assert!(!crate::execution_policy::fanout_active());
+            });
+        });
+
+        let observed = observed_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert_eq!(observed.0, ExecutionPolicy::AmbientRayon);
+        assert!(!observed.1);
     }
 }

--- a/strided-kernel/tests/execution_policy.rs
+++ b/strided-kernel/tests/execution_policy.rs
@@ -1,0 +1,1210 @@
+#![cfg(feature = "parallel")]
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::ops::Mul;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier, Condvar, Mutex};
+use std::thread::ThreadId;
+use std::time::Duration;
+
+use strided_kernel::{
+    broadcast_mul_into, copy_into, copy_transpose_scale_into, fused_elementwise_into, map_into,
+    mul_into, reduce, reduce_axis, with_execution_policy, zip_map2_into, zip_map3_into, ElementOp,
+    ExecutionPolicy, FusedInst, FusedOp, FusedPlan, FusedScalar, Identity, StridedArray,
+    StridedView, StridedViewMut,
+};
+
+const LARGE_LEN: usize = 1 << 17;
+const NON_DIVISIBLE_LEN: usize = (1 << 15) + 65;
+
+#[derive(Default)]
+struct Participants {
+    active: AtomicUsize,
+    max_active: AtomicUsize,
+    thread_ids: Mutex<Vec<ThreadId>>,
+    required_concurrency: usize,
+    rendezvous_released: AtomicBool,
+    rendezvous_lock: Mutex<()>,
+    rendezvous: Condvar,
+}
+
+impl Participants {
+    fn requiring(required_concurrency: usize) -> Self {
+        assert!(required_concurrency >= 2);
+        Self {
+            required_concurrency,
+            ..Self::default()
+        }
+    }
+
+    fn observe(&self) {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        {
+            let id = std::thread::current().id();
+            let mut ids = self.thread_ids.lock().unwrap();
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        if self.required_concurrency >= 2 && !self.rendezvous_released.load(Ordering::Acquire) {
+            let guard = self.rendezvous_lock.lock().unwrap();
+            if active >= self.required_concurrency {
+                self.rendezvous_released.store(true, Ordering::Release);
+                self.rendezvous.notify_all();
+            } else if !self.rendezvous_released.load(Ordering::Acquire) {
+                let _ = self
+                    .rendezvous
+                    .wait_timeout_while(guard, Duration::from_secs(2), |_| {
+                        !self.rendezvous_released.load(Ordering::Acquire)
+                    })
+                    .unwrap();
+            }
+        }
+        for _ in 0..32 {
+            std::hint::spin_loop();
+        }
+        self.active.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    fn max_active(&self) -> usize {
+        self.max_active.load(Ordering::SeqCst)
+    }
+
+    fn thread_ids(&self) -> Vec<ThreadId> {
+        self.thread_ids.lock().unwrap().clone()
+    }
+}
+
+#[derive(Default)]
+struct ActiveThreads {
+    depths: Mutex<HashMap<ThreadId, usize>>,
+    max_active: AtomicUsize,
+}
+
+impl ActiveThreads {
+    fn enter(&self) -> ActiveThreadGuard<'_> {
+        let thread_id = std::thread::current().id();
+        let active = {
+            let mut depths = self.depths.lock().unwrap();
+            *depths.entry(thread_id).or_default() += 1;
+            depths.len()
+        };
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        ActiveThreadGuard {
+            threads: self,
+            thread_id,
+        }
+    }
+
+    fn max_active(&self) -> usize {
+        self.max_active.load(Ordering::SeqCst)
+    }
+}
+
+struct ActiveThreadGuard<'a> {
+    threads: &'a ActiveThreads,
+    thread_id: ThreadId,
+}
+
+impl Drop for ActiveThreadGuard<'_> {
+    fn drop(&mut self) {
+        let mut depths = self.threads.depths.lock().unwrap();
+        let depth = depths.get_mut(&self.thread_id).unwrap();
+        *depth -= 1;
+        if *depth == 0 {
+            depths.remove(&self.thread_id);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TrackedValue {
+    value: f64,
+    participants: &'static Participants,
+}
+
+impl TrackedValue {
+    fn observed(self, value: f64) -> Self {
+        self.participants.observe();
+        Self {
+            value,
+            participants: self.participants,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct TrackingElementOp;
+
+impl ElementOp<TrackedValue> for TrackingElementOp {
+    fn apply(value: TrackedValue) -> TrackedValue {
+        value.observed(value.value)
+    }
+}
+
+impl FusedScalar for TrackedValue {
+    fn fused_add(self, rhs: Self) -> Self {
+        self.observed(self.value + rhs.value)
+    }
+
+    fn fused_multiply(self, rhs: Self) -> Self {
+        self.observed(self.value * rhs.value)
+    }
+
+    fn fused_negate(self) -> Self {
+        self.observed(-self.value)
+    }
+
+    fn fused_conj(self) -> Self {
+        self.observed(self.value)
+    }
+
+    fn fused_divide(self, rhs: Self) -> Self {
+        self.observed(self.value / rhs.value)
+    }
+
+    fn fused_abs(self) -> Self {
+        self.observed(self.value.abs())
+    }
+
+    fn fused_maximum(self, rhs: Self) -> Self {
+        self.observed(self.value.max(rhs.value))
+    }
+
+    fn fused_minimum(self, rhs: Self) -> Self {
+        self.observed(self.value.min(rhs.value))
+    }
+
+    fn fused_clamp(self, min: Self, max: Self) -> Self {
+        self.observed(self.value.clamp(min.value, max.value))
+    }
+
+    fn fused_exp(self) -> Self {
+        self.observed(self.value.exp())
+    }
+
+    fn fused_log(self) -> Self {
+        self.observed(self.value.ln())
+    }
+
+    fn fused_sin(self) -> Self {
+        self.observed(self.value.sin())
+    }
+
+    fn fused_cos(self) -> Self {
+        self.observed(self.value.cos())
+    }
+
+    fn fused_tanh(self) -> Self {
+        self.observed(self.value.tanh())
+    }
+
+    fn fused_sqrt(self) -> Self {
+        self.observed(self.value.sqrt())
+    }
+
+    fn fused_rsqrt(self) -> Self {
+        self.observed(self.value.sqrt().recip())
+    }
+
+    fn fused_pow(self, rhs: Self) -> Self {
+        self.observed(self.value.powf(rhs.value))
+    }
+
+    fn fused_expm1(self) -> Self {
+        self.observed(self.value.exp_m1())
+    }
+
+    fn fused_log1p(self) -> Self {
+        self.observed(self.value.ln_1p())
+    }
+}
+
+fn leaked_participants(required_concurrency: usize) -> &'static Participants {
+    let participants = if required_concurrency >= 2 {
+        Participants::requiring(required_concurrency)
+    } else {
+        Participants::default()
+    };
+    Box::leak(Box::new(participants))
+}
+
+fn exact_coverage(len: usize) -> Arc<[AtomicUsize]> {
+    (0..len)
+        .map(|_| AtomicUsize::new(0))
+        .collect::<Vec<_>>()
+        .into()
+}
+
+fn assert_exactly_once(coverage: &[AtomicUsize]) {
+    for (index, count) in coverage.iter().enumerate() {
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "logical index {index} did not execute exactly once"
+        );
+    }
+}
+
+struct TrackedMulState {
+    participants: Participants,
+    coverage: Box<[AtomicUsize]>,
+}
+
+fn leaked_mul_state(len: usize, required_concurrency: usize) -> &'static TrackedMulState {
+    let participants = if required_concurrency >= 2 {
+        Participants::requiring(required_concurrency)
+    } else {
+        Participants::default()
+    };
+    let coverage = (0..len)
+        .map(|_| AtomicUsize::new(0))
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    Box::leak(Box::new(TrackedMulState {
+        participants,
+        coverage,
+    }))
+}
+
+#[derive(Clone, Copy)]
+struct TrackedMulLhs {
+    index_component: usize,
+    value: usize,
+    state: &'static TrackedMulState,
+}
+
+#[derive(Clone, Copy)]
+struct TrackedMulRhs {
+    index_component: usize,
+    value: usize,
+}
+
+impl Mul<TrackedMulRhs> for TrackedMulLhs {
+    type Output = usize;
+
+    fn mul(self, rhs: TrackedMulRhs) -> Self::Output {
+        let index = self.index_component + rhs.index_component;
+        self.state.coverage[index].fetch_add(1, Ordering::SeqCst);
+        self.state.participants.observe();
+        self.value * rhs.value
+    }
+}
+
+fn run_large_map(policy: ExecutionPolicy, required_concurrency: usize) -> (Participants, Vec<f64>) {
+    let source = StridedArray::<f64>::from_fn_col_major(&[LARGE_LEN], |index| index[0] as f64);
+    let mut destination = StridedArray::<f64>::col_major(&[LARGE_LEN]);
+    let participants = Arc::new(if required_concurrency >= 2 {
+        Participants::requiring(required_concurrency)
+    } else {
+        Participants::default()
+    });
+    let observed = Arc::clone(&participants);
+
+    with_execution_policy(policy, || {
+        map_into(&mut destination.view_mut(), &source.view(), |value| {
+            observed.observe();
+            value + 1.0
+        })
+        .unwrap();
+    });
+
+    drop(observed);
+    (
+        Arc::into_inner(participants).unwrap(),
+        destination.into_data(),
+    )
+}
+
+fn run_large_reduce(policy: ExecutionPolicy, required_concurrency: usize) -> (Participants, usize) {
+    let source = StridedArray::<u8>::from_fn_col_major(&[LARGE_LEN], |_| 1);
+    let participants = Arc::new(if required_concurrency >= 2 {
+        Participants::requiring(required_concurrency)
+    } else {
+        Participants::default()
+    });
+    let observed = Arc::clone(&participants);
+
+    let result = with_execution_policy(policy, || {
+        reduce(
+            &source.view(),
+            |value| {
+                observed.observe();
+                value as usize
+            },
+            |left, right| left + right,
+            0usize,
+        )
+        .unwrap()
+    });
+
+    drop(observed);
+    (Arc::into_inner(participants).unwrap(), result)
+}
+
+fn run_large_transposed_copy(
+    policy: ExecutionPolicy,
+    required_concurrency: usize,
+) -> (&'static Participants, Vec<TrackedValue>) {
+    let participants = leaked_participants(required_concurrency);
+    let dims = [512usize, 256];
+    let source_strides = [256isize, 1];
+    let destination_strides = [1isize, 512];
+    let source: Vec<_> = (0..LARGE_LEN)
+        .map(|index| TrackedValue {
+            value: index as f64,
+            participants,
+        })
+        .collect();
+    let mut destination = vec![
+        TrackedValue {
+            value: -1.0,
+            participants,
+        };
+        LARGE_LEN
+    ];
+    let source =
+        StridedView::<TrackedValue, TrackingElementOp>::new(&source, &dims, &source_strides, 0)
+            .unwrap();
+    let mut destination_view =
+        StridedViewMut::new(&mut destination, &dims, &destination_strides, 0).unwrap();
+
+    with_execution_policy(policy, || {
+        copy_into(&mut destination_view, &source).unwrap()
+    });
+    (participants, destination)
+}
+
+fn run_large_fused_add(
+    policy: ExecutionPolicy,
+    required_concurrency: usize,
+) -> (&'static Participants, Vec<TrackedValue>) {
+    let participants = leaked_participants(required_concurrency);
+    let dims = [LARGE_LEN];
+    let strides = [1isize];
+    let lhs: Vec<_> = (0..LARGE_LEN)
+        .map(|index| TrackedValue {
+            value: index as f64,
+            participants,
+        })
+        .collect();
+    let rhs = vec![
+        TrackedValue {
+            value: 2.0,
+            participants,
+        };
+        LARGE_LEN
+    ];
+    let mut destination = vec![
+        TrackedValue {
+            value: -1.0,
+            participants,
+        };
+        LARGE_LEN
+    ];
+    let lhs = StridedView::new(&lhs, &dims, &strides, 0).unwrap();
+    let rhs = StridedView::new(&rhs, &dims, &strides, 0).unwrap();
+    let destination_view = StridedViewMut::new(&mut destination, &dims, &strides, 0).unwrap();
+    let mut destinations = [destination_view];
+    let inputs = [lhs, rhs];
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    with_execution_policy(policy, || {
+        fused_elementwise_into(&mut destinations, &inputs, &plan).unwrap()
+    });
+    (participants, destination)
+}
+
+fn assert_row_major_identity_permutation_copy(pool_threads: usize, policy: ExecutionPolicy) {
+    const ROWS: usize = 257;
+    const COLS: usize = 129;
+    let source = StridedArray::<f64>::from_fn_row_major(&[ROWS, COLS], |index| {
+        (index[0] * COLS + index[1]) as f64
+    });
+    let mut destination = StridedArray::<f64>::row_major(&[COLS, ROWS]);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(pool_threads)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        with_execution_policy(policy, || {
+            copy_transpose_scale_into(&mut destination.view_mut(), &source.view(), 1.0).unwrap();
+        });
+    });
+
+    for row in 0..ROWS {
+        for column in 0..COLS {
+            assert_eq!(destination.get(&[column, row]), source.get(&[row, column]));
+        }
+    }
+}
+
+#[test]
+fn explicit_execution_policy_scope_returns_the_operation_result() {
+    let value = with_execution_policy(ExecutionPolicy::Sequential, || 42usize);
+    assert_eq!(value, 42);
+
+    let two = NonZeroUsize::new(2).unwrap();
+    let value = with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || 7usize);
+    assert_eq!(value, 7);
+}
+
+#[test]
+fn identity_permutation_copy_is_correct_for_parallel_eligible_and_serial_fallback() {
+    let two = NonZeroUsize::new(2).unwrap();
+    assert_row_major_identity_permutation_copy(2, ExecutionPolicy::Rayon { max_threads: two });
+    assert_row_major_identity_permutation_copy(4, ExecutionPolicy::Rayon { max_threads: two });
+}
+
+#[test]
+fn sequential_map_stays_on_the_calling_thread_inside_a_large_rayon_pool() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, output) = run_large_map(ExecutionPolicy::Sequential, 1);
+
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+        assert_eq!(output[0], 1.0);
+        assert_eq!(output[LARGE_LEN - 1], LARGE_LEN as f64);
+    });
+}
+
+#[test]
+fn rayon_map_caps_concurrent_participants_inside_a_larger_pool() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let (participants, output) = run_large_map(ExecutionPolicy::Rayon { max_threads: two }, 2);
+
+        assert_eq!(participants.max_active(), 2);
+        assert_eq!(participants.thread_ids().len(), 2);
+        assert_eq!(output[LARGE_LEN - 1], LARGE_LEN as f64);
+    });
+}
+
+#[test]
+fn rayon_budget_one_uses_no_fanout_and_stays_on_the_calling_thread() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let one = NonZeroUsize::new(1).unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, output) = run_large_map(ExecutionPolicy::Rayon { max_threads: one }, 1);
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+        assert_eq!(output[LARGE_LEN - 1], LARGE_LEN as f64);
+    });
+}
+
+#[test]
+fn sequential_policy_ignores_a_multithreaded_global_rayon_pool() {
+    assert!(
+        rayon::current_num_threads() > 1,
+        "this test requires a multithreaded global Rayon pool"
+    );
+    let caller = std::thread::current().id();
+    let source = StridedArray::<usize>::from_fn_col_major(&[NON_DIVISIBLE_LEN], |index| index[0]);
+    let mut destination = StridedArray::<usize>::col_major(&[NON_DIVISIBLE_LEN]);
+    let participants = Arc::new(Participants::default());
+    let observed = Arc::clone(&participants);
+    let coverage = exact_coverage(NON_DIVISIBLE_LEN);
+    let covered = Arc::clone(&coverage);
+
+    with_execution_policy(ExecutionPolicy::Sequential, || {
+        map_into(&mut destination.view_mut(), &source.view(), |index| {
+            covered[index].fetch_add(1, Ordering::SeqCst);
+            observed.observe();
+            index + 1
+        })
+        .unwrap();
+    });
+
+    assert_eq!(participants.max_active(), 1);
+    assert_eq!(participants.thread_ids(), vec![caller]);
+    assert_exactly_once(&coverage);
+    assert_eq!(destination.get(&[NON_DIVISIBLE_LEN - 1]), NON_DIVISIBLE_LEN);
+}
+
+#[test]
+fn bounded_zip2_and_zip3_cover_non_divisible_inputs_exactly_once() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+    let dims = [NON_DIVISIBLE_LEN];
+    let reverse_strides = [-1isize];
+    let forward_strides = [1isize];
+    let a_data: Vec<_> = (0..NON_DIVISIBLE_LEN).collect();
+    let b_data: Vec<_> = (0..NON_DIVISIBLE_LEN).map(|index| index * 3).collect();
+    let c_data: Vec<_> = (0..NON_DIVISIBLE_LEN).map(|index| index * 5).collect();
+    let a = StridedView::<usize, Identity>::new(
+        &a_data,
+        &dims,
+        &reverse_strides,
+        (NON_DIVISIBLE_LEN - 1) as isize,
+    )
+    .unwrap();
+    let b = StridedView::<usize, Identity>::new(&b_data, &dims, &forward_strides, 0).unwrap();
+    let c = StridedView::<usize, Identity>::new(&c_data, &dims, &forward_strides, 0).unwrap();
+
+    pool.install(|| {
+        let mut zip2_destination = StridedArray::<usize>::col_major(&dims);
+        let zip2_coverage = exact_coverage(NON_DIVISIBLE_LEN);
+        let zip2_covered = Arc::clone(&zip2_coverage);
+        let zip2_participants = Arc::new(Participants::requiring(2));
+        let zip2_observed = Arc::clone(&zip2_participants);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            zip_map2_into(
+                &mut zip2_destination.view_mut(),
+                &a,
+                &b,
+                |a_index, b_value| {
+                    zip2_covered[a_index].fetch_add(1, Ordering::SeqCst);
+                    zip2_observed.observe();
+                    a_index + b_value
+                },
+            )
+            .unwrap();
+        });
+        assert_eq!(zip2_participants.max_active(), 2);
+        assert_eq!(zip2_participants.thread_ids().len(), 2);
+        assert_exactly_once(&zip2_coverage);
+        assert_eq!(zip2_destination.get(&[0]), NON_DIVISIBLE_LEN - 1);
+        assert_eq!(
+            zip2_destination.get(&[NON_DIVISIBLE_LEN - 1]),
+            3 * (NON_DIVISIBLE_LEN - 1)
+        );
+
+        let mut zip3_destination = StridedArray::<usize>::col_major(&dims);
+        let zip3_coverage = exact_coverage(NON_DIVISIBLE_LEN);
+        let zip3_covered = Arc::clone(&zip3_coverage);
+        let zip3_participants = Arc::new(Participants::requiring(2));
+        let zip3_observed = Arc::clone(&zip3_participants);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            zip_map3_into(
+                &mut zip3_destination.view_mut(),
+                &a,
+                &b,
+                &c,
+                |a_index, b_value, c_value| {
+                    zip3_covered[a_index].fetch_add(1, Ordering::SeqCst);
+                    zip3_observed.observe();
+                    a_index + b_value + c_value
+                },
+            )
+            .unwrap();
+        });
+        assert_eq!(zip3_participants.max_active(), 2);
+        assert_eq!(zip3_participants.thread_ids().len(), 2);
+        assert_exactly_once(&zip3_coverage);
+        assert_eq!(zip3_destination.get(&[0]), NON_DIVISIBLE_LEN - 1);
+        assert_eq!(
+            zip3_destination.get(&[NON_DIVISIBLE_LEN - 1]),
+            8 * (NON_DIVISIBLE_LEN - 1)
+        );
+    });
+}
+
+#[test]
+fn bounded_mul_and_broadcast_mul_cover_range_partitions_exactly_once() {
+    const ROWS: usize = 257;
+    const COLS: usize = 129;
+    const LEN: usize = ROWS * COLS;
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let mul_state = leaked_mul_state(LEN, 2);
+        let lhs_data: Vec<_> = (0..LEN)
+            .map(|linear| TrackedMulLhs {
+                index_component: linear,
+                value: linear + 1,
+                state: mul_state,
+            })
+            .collect();
+        let lhs = StridedView::<TrackedMulLhs, Identity>::new(
+            &lhs_data,
+            &[ROWS, COLS],
+            &[1, ROWS as isize],
+            0,
+        )
+        .unwrap();
+        let rhs_data = [TrackedMulRhs {
+            index_component: 0,
+            value: 3,
+        }];
+        let rhs = StridedView::<TrackedMulRhs, Identity>::new(&rhs_data, &[ROWS, COLS], &[0, 0], 0)
+            .unwrap();
+        let mut destination = StridedArray::<usize>::col_major(&[ROWS, COLS]);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            mul_into(&mut destination.view_mut(), &lhs, &rhs).unwrap();
+        });
+        assert_eq!(mul_state.participants.max_active(), 2);
+        assert_eq!(mul_state.participants.thread_ids().len(), 2);
+        assert_exactly_once(&mul_state.coverage);
+        assert_eq!(destination.get(&[0, 0]), 3);
+        assert_eq!(destination.get(&[ROWS - 1, COLS - 1]), LEN * 3);
+
+        let broadcast_state = leaked_mul_state(LEN, 2);
+        let lhs_data: Vec<_> = (0..ROWS)
+            .map(|index| TrackedMulLhs {
+                index_component: index,
+                value: index + 1,
+                state: broadcast_state,
+            })
+            .collect();
+        let rhs_data: Vec<_> = (0..COLS)
+            .map(|index| TrackedMulRhs {
+                index_component: ROWS * index,
+                value: index + 2,
+            })
+            .collect();
+        let lhs = StridedView::<TrackedMulLhs, Identity>::new(&lhs_data, &[ROWS], &[1], 0).unwrap();
+        let rhs = StridedView::<TrackedMulRhs, Identity>::new(&rhs_data, &[COLS], &[1], 0).unwrap();
+        let mut destination = StridedArray::<usize>::col_major(&[ROWS, COLS]);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            broadcast_mul_into(&mut destination.view_mut(), &lhs, &[0], &rhs, &[1]).unwrap();
+        });
+        assert_eq!(broadcast_state.participants.max_active(), 2);
+        assert_eq!(broadcast_state.participants.thread_ids().len(), 2);
+        assert_exactly_once(&broadcast_state.coverage);
+        assert_eq!(destination.get(&[0, 0]), 2);
+        assert_eq!(destination.get(&[ROWS - 1, COLS - 1]), ROWS * (COLS + 1));
+    });
+}
+
+#[test]
+fn reduce_axis_remains_caller_threaded_under_all_explicit_policies() {
+    const ROWS: usize = 257;
+    const COLS: usize = 129;
+    const LEN: usize = ROWS * COLS;
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        for policy in [
+            ExecutionPolicy::Sequential,
+            ExecutionPolicy::Rayon { max_threads: two },
+        ] {
+            let source = StridedArray::<usize>::from_fn_col_major(&[ROWS, COLS], |index| {
+                index[0] + ROWS * index[1]
+            });
+            let participants = Arc::new(Participants::default());
+            let observed = Arc::clone(&participants);
+            let coverage = exact_coverage(LEN);
+            let covered = Arc::clone(&coverage);
+            let output = with_execution_policy(policy, || {
+                reduce_axis(
+                    &source.view(),
+                    1,
+                    |index| {
+                        covered[index].fetch_add(1, Ordering::SeqCst);
+                        observed.observe();
+                        index
+                    },
+                    |left, right| left + right,
+                    0usize,
+                )
+                .unwrap()
+            });
+
+            assert_eq!(participants.max_active(), 1);
+            assert_eq!(participants.thread_ids(), vec![caller]);
+            assert_exactly_once(&coverage);
+            for row in 0..ROWS {
+                let expected = COLS * row + ROWS * COLS * (COLS - 1) / 2;
+                assert_eq!(output.get(&[row]), expected);
+            }
+        }
+    });
+}
+
+#[test]
+fn bounded_tiled_transpose_scale_handles_non_tile_remainders() {
+    const ROWS: usize = 257;
+    const COLS: usize = 129;
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+    pool.install(|| {
+        let source = StridedArray::<f64>::from_fn_col_major(&[ROWS, COLS], |index| {
+            (index[0] + ROWS * index[1]) as f64
+        });
+        let mut destination = StridedArray::<f64>::col_major(&[COLS, ROWS]);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            copy_transpose_scale_into(&mut destination.view_mut(), &source.view(), 2.0).unwrap();
+        });
+
+        for i in 0..ROWS {
+            for j in 0..COLS {
+                assert_eq!(destination.get(&[j, i]), 2.0 * (i + ROWS * j) as f64);
+            }
+        }
+    });
+}
+
+#[test]
+fn nested_rayon_operation_is_sequential_inside_an_outer_worker_partition() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+    let four = NonZeroUsize::new(4).unwrap();
+
+    pool.install(|| {
+        let outer_source =
+            StridedArray::<f64>::from_fn_col_major(&[LARGE_LEN], |index| index[0] as f64);
+        let mut outer_destination = StridedArray::<f64>::col_major(&[LARGE_LEN]);
+        let nested_started = AtomicBool::new(false);
+        let nested_participants = Arc::new(Participants::default());
+        let observed = Arc::clone(&nested_participants);
+        let scope_caller = std::thread::current().id();
+
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            map_into(
+                &mut outer_destination.view_mut(),
+                &outer_source.view(),
+                |value| {
+                    if std::thread::current().id() != scope_caller
+                        && !nested_started.swap(true, Ordering::SeqCst)
+                    {
+                        let source =
+                            StridedArray::<f64>::from_fn_col_major(&[LARGE_LEN], |index| {
+                                index[0] as f64
+                            });
+                        let mut destination = StridedArray::<f64>::col_major(&[LARGE_LEN]);
+                        with_execution_policy(ExecutionPolicy::Rayon { max_threads: four }, || {
+                            map_into(
+                                &mut destination.view_mut(),
+                                &source.view(),
+                                |nested_value| {
+                                    observed.observe();
+                                    nested_value + 2.0
+                                },
+                            )
+                            .unwrap();
+                        });
+                        assert_eq!(destination.get(&[LARGE_LEN - 1]), LARGE_LEN as f64 + 1.0);
+                    }
+                    value + 1.0
+                },
+            )
+            .unwrap();
+        });
+
+        assert!(nested_started.load(Ordering::SeqCst));
+        drop(observed);
+        let participants = Arc::into_inner(nested_participants).unwrap();
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids().len(), 1);
+        assert_eq!(outer_destination.get(&[LARGE_LEN - 1]), LARGE_LEN as f64);
+    });
+}
+
+#[test]
+fn nested_sequential_policy_dominates_a_rayon_request() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let four = NonZeroUsize::new(4).unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, _) = with_execution_policy(ExecutionPolicy::Sequential, || {
+            run_large_map(ExecutionPolicy::Rayon { max_threads: four }, 1)
+        });
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+    });
+}
+
+#[test]
+fn bounded_outer_partitions_force_nested_strided_operations_to_run_sequentially() {
+    const NESTED_LEN: usize = MINTHREADLENGTH_FOR_TEST + 37;
+    const MINTHREADLENGTH_FOR_TEST: usize = 1 << 15;
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+    let active_threads = Arc::new(ActiveThreads::default());
+    let outer_rendezvous = Arc::new(Barrier::new(2));
+    let nested_waited = Arc::new([AtomicBool::new(false), AtomicBool::new(false)]);
+    let coverage: Arc<[AtomicUsize]> = (0..2 * NESTED_LEN)
+        .map(|_| AtomicUsize::new(0))
+        .collect::<Vec<_>>()
+        .into();
+
+    pool.install(|| {
+        let source = StridedArray::<usize>::from_fn_col_major(&[LARGE_LEN], |index| index[0]);
+        let mut destination = StridedArray::<usize>::col_major(&[LARGE_LEN]);
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            map_into(&mut destination.view_mut(), &source.view(), |value| {
+                let nested_operation = if value == 0 {
+                    Some(0)
+                } else if value == LARGE_LEN / 2 {
+                    Some(1)
+                } else {
+                    None
+                };
+                if let Some(nested_operation) = nested_operation {
+                    let _outer_guard = active_threads.enter();
+                    outer_rendezvous.wait();
+                    let nested_source =
+                        StridedArray::<usize>::from_fn_col_major(&[NESTED_LEN], |index| index[0]);
+                    let mut nested_destination = StridedArray::<usize>::col_major(&[NESTED_LEN]);
+                    with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+                        map_into(
+                            &mut nested_destination.view_mut(),
+                            &nested_source.view(),
+                            |nested_index| {
+                                let _nested_guard = active_threads.enter();
+                                coverage[nested_operation * NESTED_LEN + nested_index]
+                                    .fetch_add(1, Ordering::SeqCst);
+                                if !nested_waited[nested_operation].swap(true, Ordering::SeqCst) {
+                                    let deadline =
+                                        std::time::Instant::now() + Duration::from_millis(200);
+                                    while active_threads.max_active() < 3
+                                        && std::time::Instant::now() < deadline
+                                    {
+                                        std::hint::spin_loop();
+                                    }
+                                }
+                                nested_index
+                            },
+                        )
+                        .unwrap();
+                    });
+                    assert_eq!(nested_destination.get(&[NESTED_LEN - 1]), NESTED_LEN - 1);
+                }
+                value
+            })
+            .unwrap();
+        });
+        assert_eq!(destination.get(&[LARGE_LEN - 1]), LARGE_LEN - 1);
+    });
+
+    assert_eq!(
+        active_threads.max_active(),
+        2,
+        "nested strided work exceeded the outer operation's aggregate budget"
+    );
+    for (index, count) in coverage.iter().enumerate() {
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "nested logical index {index} did not execute exactly once"
+        );
+    }
+}
+
+#[test]
+fn a_panicking_scope_restores_the_previous_policy() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        let panic = std::panic::catch_unwind(|| {
+            with_execution_policy(ExecutionPolicy::Sequential, || panic!("policy scope test"));
+        });
+        assert!(panic.is_err());
+
+        let (participants, _) = run_large_map(ExecutionPolicy::AmbientRayon, 2);
+        assert!(participants.max_active() > 1);
+        assert!(participants.thread_ids().len() > 1);
+    });
+}
+
+#[test]
+fn a_panicking_worker_leaf_restores_policy_before_later_ambient_work() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let source_data: Vec<_> = (0..NON_DIVISIBLE_LEN).collect();
+        let source = StridedView::<usize, Identity>::new(
+            &source_data,
+            &[NON_DIVISIBLE_LEN],
+            &[-1],
+            (NON_DIVISIBLE_LEN - 1) as isize,
+        )
+        .unwrap();
+        let mut destination = StridedArray::<usize>::col_major(&[NON_DIVISIBLE_LEN]);
+        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+                map_into(&mut destination.view_mut(), &source, |value| {
+                    assert_ne!(value, 0, "worker leaf policy restoration test");
+                    value
+                })
+                .unwrap();
+            });
+        }));
+        assert!(panic.is_err());
+
+        let (participants, output) = run_large_map(ExecutionPolicy::AmbientRayon, 2);
+        assert!(participants.max_active() > 1);
+        assert!(participants.thread_ids().len() > 1);
+        assert_eq!(output[LARGE_LEN - 1], LARGE_LEN as f64);
+    });
+}
+
+#[test]
+fn sequential_reduction_stays_on_the_calling_thread() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, result) = run_large_reduce(ExecutionPolicy::Sequential, 1);
+        assert_eq!(result, LARGE_LEN);
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+    });
+}
+
+#[test]
+fn rayon_reduction_caps_concurrent_participants() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let (participants, result) =
+            run_large_reduce(ExecutionPolicy::Rayon { max_threads: two }, 2);
+        assert_eq!(result, LARGE_LEN);
+        assert_eq!(participants.max_active(), 2);
+        assert_eq!(participants.thread_ids().len(), 2);
+    });
+}
+
+#[test]
+fn sequential_transposed_copy_stays_on_the_calling_thread() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, output) = run_large_transposed_copy(ExecutionPolicy::Sequential, 1);
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+        assert_eq!(output[1 + 2 * 512].value, 258.0);
+    });
+}
+
+#[test]
+fn rayon_transposed_copy_caps_concurrent_participants() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let (participants, output) =
+            run_large_transposed_copy(ExecutionPolicy::Rayon { max_threads: two }, 2);
+        assert_eq!(participants.max_active(), 2);
+        assert_eq!(participants.thread_ids().len(), 2);
+        assert_eq!(output[1 + 2 * 512].value, 258.0);
+    });
+}
+
+#[test]
+fn sequential_fused_path_stays_on_the_calling_thread() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+
+    pool.install(|| {
+        let caller = std::thread::current().id();
+        let (participants, output) = run_large_fused_add(ExecutionPolicy::Sequential, 1);
+        assert_eq!(participants.max_active(), 1);
+        assert_eq!(participants.thread_ids(), vec![caller]);
+        assert_eq!(output[LARGE_LEN - 1].value, LARGE_LEN as f64 + 1.0);
+    });
+}
+
+#[test]
+fn rayon_fused_path_caps_concurrent_participants() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let two = NonZeroUsize::new(2).unwrap();
+
+    pool.install(|| {
+        let (participants, output) =
+            run_large_fused_add(ExecutionPolicy::Rayon { max_threads: two }, 2);
+        assert_eq!(participants.max_active(), 2);
+        assert_eq!(participants.thread_ids().len(), 2);
+        assert_eq!(output[LARGE_LEN - 1].value, LARGE_LEN as f64 + 1.0);
+    });
+}
+
+fn parallel_source_violations(relative: &std::path::Path, source: &str) -> Vec<String> {
+    let mut violations = Vec::new();
+    let threading_module = std::path::Path::new("threading.rs");
+    let approved_central_identifiers = [
+        ("rayon::join(", 2usize),
+        ("rayon::current_num_threads()", 1),
+        ("rayon::ThreadPool>", 1),
+        ("rayon::ThreadPoolBuilder::new()", 1),
+        ("strided_perm::copy_into_par(", 1),
+        ("strided_perm::copy_into(", 1),
+        ("strided_perm::copy_into_col_major(", 1),
+    ];
+    let mut central_counts = vec![0usize; approved_central_identifiers.len()];
+
+    for (line_index, line) in source.lines().enumerate() {
+        let line_number = line_index + 1;
+        let code = line.split("//").next().unwrap_or("");
+        if code.trim().is_empty() {
+            continue;
+        }
+        let has_owned_identifier = ["rayon", "strided_perm"].iter().any(|identifier| {
+            code.split(|character: char| !character.is_alphanumeric() && character != '_')
+                .any(|token| token == *identifier)
+        });
+        if !has_owned_identifier {
+            continue;
+        }
+
+        if relative != threading_module {
+            violations.push(format!(
+                "{}:{line_number}: parallel-runtime identifier exists outside threading.rs",
+                relative.display()
+            ));
+            continue;
+        }
+
+        let mut unapproved = code.to_owned();
+        for (index, (approved, _)) in approved_central_identifiers.iter().enumerate() {
+            let count = unapproved.matches(approved).count();
+            central_counts[index] += count;
+            unapproved = unapproved.replace(approved, "");
+        }
+        if ["rayon", "strided_perm"].iter().any(|identifier| {
+            unapproved
+                .split(|character: char| !character.is_alphanumeric() && character != '_')
+                .any(|token| token == *identifier)
+        }) {
+            violations.push(format!(
+                "{}:{line_number}: unapproved central parallel-runtime API",
+                relative.display()
+            ));
+        }
+    }
+
+    if relative == threading_module {
+        for ((approved, expected), actual) in
+            approved_central_identifiers.iter().zip(central_counts)
+        {
+            if actual != *expected {
+                violations.push(format!(
+                    "threading.rs: expected {expected} call(s) to {approved}, found {actual}"
+                ));
+            }
+        }
+    }
+
+    violations
+}
+
+#[test]
+fn scanner_rejects_parallel_bypass_mutations() {
+    let bypasses = [
+        "use rayon::slice::ParallelSliceMut; values.par_sort_unstable();",
+        "rayon::in_place_scope(|scope| work(scope));",
+        "rayon::yield_now();",
+        "use strided_perm as perm; perm::copy_into(dest, src);",
+    ];
+    for mutation in bypasses {
+        assert!(
+            !parallel_source_violations(std::path::Path::new("mutated.rs"), mutation).is_empty(),
+            "scanner accepted parallel bypass mutation: {mutation}"
+        );
+    }
+
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let threading = std::fs::read_to_string(source_root.join("threading.rs")).unwrap();
+    let extra_central_call = format!("{threading}\nfn bypass() {{ rayon::join(|| (), || ()); }}\n");
+    assert!(
+        !parallel_source_violations(std::path::Path::new("threading.rs"), &extra_central_call)
+            .is_empty()
+    );
+}
+
+#[test]
+fn production_parallelism_is_routed_through_the_execution_policy_layer() {
+    fn visit(directory: &std::path::Path, files: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                visit(&path, files);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    visit(&source_root, &mut files);
+
+    let mut violations = Vec::new();
+    for path in files {
+        let source = std::fs::read_to_string(&path).unwrap();
+        let relative = path.strip_prefix(&source_root).unwrap();
+        violations.extend(parallel_source_violations(relative, &source));
+    }
+    assert!(violations.is_empty(), "{}", violations.join("\n"));
+}


### PR DESCRIPTION
## Summary
- restore `ExecutionPolicy` and `with_execution_policy` in `strided-kernel` on current `main`
- route map/reduce/fused/copy parallel fanout through the explicit policy layer
- keep `reduce_serial` serial for erased reduce `ExecContext::serial()` callers

## Why
`tenferro-rs` currently pins an explicit-policy strided commit. Updating it to the new gathered mainline commit would otherwise drop the serial/inner/outer threading contract and let view kernels fan out through ambient Rayon.

## Validation
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=64 cargo test -p strided-kernel --features parallel`
- `CARGO_BUILD_JOBS=64 cargo test --workspace`