### PR TITLE
Expand erased fused dtype coverage

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -230,7 +230,7 @@ impl ErasedFusedPlan {
         if plan.outputs.len() != 1 {
             return Err(StridedError::RankMismatch(plan.outputs.len(), 1));
         }
-        crate::fused::validate_plan(&plan, plan.input_count, 1)?;
+        validate_fused_plan_for_dtype(dtype, &plan)?;
         Ok(Self { dtype, plan })
     }
 
@@ -266,6 +266,9 @@ impl ErasedFusedPlan {
         let result = match self.dtype {
             KernelDType::F32 => execute_fused::<f32>(&self.plan, ctx, dest, inputs),
             KernelDType::F64 => execute_fused::<f64>(&self.plan, ctx, dest, inputs),
+            KernelDType::I32 => execute_fused::<i32>(&self.plan, ctx, dest, inputs),
+            KernelDType::I64 => execute_fused::<i64>(&self.plan, ctx, dest, inputs),
+            KernelDType::Bool => execute_fused::<bool>(&self.plan, ctx, dest, inputs),
             KernelDType::C32 => execute_fused::<Complex32>(&self.plan, ctx, dest, inputs),
             KernelDType::C64 => execute_fused::<Complex64>(&self.plan, ctx, dest, inputs),
             _ => Err(StridedError::UnsupportedDType {
@@ -955,7 +958,42 @@ fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {
 
 fn check_fused_dtype(dtype: KernelDType) -> Result<()> {
     match dtype {
-        KernelDType::F32 | KernelDType::F64 | KernelDType::C32 | KernelDType::C64 => Ok(()),
+        KernelDType::F32
+        | KernelDType::F64
+        | KernelDType::I32
+        | KernelDType::I64
+        | KernelDType::Bool
+        | KernelDType::C32
+        | KernelDType::C64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
+fn validate_fused_plan_for_dtype(dtype: KernelDType, plan: &FusedPlan) -> Result<()> {
+    match dtype {
+        KernelDType::F32 => {
+            crate::fused::validate_plan_for_scalar::<f32>(plan, plan.input_count, 1)
+        }
+        KernelDType::F64 => {
+            crate::fused::validate_plan_for_scalar::<f64>(plan, plan.input_count, 1)
+        }
+        KernelDType::I32 => {
+            crate::fused::validate_plan_for_scalar::<i32>(plan, plan.input_count, 1)
+        }
+        KernelDType::I64 => {
+            crate::fused::validate_plan_for_scalar::<i64>(plan, plan.input_count, 1)
+        }
+        KernelDType::Bool => {
+            crate::fused::validate_plan_for_scalar::<bool>(plan, plan.input_count, 1)
+        }
+        KernelDType::C32 => {
+            crate::fused::validate_plan_for_scalar::<Complex32>(plan, plan.input_count, 1)
+        }
+        KernelDType::C64 => {
+            crate::fused::validate_plan_for_scalar::<Complex64>(plan, plan.input_count, 1)
+        }
         _ => Err(StridedError::UnsupportedDType {
             dtype: dtype.label(),
         }),

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -38,6 +38,33 @@ pub enum FusedOp {
     Log1p,
 }
 
+impl FusedOp {
+    #[inline]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Multiply => "multiply",
+            Self::Negate => "negate",
+            Self::Conj => "conj",
+            Self::Divide => "divide",
+            Self::Abs => "abs",
+            Self::Maximum => "maximum",
+            Self::Minimum => "minimum",
+            Self::Clamp => "clamp",
+            Self::Exp => "exp",
+            Self::Log => "log",
+            Self::Sin => "sin",
+            Self::Cos => "cos",
+            Self::Tanh => "tanh",
+            Self::Sqrt => "sqrt",
+            Self::Rsqrt => "rsqrt",
+            Self::Pow => "pow",
+            Self::Expm1 => "expm1",
+            Self::Log1p => "log1p",
+        }
+    }
+}
+
 /// One SSA instruction in a [`FusedPlan`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FusedInst {
@@ -66,6 +93,14 @@ pub struct FusedPlan {
 
 /// Scalar types supported by [`fused_elementwise_into`].
 pub trait FusedScalar: Copy + MaybeSendSync + 'static {
+    fn fused_dtype_label() -> &'static str {
+        core::any::type_name::<Self>()
+    }
+
+    fn supports_fused_op(_op: FusedOp) -> bool {
+        true
+    }
+
     fn fused_add(self, rhs: Self) -> Self;
     fn fused_multiply(self, rhs: Self) -> Self;
     fn fused_negate(self) -> Self;
@@ -85,6 +120,12 @@ pub trait FusedScalar: Copy + MaybeSendSync + 'static {
     fn fused_pow(self, rhs: Self) -> Self;
     fn fused_expm1(self) -> Self;
     fn fused_log1p(self) -> Self;
+}
+
+macro_rules! unsupported_fused_op {
+    ($op:literal, $ty:literal) => {
+        unreachable!("unsupported fused op {} for dtype {}", $op, $ty)
+    };
 }
 
 macro_rules! impl_real_fused_scalar {
@@ -302,6 +343,237 @@ impl_real_fused_scalar!(f64);
 impl_complex_fused_scalar!(num_complex::Complex32);
 impl_complex_fused_scalar!(num_complex::Complex64);
 
+macro_rules! impl_signed_integer_fused_scalar {
+    ($ty:ty, $label:literal) => {
+        impl FusedScalar for $ty {
+            #[inline]
+            fn fused_dtype_label() -> &'static str {
+                $label
+            }
+
+            #[inline]
+            fn supports_fused_op(op: FusedOp) -> bool {
+                matches!(
+                    op,
+                    FusedOp::Add
+                        | FusedOp::Multiply
+                        | FusedOp::Negate
+                        | FusedOp::Conj
+                        | FusedOp::Abs
+                        | FusedOp::Maximum
+                        | FusedOp::Minimum
+                        | FusedOp::Clamp
+                )
+            }
+
+            #[inline(always)]
+            fn fused_add(self, rhs: Self) -> Self {
+                self.wrapping_add(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_multiply(self, rhs: Self) -> Self {
+                self.wrapping_mul(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_negate(self) -> Self {
+                self.wrapping_neg()
+            }
+
+            #[inline(always)]
+            fn fused_conj(self) -> Self {
+                self
+            }
+
+            #[inline(always)]
+            fn fused_divide(self, _rhs: Self) -> Self {
+                unsupported_fused_op!("divide", $label)
+            }
+
+            #[inline(always)]
+            fn fused_abs(self) -> Self {
+                self.wrapping_abs()
+            }
+
+            #[inline(always)]
+            fn fused_maximum(self, rhs: Self) -> Self {
+                self.max(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_minimum(self, rhs: Self) -> Self {
+                self.min(rhs)
+            }
+
+            #[inline(always)]
+            fn fused_clamp(self, min: Self, max: Self) -> Self {
+                self.fused_maximum(min).fused_minimum(max)
+            }
+
+            #[inline(always)]
+            fn fused_exp(self) -> Self {
+                unsupported_fused_op!("exp", $label)
+            }
+
+            #[inline(always)]
+            fn fused_log(self) -> Self {
+                unsupported_fused_op!("log", $label)
+            }
+
+            #[inline(always)]
+            fn fused_sin(self) -> Self {
+                unsupported_fused_op!("sin", $label)
+            }
+
+            #[inline(always)]
+            fn fused_cos(self) -> Self {
+                unsupported_fused_op!("cos", $label)
+            }
+
+            #[inline(always)]
+            fn fused_tanh(self) -> Self {
+                unsupported_fused_op!("tanh", $label)
+            }
+
+            #[inline(always)]
+            fn fused_sqrt(self) -> Self {
+                unsupported_fused_op!("sqrt", $label)
+            }
+
+            #[inline(always)]
+            fn fused_rsqrt(self) -> Self {
+                unsupported_fused_op!("rsqrt", $label)
+            }
+
+            #[inline(always)]
+            fn fused_pow(self, _rhs: Self) -> Self {
+                unsupported_fused_op!("pow", $label)
+            }
+
+            #[inline(always)]
+            fn fused_expm1(self) -> Self {
+                unsupported_fused_op!("expm1", $label)
+            }
+
+            #[inline(always)]
+            fn fused_log1p(self) -> Self {
+                unsupported_fused_op!("log1p", $label)
+            }
+        }
+    };
+}
+
+impl_signed_integer_fused_scalar!(i32, "i32");
+impl_signed_integer_fused_scalar!(i64, "i64");
+
+impl FusedScalar for bool {
+    #[inline]
+    fn fused_dtype_label() -> &'static str {
+        "bool"
+    }
+
+    #[inline]
+    fn supports_fused_op(op: FusedOp) -> bool {
+        matches!(op, FusedOp::Conj)
+    }
+
+    #[inline(always)]
+    fn fused_add(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("add", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_multiply(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("multiply", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_negate(self) -> Self {
+        unsupported_fused_op!("negate", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_conj(self) -> Self {
+        self
+    }
+
+    #[inline(always)]
+    fn fused_divide(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("divide", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_abs(self) -> Self {
+        unsupported_fused_op!("abs", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_maximum(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("maximum", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_minimum(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("minimum", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_clamp(self, _min: Self, _max: Self) -> Self {
+        unsupported_fused_op!("clamp", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_exp(self) -> Self {
+        unsupported_fused_op!("exp", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_log(self) -> Self {
+        unsupported_fused_op!("log", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_sin(self) -> Self {
+        unsupported_fused_op!("sin", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_cos(self) -> Self {
+        unsupported_fused_op!("cos", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_tanh(self) -> Self {
+        unsupported_fused_op!("tanh", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_sqrt(self) -> Self {
+        unsupported_fused_op!("sqrt", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_rsqrt(self) -> Self {
+        unsupported_fused_op!("rsqrt", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_pow(self, _rhs: Self) -> Self {
+        unsupported_fused_op!("pow", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_expm1(self) -> Self {
+        unsupported_fused_op!("expm1", "bool")
+    }
+
+    #[inline(always)]
+    fn fused_log1p(self) -> Self {
+        unsupported_fused_op!("log1p", "bool")
+    }
+}
+
 #[inline]
 fn op_arity(op: FusedOp) -> usize {
     match op {
@@ -371,6 +643,23 @@ pub(crate) fn validate_plan(
         }
     }
 
+    Ok(())
+}
+
+pub(crate) fn validate_plan_for_scalar<T: FusedScalar>(
+    plan: &FusedPlan,
+    input_count: usize,
+    output_count: usize,
+) -> Result<()> {
+    validate_plan(plan, input_count, output_count)?;
+    for inst in &plan.ops {
+        if !T::supports_fused_op(inst.op) {
+            return Err(StridedError::UnsupportedOp {
+                op: inst.op.label(),
+                dtype: T::fused_dtype_label(),
+            });
+        }
+    }
     Ok(())
 }
 
@@ -845,7 +1134,7 @@ pub(crate) fn fused_elementwise_into_serial<T: FusedScalar>(
     inputs: &[StridedView<'_, T>],
     plan: &FusedPlan,
 ) -> Result<()> {
-    validate_plan(plan, inputs.len(), dests.len())?;
+    validate_plan_for_scalar::<T>(plan, inputs.len(), dests.len())?;
     validate_shapes(dests, inputs)?;
     interpret_fused_elementwise_into_serial(dests, inputs, plan)
 }
@@ -869,13 +1158,16 @@ pub(crate) fn fused_elementwise_into_serial<T: FusedScalar>(
 ///
 /// Real `Maximum`, `Minimum`, and `Clamp` use Rust `f32`/`f64` `max`/`min`
 /// semantics. Complex `Abs` returns the norm in the real component; complex
-/// `Maximum`, `Minimum`, and `Clamp` compare by squared norm.
+/// `Maximum`, `Minimum`, and `Clamp` compare by squared norm. Signed integer
+/// `Add`, `Multiply`, `Negate`, and `Abs` use wrapping arithmetic. `bool`
+/// supports only copy-like identity plans and `Conj`; ambiguous arithmetic and
+/// transcendental op/dtype pairs are rejected before any destination is written.
 pub fn fused_elementwise_into<T: FusedScalar>(
     dests: &mut [StridedViewMut<'_, T>],
     inputs: &[StridedView<'_, T>],
     plan: &FusedPlan,
 ) -> Result<()> {
-    validate_plan(plan, inputs.len(), dests.len())?;
+    validate_plan_for_scalar::<T>(plan, inputs.len(), dests.len())?;
     validate_shapes(dests, inputs)?;
     if try_static_specialization(dests, inputs, plan)? {
         return Ok(());

--- a/strided-kernel/tests/erased_fused_plan.rs
+++ b/strided-kernel/tests/erased_fused_plan.rs
@@ -202,6 +202,127 @@ fn erased_fused_plan_executes_f64_four_input_dag() {
 }
 
 #[test]
+fn erased_fused_plan_executes_i32_safe_integer_dag() {
+    let dims = [3usize];
+    let strides = [1isize];
+    let x = [-3i32, 2, 5];
+    let y = [4i32, -7, 1];
+    let lo = [0i32, 0, 0];
+    let hi = [10i32, 10, 10];
+    let mut dst = [0i32; 3];
+
+    let plan = ErasedFusedPlan::compile(
+        KernelDType::I32,
+        FusedPlan {
+            input_count: 4,
+            outputs: vec![10],
+            ops: vec![
+                FusedInst {
+                    op: FusedOp::Add,
+                    inputs: vec![0, 1],
+                },
+                FusedInst {
+                    op: FusedOp::Multiply,
+                    inputs: vec![4, 0],
+                },
+                FusedInst {
+                    op: FusedOp::Negate,
+                    inputs: vec![5],
+                },
+                FusedInst {
+                    op: FusedOp::Abs,
+                    inputs: vec![6],
+                },
+                FusedInst {
+                    op: FusedOp::Maximum,
+                    inputs: vec![7, 2],
+                },
+                FusedInst {
+                    op: FusedOp::Minimum,
+                    inputs: vec![8, 3],
+                },
+                FusedInst {
+                    op: FusedOp::Clamp,
+                    inputs: vec![9, 2, 3],
+                },
+            ],
+        },
+    )
+    .unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&x), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&y), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&lo), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&hi), &dims, &strides, 0).unwrap(),
+    ];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [3, 10, 10]);
+}
+
+#[test]
+fn erased_fused_plan_executes_i64_binary_add_transposed_layout() {
+    let dims = [2usize, 3];
+    let src_strides = [3isize, 1];
+    let dst_strides = [1isize, 2];
+    let a = [0i64, 1, 2, 10, 11, 12];
+    let b = [100i64, 101, 102, 110, 111, 112];
+    let mut dst = [0i64; 6];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::I64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&a), &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&b), &dims, &src_strides, 0).unwrap(),
+    ];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::I64,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &dst_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, [100, 120, 102, 122, 104, 124]);
+}
+
+#[test]
+fn erased_fused_plan_executes_bool_identity_conj() {
+    let dims = [3usize];
+    let strides = [1isize];
+    let input = [true, false, true];
+    let mut dst = [false; 3];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::Bool, unary_plan(FusedOp::Conj)).unwrap();
+    let inputs =
+        [
+            ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&input), &dims, &strides, 0)
+                .unwrap(),
+        ];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::Bool,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+
+    assert_eq!(dst, input);
+}
+
+#[test]
 fn erased_fused_plan_rejects_dtype_mismatch_before_writing() {
     let dims = [2usize];
     let strides = [1isize];
@@ -274,6 +395,37 @@ fn erased_fused_plan_rejects_input_dtype_mismatch_before_writing() {
 }
 
 #[test]
+fn erased_fused_plan_rejects_runtime_shape_mismatch_before_writing() {
+    let dest_dims = [2usize];
+    let input_dims = [3usize];
+    let strides = [1isize];
+    let a = [1.0f64, 2.0, 3.0];
+    let b = [4.0f64, 5.0, 6.0];
+    let mut dst = [9.0f64, 10.0];
+
+    let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
+    let inputs = [
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &input_dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &input_dims, &strides, 0).unwrap(),
+    ];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dest_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let err = plan
+        .execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap_err();
+
+    assert!(matches!(err, StridedError::ShapeMismatch(_, _)));
+    assert_eq!(dst, [9.0, 10.0]);
+}
+
+#[test]
 fn erased_fused_plan_exposes_dtype_and_plan() {
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
 
@@ -283,14 +435,30 @@ fn erased_fused_plan_exposes_dtype_and_plan() {
 }
 
 #[test]
-fn erased_fused_plan_rejects_unsupported_dtype_and_arity() {
-    let unsupported_dtype =
-        ErasedFusedPlan::compile(KernelDType::I32, binary_plan(FusedOp::Add)).unwrap_err();
+fn erased_fused_plan_rejects_unsupported_ops_by_dtype() {
+    let unsupported_integer_op =
+        ErasedFusedPlan::compile(KernelDType::I32, binary_plan(FusedOp::Divide)).unwrap_err();
     assert!(matches!(
-        unsupported_dtype,
-        StridedError::UnsupportedDType { dtype: "i32" }
+        unsupported_integer_op,
+        StridedError::UnsupportedOp {
+            op: "divide",
+            dtype: "i32"
+        }
     ));
 
+    let unsupported_bool_op =
+        ErasedFusedPlan::compile(KernelDType::Bool, binary_plan(FusedOp::Add)).unwrap_err();
+    assert!(matches!(
+        unsupported_bool_op,
+        StridedError::UnsupportedOp {
+            op: "add",
+            dtype: "bool"
+        }
+    ));
+}
+
+#[test]
+fn erased_fused_plan_rejects_unsupported_arity() {
     let too_many_inputs = FusedPlan {
         input_count: 5,
         outputs: vec![0],

--- a/strided-kernel/tests/fused_elementwise.rs
+++ b/strided-kernel/tests/fused_elementwise.rs
@@ -364,6 +364,52 @@ fn fused_real_clamp_does_not_panic_on_unordered_or_nan_bounds() {
 }
 
 #[test]
+fn fused_integer_add_uses_wrapping_arithmetic() {
+    let a = StridedArray::<i32>::from_parts(vec![i32::MAX, i32::MIN, -3], &[3], &[1], 0).unwrap();
+    let b = StridedArray::<i32>::from_parts(vec![1, -1, 2], &[3], &[1], 0).unwrap();
+    let mut out = StridedArray::<i32>::col_major(&[3]);
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan).unwrap();
+
+    assert_eq!(out.data(), &[i32::MIN, i32::MAX, -1]);
+}
+
+#[test]
+fn fused_bool_arithmetic_is_rejected_before_writing() {
+    let a = StridedArray::<bool>::from_parts(vec![true, false], &[2], &[1], 0).unwrap();
+    let b = StridedArray::<bool>::from_parts(vec![false, true], &[2], &[1], 0).unwrap();
+    let mut out = StridedArray::<bool>::from_parts(vec![true, true], &[2], &[1], 0).unwrap();
+    let plan = FusedPlan {
+        input_count: 2,
+        outputs: vec![2],
+        ops: vec![FusedInst {
+            op: FusedOp::Add,
+            inputs: vec![0, 1],
+        }],
+    };
+
+    let err = fused_elementwise_into(&mut [out.view_mut()], &[a.view(), b.view()], &plan)
+        .expect_err("bool add must fail");
+
+    assert!(matches!(
+        err,
+        StridedError::UnsupportedOp {
+            op: "add",
+            dtype: "bool"
+        }
+    ));
+    assert_eq!(out.data(), &[true, true]);
+}
+
+#[test]
 fn fused_complex_divide_matches_native_complex_division() {
     let a = StridedArray::<Complex64>::from_parts(
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -117,6 +117,13 @@ pub enum StridedError {
     #[error("unsupported dtype {dtype}")]
     UnsupportedDType { dtype: &'static str },
 
+    /// The dtype is recognized, but the selected op is not defined for it.
+    #[error("unsupported op {op} for dtype {dtype}")]
+    UnsupportedOp {
+        op: &'static str,
+        dtype: &'static str,
+    },
+
     /// The operation arity is unsupported by this entry point.
     #[error("unsupported arity {arity}; maximum supported arity is {max}")]
     UnsupportedArity { arity: usize, max: usize },


### PR DESCRIPTION
## Summary
- Extend ErasedFusedPlan replay to i32, i64, and bool where semantics are explicit.
- Add dtype-specific fused-op validation and UnsupportedOp errors before execution/writes.
- Define signed integer fused arithmetic as wrapping for supported arithmetic ops; bool supports only copy-like Conj/identity plans.

## Out of scope
- C ABI surface.
- Tenferro adoption/pin updates.

## Verification
- cargo fmt --all -- --check
- git diff --check
- CARGO_BUILD_JOBS=64 cargo test -p strided-kernel --test erased_fused_plan
- CARGO_BUILD_JOBS=64 cargo test -p strided-kernel --test fused_elementwise
- CARGO_BUILD_JOBS=64 cargo test --workspace
- CARGO_BUILD_JOBS=64 cargo test -p strided-kernel --all-features
- CARGO_BUILD_JOBS=64 cargo doc --workspace --no-deps
- CARGO_BUILD_JOBS=64 cargo llvm-cov --workspace --json --output-path coverage.json && python3 scripts/check-coverage.py coverage.json

Refs #149