### PR TITLE
Fix erased integer reduction wrapping

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -13,7 +13,7 @@
 //! Mutable erased descriptors only re-scan value-constrained dtypes, currently
 //! `bool`, after their raw bytes have escaped through `data_mut`.
 
-use core::ops::{Add, Mul};
+use core::ops::Add;
 
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
@@ -1089,7 +1089,7 @@ fn execute_reduce<T>(
     src: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+    T: ErasedReduceScalar,
 {
     let source = erased_view::<T>(src);
     let value = if ctx.is_ambient() {
@@ -1124,7 +1124,7 @@ fn dispatch_reduce<T>(
     src: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+    T: ErasedReduceScalar,
 {
     match layout {
         ReduceLayout::Full { .. } => execute_reduce::<T>(op, ctx, dest, src),
@@ -1164,7 +1164,7 @@ fn execute_reduce_axes<T>(
     layout: AxesLayout<'_>,
 ) -> Result<()>
 where
-    T: Copy + Add<Output = T> + Mul<Output = T> + One + Zero + crate::MaybeSendSync,
+    T: ErasedReduceScalar,
 {
     if layout.dest_total == 0 {
         return Ok(());
@@ -1222,13 +1222,57 @@ where
 #[inline]
 fn reduce_values<T>(op: ReduceOp, a: T, b: T) -> T
 where
-    T: Add<Output = T> + Mul<Output = T>,
+    T: ErasedReduceScalar,
 {
     match op {
-        ReduceOp::Sum => a + b,
-        ReduceOp::Product => a * b,
+        ReduceOp::Sum => T::reduce_sum(a, b),
+        ReduceOp::Product => T::reduce_product(a, b),
     }
 }
+
+trait ErasedReduceScalar: Copy + One + Zero + crate::MaybeSendSync {
+    fn reduce_sum(lhs: Self, rhs: Self) -> Self;
+    fn reduce_product(lhs: Self, rhs: Self) -> Self;
+}
+
+macro_rules! impl_default_erased_reduce_scalar {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl ErasedReduceScalar for $ty {
+                #[inline(always)]
+                fn reduce_sum(lhs: Self, rhs: Self) -> Self {
+                    lhs + rhs
+                }
+
+                #[inline(always)]
+                fn reduce_product(lhs: Self, rhs: Self) -> Self {
+                    lhs * rhs
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_wrapping_erased_reduce_scalar {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl ErasedReduceScalar for $ty {
+                #[inline(always)]
+                fn reduce_sum(lhs: Self, rhs: Self) -> Self {
+                    lhs.wrapping_add(rhs)
+                }
+
+                #[inline(always)]
+                fn reduce_product(lhs: Self, rhs: Self) -> Self {
+                    lhs.wrapping_mul(rhs)
+                }
+            }
+        )*
+    };
+}
+
+impl_default_erased_reduce_scalar!(f32, f64, Complex32, Complex64);
+impl_wrapping_erased_reduce_scalar!(i32, i64);
 
 fn validate_unique_axes(axes: &[usize], rank: usize) -> Result<()> {
     let mut seen = vec![false; rank];

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -87,6 +87,51 @@ fn erased_reduce_plan_executes_i32_sum_with_ambient_context() {
 }
 
 #[test]
+fn erased_reduce_plan_integer_full_reductions_use_wrapping_arithmetic() {
+    let dims = [2usize];
+    let strides = [1isize];
+
+    let input_i32 = [i32::MAX, 1];
+    let mut sum_output = [0i32];
+    let sum_plan =
+        ErasedReducePlan::compile(KernelDType::I32, ReduceOp::Sum, &dims, &strides).unwrap();
+    let sum_source =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&input_i32), &dims, &strides, 0)
+            .unwrap();
+    let mut sum_dest =
+        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut sum_output), &[], &[], 0)
+            .unwrap();
+
+    sum_plan
+        .execute(&ExecContext::serial(), &mut sum_dest, &sum_source)
+        .unwrap();
+
+    assert_eq!(sum_output, [i32::MIN]);
+
+    let input_i64 = [i64::MAX, 2];
+    let mut product_output = [0i64];
+    let product_plan =
+        ErasedReducePlan::compile(KernelDType::I64, ReduceOp::Product, &dims, &strides).unwrap();
+    let product_source =
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&input_i64), &dims, &strides, 0)
+            .unwrap();
+    let mut product_dest = ErasedRawStridedMut::new(
+        KernelDType::I64,
+        as_bytes_mut(&mut product_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    product_plan
+        .execute(&ExecContext::serial(), &mut product_dest, &product_source)
+        .unwrap();
+
+    assert_eq!(product_output, [i64::MAX.wrapping_mul(2)]);
+}
+
+#[test]
 fn erased_reduce_plan_executes_remaining_supported_dtype_set() {
     let dims = [2usize];
     let strides = [1isize];
@@ -215,6 +260,48 @@ fn erased_reduce_plan_executes_single_axis_sum_into_strided_output() {
         .unwrap();
 
     assert_eq!(output, [1.0, 21.0, 41.0]);
+}
+
+#[test]
+fn erased_reduce_plan_integer_axis_reductions_use_wrapping_arithmetic() {
+    let src_dims = [2usize, 2];
+    let src_strides = [1isize, 2];
+    let dest_dims = [2usize];
+    let dest_strides = [1isize];
+    let input = [i32::MAX, 1, i32::MIN, -1];
+    let mut output = [0i32; 2];
+
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::I32,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::I32,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [i32::MIN, i32::MAX]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- route erased reduction arithmetic through a private scalar trait
- keep float and complex reductions on ordinary arithmetic
- use wrapping add/mul for `i32` and `i64` erased reductions

## Root Cause

`ErasedReducePlan` dispatched integer reductions into a generic `reduce_values` helper using `a + b` and `a * b`. In debug builds this panicked on integer overflow, while downstream tenferro CPU integer sum/product reductions require explicit two's-complement wrapping semantics.

## Validation

- `cargo fmt --check`
- `CARGO_BUILD_JOBS=64 cargo test -p strided-kernel`
- `CARGO_BUILD_JOBS=64 cargo test`