### PR TITLE
Add erased axis reduction plans

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -21,7 +21,7 @@ use num_traits::{One, Zero};
 use crate::{
     fused_elementwise_into, CopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
     FusedPlan, FusedScalar, GatherIndex, GatherPlan, GatherSpec, KernelDType, RawStridedMut,
-    RawStridedRef, Result, StridedError, StridedView, StridedViewMut,
+    RawStridedRef, Result, StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -115,17 +115,70 @@ pub enum ReduceOp {
     Product,
 }
 
-/// Dtype-erased full-reduction wrapper.
+/// Dtype-erased reduction wrapper.
 ///
-/// This is the erased replay boundary for full-tensor reductions whose result
-/// is one scalar. It supports only operations with an unambiguous identity value
-/// in the selected dtype.
+/// This is the erased replay boundary for full-tensor scalar reductions and
+/// axis reductions with a fixed output layout. It supports only operations with
+/// an unambiguous identity value in the selected dtype.
 #[derive(Clone, Debug)]
 pub struct ErasedReducePlan {
     dtype: KernelDType,
     op: ReduceOp,
-    dims: Vec<usize>,
-    src_strides: Vec<isize>,
+    layout: ReduceLayout,
+}
+
+#[derive(Clone, Debug)]
+enum ReduceLayout {
+    Full {
+        dims: Vec<usize>,
+        src_strides: Vec<isize>,
+    },
+    Axes {
+        src_dims: Vec<usize>,
+        src_strides: Vec<isize>,
+        dest_dims: Vec<usize>,
+        dest_strides: Vec<isize>,
+        axes: Vec<usize>,
+        kept_axes: Vec<usize>,
+        reduce_dims: Vec<usize>,
+        dest_total: usize,
+        reduce_total: usize,
+    },
+}
+
+impl ReduceLayout {
+    fn src_dims(&self) -> &[usize] {
+        match self {
+            Self::Full { dims, .. } => dims,
+            Self::Axes { src_dims, .. } => src_dims,
+        }
+    }
+
+    fn src_strides(&self) -> &[isize] {
+        match self {
+            Self::Full { src_strides, .. } | Self::Axes { src_strides, .. } => src_strides,
+        }
+    }
+
+    fn check_src_layout(&self, src: &ErasedRawStridedRef<'_>) -> Result<()> {
+        if src.dims() != self.src_dims() || src.strides() != self.src_strides() {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AxesLayout<'a> {
+    src_dims: &'a [usize],
+    src_strides: &'a [isize],
+    dest_dims: &'a [usize],
+    dest_strides: &'a [isize],
+    axes: &'a [usize],
+    kept_axes: &'a [usize],
+    reduce_dims: &'a [usize],
+    dest_total: usize,
+    reduce_total: usize,
 }
 
 /// Dtype-erased gather wrapper.
@@ -221,8 +274,73 @@ impl ErasedReducePlan {
         Ok(Self {
             dtype,
             op,
-            dims: dims.to_vec(),
-            src_strides: src_strides.to_vec(),
+            layout: ReduceLayout::Full {
+                dims: dims.to_vec(),
+                src_strides: src_strides.to_vec(),
+            },
+        })
+    }
+
+    /// Validate and store an axis-reduction plan for one dtype and fixed source/output layouts.
+    ///
+    /// `axes` names the source axes reduced away. Output dimensions must be the
+    /// remaining source dimensions in source-axis order. When all axes are
+    /// reduced, any output layout with exactly one reachable element is accepted.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile_axes(
+        dtype: KernelDType,
+        op: ReduceOp,
+        src_dims: &[usize],
+        src_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        axes: &[usize],
+    ) -> Result<Self> {
+        check_reduce_dtype(dtype)?;
+        if src_dims.len() != src_strides.len() || dest_dims.len() != dest_strides.len() {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        checked_total_len(src_dims)?;
+        let dest_total = checked_total_len(dest_dims)?;
+        if !crate::fused::is_injective_layout(dest_dims, dest_strides) {
+            return Err(StridedError::NonInjectiveOutputLayout);
+        }
+        validate_unique_axes(axes, src_dims.len())?;
+
+        let kept_axes: Vec<usize> = (0..src_dims.len())
+            .filter(|axis| !axes.contains(axis))
+            .collect();
+        let expected_dest_dims: Vec<usize> = kept_axes.iter().map(|&axis| src_dims[axis]).collect();
+        if expected_dest_dims.is_empty() {
+            if dest_total != 1 {
+                return Err(StridedError::ShapeMismatch(
+                    dest_dims.to_vec(),
+                    expected_dest_dims,
+                ));
+            }
+        } else if dest_dims != expected_dest_dims.as_slice() {
+            return Err(StridedError::ShapeMismatch(
+                dest_dims.to_vec(),
+                expected_dest_dims,
+            ));
+        }
+
+        let reduce_dims = axes.iter().map(|&axis| src_dims[axis]).collect::<Vec<_>>();
+        let reduce_total = checked_total_len(&reduce_dims)?;
+        Ok(Self {
+            dtype,
+            op,
+            layout: ReduceLayout::Axes {
+                src_dims: src_dims.to_vec(),
+                src_strides: src_strides.to_vec(),
+                dest_dims: dest_dims.to_vec(),
+                dest_strides: dest_strides.to_vec(),
+                axes: axes.to_vec(),
+                kept_axes,
+                reduce_dims,
+                dest_total,
+                reduce_total,
+            },
         })
     }
 
@@ -236,7 +354,7 @@ impl ErasedReducePlan {
         self.op
     }
 
-    /// Execute a full reduction into a scalar erased output descriptor.
+    /// Execute the reduction into an erased output descriptor.
     pub fn execute(
         &self,
         ctx: &ExecContext,
@@ -245,22 +363,34 @@ impl ErasedReducePlan {
     ) -> Result<()> {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, src.dtype())?;
-        if src.dims() != self.dims.as_slice() || src.strides() != self.src_strides.as_slice() {
-            return Err(StridedError::PlanLayoutMismatch);
-        }
-        let dest_len = checked_total_len(dest.dims())?;
-        if dest_len != 1 {
-            return Err(StridedError::RankMismatch(dest_len, 1));
+        self.layout.check_src_layout(src)?;
+        match &self.layout {
+            ReduceLayout::Full { .. } => {
+                let dest_len = checked_total_len(dest.dims())?;
+                if dest_len != 1 {
+                    return Err(StridedError::RankMismatch(dest_len, 1));
+                }
+            }
+            ReduceLayout::Axes {
+                dest_dims,
+                dest_strides,
+                ..
+            } => {
+                if dest.dims() != dest_dims.as_slice() || dest.strides() != dest_strides.as_slice()
+                {
+                    return Err(StridedError::PlanLayoutMismatch);
+                }
+            }
         }
         dest.validate_data_if_needed()?;
 
         let result = match self.dtype {
-            KernelDType::F32 => execute_reduce::<f32>(self.op, ctx, dest, src),
-            KernelDType::F64 => execute_reduce::<f64>(self.op, ctx, dest, src),
-            KernelDType::I32 => execute_reduce::<i32>(self.op, ctx, dest, src),
-            KernelDType::I64 => execute_reduce::<i64>(self.op, ctx, dest, src),
-            KernelDType::C32 => execute_reduce::<Complex32>(self.op, ctx, dest, src),
-            KernelDType::C64 => execute_reduce::<Complex64>(self.op, ctx, dest, src),
+            KernelDType::F32 => dispatch_reduce::<f32>(self.op, &self.layout, ctx, dest, src),
+            KernelDType::F64 => dispatch_reduce::<f64>(self.op, &self.layout, ctx, dest, src),
+            KernelDType::I32 => dispatch_reduce::<i32>(self.op, &self.layout, ctx, dest, src),
+            KernelDType::I64 => dispatch_reduce::<i64>(self.op, &self.layout, ctx, dest, src),
+            KernelDType::C32 => dispatch_reduce::<Complex32>(self.op, &self.layout, ctx, dest, src),
+            KernelDType::C64 => dispatch_reduce::<Complex64>(self.op, &self.layout, ctx, dest, src),
             _ => Err(StridedError::UnsupportedDType {
                 dtype: self.dtype.label(),
             }),
@@ -521,6 +651,98 @@ where
     Ok(())
 }
 
+fn dispatch_reduce<T>(
+    op: ReduceOp,
+    layout: &ReduceLayout,
+    ctx: &ExecContext,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+{
+    match layout {
+        ReduceLayout::Full { .. } => execute_reduce::<T>(op, ctx, dest, src),
+        ReduceLayout::Axes {
+            src_dims,
+            src_strides,
+            dest_dims,
+            dest_strides,
+            axes,
+            kept_axes,
+            reduce_dims,
+            dest_total,
+            reduce_total,
+        } => execute_reduce_axes::<T>(
+            op,
+            dest,
+            src,
+            AxesLayout {
+                src_dims,
+                src_strides,
+                dest_dims,
+                dest_strides,
+                axes,
+                kept_axes,
+                reduce_dims,
+                dest_total: *dest_total,
+                reduce_total: *reduce_total,
+            },
+        ),
+    }
+}
+
+fn execute_reduce_axes<T>(
+    op: ReduceOp,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+    layout: AxesLayout<'_>,
+) -> Result<()>
+where
+    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+{
+    if layout.dest_total == 0 {
+        return Ok(());
+    }
+
+    let source_data = typed_slice::<T>(src.data());
+    let dest_offset_base = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+
+    let mut out_idx_storage = CoordScratch::new(layout.dest_dims.len());
+    let mut reduce_idx_storage = CoordScratch::new(layout.reduce_dims.len());
+    let mut src_idx_storage = CoordScratch::new(layout.src_dims.len());
+    let out_idx = out_idx_storage.as_mut_slice();
+    let reduce_idx = reduce_idx_storage.as_mut_slice();
+    let src_idx = src_idx_storage.as_mut_slice();
+
+    for _ in 0..layout.dest_total {
+        src_idx.fill(0);
+        for (dest_axis, &src_axis) in layout.kept_axes.iter().enumerate() {
+            src_idx[src_axis] = out_idx[dest_axis];
+        }
+
+        let mut acc = reduce_identity(op);
+        reduce_idx.fill(0);
+        for _ in 0..layout.reduce_total {
+            for (reduce_axis, &src_axis) in layout.axes.iter().enumerate() {
+                src_idx[src_axis] = reduce_idx[reduce_axis];
+            }
+            let source_offset = checked_strided_offset(src.offset(), layout.src_strides, src_idx)?;
+            let value = unsafe { *source_data.as_ptr().offset(source_offset) };
+            acc = reduce_values(op, acc, value);
+            advance_col_major_index(reduce_idx, layout.reduce_dims);
+        }
+
+        let dest_offset = checked_strided_offset(dest_offset_base, layout.dest_strides, out_idx)?;
+        unsafe {
+            *dest_data.as_mut_ptr().offset(dest_offset) = acc;
+        }
+        advance_col_major_index(out_idx, layout.dest_dims);
+    }
+    Ok(())
+}
+
 #[inline]
 fn reduce_identity<T>(op: ReduceOp) -> T
 where
@@ -540,6 +762,77 @@ where
     match op {
         ReduceOp::Sum => a + b,
         ReduceOp::Product => a * b,
+    }
+}
+
+fn validate_unique_axes(axes: &[usize], rank: usize) -> Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(StridedError::InvalidAxis { axis, rank });
+        }
+        if seen[axis] {
+            return Err(StridedError::InvalidAxis { axis, rank });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn checked_strided_offset(base: isize, strides: &[isize], index: &[usize]) -> Result<isize> {
+    let mut offset = base;
+    for (&stride, &coord) in strides.iter().zip(index.iter()) {
+        offset = checked_offset_add(offset, stride, coord)?;
+    }
+    Ok(offset)
+}
+
+fn checked_offset_add(base: isize, stride: isize, coord: usize) -> Result<isize> {
+    let coord = isize::try_from(coord).map_err(|_| StridedError::OffsetOverflow)?;
+    let scaled = stride
+        .checked_mul(coord)
+        .ok_or(StridedError::OffsetOverflow)?;
+    base.checked_add(scaled).ok_or(StridedError::OffsetOverflow)
+}
+
+fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
+    for axis in 0..index.len() {
+        index[axis] += 1;
+        if index[axis] < shape[axis] {
+            return;
+        }
+        index[axis] = 0;
+    }
+}
+
+struct CoordScratch {
+    inline: [usize; RAW_FUSED_RANK_LIMIT],
+    heap: Option<Vec<usize>>,
+    len: usize,
+}
+
+impl CoordScratch {
+    fn new(len: usize) -> Self {
+        if len <= RAW_FUSED_RANK_LIMIT {
+            Self {
+                inline: [0; RAW_FUSED_RANK_LIMIT],
+                heap: None,
+                len,
+            }
+        } else {
+            Self {
+                inline: [0; RAW_FUSED_RANK_LIMIT],
+                heap: Some(vec![0; len]),
+                len,
+            }
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [usize] {
+        match &mut self.heap {
+            Some(heap) => heap,
+            None => &mut self.inline[..self.len],
+        }
     }
 }
 

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -1,5 +1,5 @@
-//! Asserts the zero-allocation contract of `CopyPlan::execute*` for ranks at
-//! most `RAW_FUSED_RANK_LIMIT`.
+//! Asserts the zero-allocation contract of prepared erased/raw replay for ranks
+//! at most `RAW_FUSED_RANK_LIMIT`.
 //!
 //! This lives in its own integration-test binary because it installs a
 //! counting global allocator; keeping it isolated avoids counting noise from
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use num_complex::Complex64;
 use strided_kernel::{
-    CopyPlan, ErasedCopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType,
-    RawStridedMut, RawStridedRef,
+    CopyPlan, ErasedCopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan,
+    ExecContext, KernelDType, RawStridedMut, RawStridedRef, ReduceOp,
 };
 
 struct CountingAllocator;
@@ -135,4 +135,47 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased execute must not allocate");
+
+    let src_dims = [2usize; 8];
+    let src_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
+    let dest_dims = [2usize; 4];
+    let dest_strides: Vec<isize> = (0..4).map(|axis| 1isize << axis).collect();
+    let axes = [1usize, 3, 5, 7];
+    let src: Vec<f64> = (0..256).map(|value| value as f64).collect();
+    let mut dst = vec![0.0f64; 16];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &axes,
+    )
+    .unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &src_dims, &src_strides, 0)
+            .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &source)
+                .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased reduce-axis execute must not allocate"
+    );
 }

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -176,6 +176,230 @@ fn erased_reduce_plan_empty_input_returns_operation_identity() {
 }
 
 #[test]
+fn erased_reduce_plan_executes_single_axis_sum_into_strided_output() {
+    let src_dims = [2usize, 3];
+    let src_strides = [1isize, 2];
+    let input = [0.0f64, 1.0, 10.0, 11.0, 20.0, 21.0];
+    let dest_dims = [3usize];
+    let dest_strides = [1isize];
+    let mut output = [0.0f64; 3];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [1.0, 21.0, 41.0]);
+}
+
+#[test]
+fn erased_reduce_plan_executes_multi_axis_sum_with_kept_middle_axis() {
+    let src_dims = [2usize, 3, 4];
+    let src_strides = [1isize, 2, 6];
+    let input: Vec<f64> = (0..src_dims[2])
+        .flat_map(|k| {
+            (0..src_dims[1]).flat_map(move |j| {
+                (0..src_dims[0]).map(move |i| i as f64 + 10.0 * j as f64 + 100.0 * k as f64)
+            })
+        })
+        .collect();
+    let dest_dims = [3usize];
+    let dest_strides = [1isize];
+    let mut output = [0.0f64; 3];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0, 2],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::max_threads(2).unwrap(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [1204.0, 1284.0, 1364.0]);
+}
+
+#[test]
+fn erased_reduce_plan_executes_all_axes_sum_into_rank0_scalar() {
+    let src_dims = [2usize, 3];
+    let src_strides = [1isize, 2];
+    let input = [0.0f64, 1.0, 10.0, 11.0, 20.0, 21.0];
+    let dest_dims: [usize; 0] = [];
+    let dest_strides: [isize; 0] = [];
+    let mut output = [0.0f64];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0, 1],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [63.0]);
+}
+
+#[test]
+fn erased_reduce_plan_axis_reduction_writes_identity_for_empty_reduced_domain() {
+    let src_dims = [2usize, 0];
+    let src_strides = [1isize, 2];
+    let input: [f64; 0] = [];
+    let dest_dims = [2usize];
+    let dest_strides = [1isize];
+    let mut output = [9.0f64, 10.0];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Product,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[1],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [1.0, 1.0]);
+}
+
+#[test]
+fn erased_reduce_plan_axis_compile_rejects_invalid_contracts() {
+    let src_dims = [2usize, 3];
+    let src_strides = [1isize, 2];
+    let dest_dims = [3usize];
+    let dest_strides = [1isize];
+
+    let duplicate_axis = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0, 0],
+    )
+    .unwrap_err();
+    assert!(matches!(
+        duplicate_axis,
+        StridedError::InvalidAxis { axis: 0, rank: 2 }
+    ));
+
+    let shape_mismatch = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &[2],
+        &[1],
+        &[0],
+    )
+    .unwrap_err();
+    assert!(matches!(shape_mismatch, StridedError::ShapeMismatch(_, _)));
+
+    let non_injective_dest = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &[0],
+        &[0],
+    )
+    .unwrap_err();
+    assert!(matches!(
+        non_injective_dest,
+        StridedError::NonInjectiveOutputLayout
+    ));
+}
+
+#[test]
 fn erased_reduce_plan_rejects_dtype_mismatch_before_writing() {
     let dims = [2usize];
     let strides = [1isize];


### PR DESCRIPTION
## Summary
- Extends `ErasedReducePlan` with `compile_axes(...)` for fixed source/output layouts.
- Supports axis and multi-axis `Sum`/`Product` reductions over the existing erased reduction dtype set, including rank-0 scalar output and zero-length reduced domains.
- Keeps full-reduction replay behavior intact and keeps rank <= 8 axis-reduction replay scratch allocation-free.

Part of #149.

## Out of scope
- C ABI symbols or ABI handle/lifetime design.
- Parallel axis-reduction execution.
- Max/min, bool reductions, dtype promotion, or tenferro adoption/pin bump.
- Scatter/update and dynamic_slice semantics.

## Test plan
- `cargo fmt --all -- --check`
- `cargo fmt --check`
- `CARGO_BUILD_JOBS=64 cargo test -p strided-kernel --test erased_reduce_plan`
- `CARGO_BUILD_JOBS=64 cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --workspace --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json` -> 52/52 files passed
- `cargo test -p strided-rs --doc`