### PR TITLE
Add erased static indexing plans

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -19,10 +19,11 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use crate::{
-    fused_elementwise_into, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
+    fused_elementwise_into, ConcatenatePlan, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
     ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, FusedPlan, FusedScalar, GatherIndex,
-    GatherPlan, GatherSpec, KernelDType, RawStridedMut, RawStridedRef, Result, ScatterPlan,
-    ScatterSpec, StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
+    GatherPlan, GatherSpec, KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result,
+    ReversePlan, ScatterPlan, ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut,
+    RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -32,6 +33,34 @@ const ERASED_FUSED_INPUT_LIMIT: usize = 4;
 pub struct ErasedCopyPlan {
     dtype: KernelDType,
     plan: CopyPlan,
+}
+
+/// Dtype-erased static-slice wrapper.
+#[derive(Clone, Debug)]
+pub struct ErasedSlicePlan {
+    dtype: KernelDType,
+    plan: SlicePlan,
+}
+
+/// Dtype-erased reverse wrapper.
+#[derive(Clone, Debug)]
+pub struct ErasedReversePlan {
+    dtype: KernelDType,
+    plan: ReversePlan,
+}
+
+/// Dtype-erased pad wrapper.
+#[derive(Clone, Debug)]
+pub struct ErasedPadPlan {
+    dtype: KernelDType,
+    plan: PadPlan,
+}
+
+/// Dtype-erased concatenate wrapper.
+#[derive(Clone, Debug)]
+pub struct ErasedConcatenatePlan {
+    dtype: KernelDType,
+    plan: ConcatenatePlan,
 }
 
 impl ErasedCopyPlan {
@@ -94,6 +123,281 @@ impl ErasedCopyPlan {
             });
         }
         Ok(())
+    }
+}
+
+impl ErasedSlicePlan {
+    /// Validate and store a static slice plan for one dtype and fixed layout set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile(
+        dtype: KernelDType,
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        starts: &[usize],
+        limits: &[usize],
+        slice_strides: &[usize],
+    ) -> Result<Self> {
+        check_static_indexing_dtype(dtype)?;
+        Ok(Self {
+            dtype,
+            plan: SlicePlan::compile(
+                operand_dims,
+                operand_strides,
+                dest_dims,
+                dest_strides,
+                starts,
+                limits,
+                slice_strides,
+            )?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &SlicePlan {
+        &self.plan
+    }
+
+    /// Execute a static slice into an erased output descriptor.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        operand: &ErasedRawStridedRef<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_slice::<f32>(&self.plan, dest, operand),
+            KernelDType::F64 => execute_slice::<f64>(&self.plan, dest, operand),
+            KernelDType::I32 => execute_slice::<i32>(&self.plan, dest, operand),
+            KernelDType::I64 => execute_slice::<i64>(&self.plan, dest, operand),
+            KernelDType::Bool => execute_slice::<bool>(&self.plan, dest, operand),
+            KernelDType::C32 => execute_slice::<Complex32>(&self.plan, dest, operand),
+            KernelDType::C64 => execute_slice::<Complex64>(&self.plan, dest, operand),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: static slice writes values read from a descriptor with
+            // the same dtype and already-validated byte representation.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
+impl ErasedReversePlan {
+    /// Validate and store a reverse plan for one dtype and fixed layout set.
+    pub fn compile(
+        dtype: KernelDType,
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_strides: &[isize],
+        axes: &[usize],
+    ) -> Result<Self> {
+        check_static_indexing_dtype(dtype)?;
+        Ok(Self {
+            dtype,
+            plan: ReversePlan::compile(operand_dims, operand_strides, dest_strides, axes)?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &ReversePlan {
+        &self.plan
+    }
+
+    /// Execute a reverse into an erased output descriptor.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        operand: &ErasedRawStridedRef<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_reverse::<f32>(&self.plan, dest, operand),
+            KernelDType::F64 => execute_reverse::<f64>(&self.plan, dest, operand),
+            KernelDType::I32 => execute_reverse::<i32>(&self.plan, dest, operand),
+            KernelDType::I64 => execute_reverse::<i64>(&self.plan, dest, operand),
+            KernelDType::Bool => execute_reverse::<bool>(&self.plan, dest, operand),
+            KernelDType::C32 => execute_reverse::<Complex32>(&self.plan, dest, operand),
+            KernelDType::C64 => execute_reverse::<Complex64>(&self.plan, dest, operand),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: reverse writes values read from a descriptor with the
+            // same dtype and already-validated byte representation.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
+impl ErasedPadPlan {
+    /// Validate and store a pad plan for one dtype and fixed layout set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile(
+        dtype: KernelDType,
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        edge_padding_low: &[i64],
+        edge_padding_high: &[i64],
+        interior_padding: &[i64],
+    ) -> Result<Self> {
+        check_static_indexing_dtype(dtype)?;
+        Ok(Self {
+            dtype,
+            plan: PadPlan::compile(
+                operand_dims,
+                operand_strides,
+                dest_dims,
+                dest_strides,
+                edge_padding_low,
+                edge_padding_high,
+                interior_padding,
+            )?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &PadPlan {
+        &self.plan
+    }
+
+    /// Execute pad into an erased output descriptor using one dtype scalar as fill.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        operand: &ErasedRawStridedRef<'_>,
+        fill: &[u8],
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        validate_scalar_bytes(self.dtype, fill)?;
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_pad::<f32>(&self.plan, dest, operand, fill),
+            KernelDType::F64 => execute_pad::<f64>(&self.plan, dest, operand, fill),
+            KernelDType::I32 => execute_pad::<i32>(&self.plan, dest, operand, fill),
+            KernelDType::I64 => execute_pad::<i64>(&self.plan, dest, operand, fill),
+            KernelDType::Bool => execute_pad::<bool>(&self.plan, dest, operand, fill),
+            KernelDType::C32 => execute_pad::<Complex32>(&self.plan, dest, operand, fill),
+            KernelDType::C64 => execute_pad::<Complex64>(&self.plan, dest, operand, fill),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: pad writes either the validated fill scalar or values
+            // read from a descriptor with the same validated dtype.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
+    }
+}
+
+impl ErasedConcatenatePlan {
+    /// Validate and store a concatenate plan for one dtype and fixed layout set.
+    pub fn compile(
+        dtype: KernelDType,
+        input_dims: &[&[usize]],
+        input_strides: &[&[isize]],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        axis: usize,
+    ) -> Result<Self> {
+        check_static_indexing_dtype(dtype)?;
+        Ok(Self {
+            dtype,
+            plan: ConcatenatePlan::compile(
+                input_dims,
+                input_strides,
+                dest_dims,
+                dest_strides,
+                axis,
+            )?,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn plan(&self) -> &ConcatenatePlan {
+        &self.plan
+    }
+
+    /// Execute concatenate into an erased output descriptor.
+    pub fn execute(
+        &self,
+        _ctx: &ExecContext,
+        dest: &mut ErasedRawStridedMut<'_>,
+        inputs: &[ErasedRawStridedRef<'_>],
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        for input in inputs {
+            check_dtype(self.dtype, input.dtype())?;
+        }
+        dest.validate_data_if_needed()?;
+
+        let result = match self.dtype {
+            KernelDType::F32 => execute_concatenate::<f32>(&self.plan, dest, inputs),
+            KernelDType::F64 => execute_concatenate::<f64>(&self.plan, dest, inputs),
+            KernelDType::I32 => execute_concatenate::<i32>(&self.plan, dest, inputs),
+            KernelDType::I64 => execute_concatenate::<i64>(&self.plan, dest, inputs),
+            KernelDType::Bool => execute_concatenate::<bool>(&self.plan, dest, inputs),
+            KernelDType::C32 => execute_concatenate::<Complex32>(&self.plan, dest, inputs),
+            KernelDType::C64 => execute_concatenate::<Complex64>(&self.plan, dest, inputs),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        };
+        if result.is_ok() {
+            // SAFETY: concatenate writes values read from descriptors with
+            // the same dtype and already-validated byte representation.
+            unsafe {
+                dest.assume_data_valid();
+            }
+        }
+        result
     }
 }
 
@@ -1052,6 +1356,38 @@ fn check_scatter_value_dtype(dtype: KernelDType) -> Result<()> {
     }
 }
 
+fn check_static_indexing_dtype(dtype: KernelDType) -> Result<()> {
+    match dtype {
+        KernelDType::F32
+        | KernelDType::F64
+        | KernelDType::I32
+        | KernelDType::I64
+        | KernelDType::Bool
+        | KernelDType::C32
+        | KernelDType::C64 => Ok(()),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    }
+}
+
+fn validate_scalar_bytes(dtype: KernelDType, bytes: &[u8]) -> Result<()> {
+    let element_size = dtype.size_of();
+    if bytes.len() != element_size {
+        return Err(StridedError::ByteLengthMismatch {
+            dtype: dtype.label(),
+            byte_len: bytes.len(),
+            element_size,
+        });
+    }
+    if dtype.requires_valid_byte_values() {
+        if let Some(&value) = bytes.iter().find(|&&value| value > 1) {
+            return Err(StridedError::InvalidBoolByte { value });
+        }
+    }
+    Ok(())
+}
+
 fn checked_total_len(dims: &[usize]) -> Result<usize> {
     if dims.is_empty() {
         return Ok(1);
@@ -1080,6 +1416,116 @@ where
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.execute(&mut dest, &source)
+}
+
+fn execute_slice<T>(
+    plan: &SlicePlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute(&mut dest_ref, &operand_ref)
+}
+
+fn execute_reverse<T>(
+    plan: &ReversePlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute(&mut dest_ref, &operand_ref)
+}
+
+fn execute_pad<T>(
+    plan: &PadPlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+    fill: &[u8],
+) -> Result<()>
+where
+    T: Copy,
+{
+    let fill = read_unaligned_scalar::<T>(fill);
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute(&mut dest_ref, &operand_ref, fill)
+}
+
+fn execute_concatenate<T>(
+    plan: &ConcatenatePlan,
+    dest: &mut ErasedRawStridedMut<'_>,
+    inputs: &[ErasedRawStridedRef<'_>],
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    if inputs.len() != plan.input_count() {
+        return Err(StridedError::RankMismatch(inputs.len(), plan.input_count()));
+    }
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.check_dest_layout(&dest_ref)?;
+
+    for (position, input) in inputs.iter().enumerate() {
+        let input_data = typed_slice::<T>(input.data());
+        let input_ref = unsafe {
+            RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
+        };
+        plan.check_input_layout(position, &input_ref)?;
+        plan.execute_segment(position, &mut dest_ref, &input_ref)?;
+    }
+    Ok(())
 }
 
 fn execute_reduce<T>(
@@ -1686,4 +2132,11 @@ fn typed_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
             bytes.len() / core::mem::size_of::<T>(),
         )
     }
+}
+
+fn read_unaligned_scalar<T>(bytes: &[u8]) -> T
+where
+    T: Copy,
+{
+    unsafe { core::ptr::read_unaligned(bytes.as_ptr().cast::<T>()) }
 }

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -64,6 +64,7 @@ mod gather_plan;
 mod kernel;
 mod order;
 mod simd;
+mod static_indexing_plan;
 mod threading;
 
 mod maybe_sync;
@@ -127,14 +128,16 @@ pub use raw_ops::{
 // ============================================================================
 pub use copy_plan::CopyPlan;
 pub use erased::{
-    ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedFusedPlan,
-    ErasedGatherPlan, ErasedReducePlan, ErasedScatterPlan, ReduceOp,
+    ErasedConcatenatePlan, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
+    ErasedFusedPlan, ErasedGatherPlan, ErasedPadPlan, ErasedReducePlan, ErasedReversePlan,
+    ErasedScatterPlan, ErasedSlicePlan, ReduceOp,
 };
 pub use exec_context::ExecContext;
 pub use gather_plan::{
     DynamicSlicePlan, DynamicUpdateSlicePlan, GatherIndex, GatherPlan, GatherSpec, ScatterPlan,
     ScatterSpec,
 };
+pub use static_indexing_plan::{ConcatenatePlan, PadPlan, ReversePlan, SlicePlan};
 
 // ============================================================================
 // Reduce operations

--- a/strided-kernel/src/static_indexing_plan.rs
+++ b/strided-kernel/src/static_indexing_plan.rs
@@ -1,0 +1,678 @@
+//! Prepared static-indexing plans over raw strided value layouts.
+//!
+//! This module owns reusable static indexing traversal for downstream tensor
+//! runtimes. It keeps allocation, dtype policy, and tensor-level validation out
+//! of `strided-kernel`; callers provide already-owned output buffers and fixed
+//! raw descriptors.
+
+use crate::{CopyPlan, MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError};
+
+#[cfg(feature = "parallel")]
+type AxisVec<T> = smallvec::SmallVec<[T; crate::RAW_FUSED_RANK_LIMIT]>;
+#[cfg(not(feature = "parallel"))]
+type AxisVec<T> = Vec<T>;
+
+/// A compiled static-slice traversal.
+///
+/// `compile` validates the fixed `starts`/`limits`/`slice_strides` contract and
+/// lowers replay to a strided copy from the corresponding source view.
+#[derive(Clone, Debug)]
+pub struct SlicePlan {
+    operand_dims: AxisVec<usize>,
+    operand_strides: AxisVec<isize>,
+    dest_dims: AxisVec<usize>,
+    dest_strides: AxisVec<isize>,
+    source_strides: AxisVec<isize>,
+    source_offset_delta: isize,
+    copy_plan: CopyPlan,
+}
+
+/// A compiled reverse traversal over selected axes.
+///
+/// Replay is a strided copy from a negative-stride source view.
+#[derive(Clone, Debug)]
+pub struct ReversePlan {
+    operand_dims: AxisVec<usize>,
+    operand_strides: AxisVec<isize>,
+    dest_strides: AxisVec<isize>,
+    source_strides: AxisVec<isize>,
+    source_offset_delta: isize,
+    copy_plan: CopyPlan,
+}
+
+/// A compiled pad traversal.
+///
+/// Replay first fills every destination element with the caller-provided fill
+/// scalar, then copies reachable input positions into the padded output.
+#[derive(Clone, Debug)]
+pub struct PadPlan {
+    operand_dims: AxisVec<usize>,
+    operand_strides: AxisVec<isize>,
+    dest_dims: AxisVec<usize>,
+    dest_strides: AxisVec<isize>,
+    edge_padding_low: AxisVec<i64>,
+    interior_step: AxisVec<i64>,
+    operand_total: usize,
+    dest_total: usize,
+}
+
+/// A compiled multi-input concatenate traversal.
+///
+/// Each input segment is lowered to a prepared strided copy into the
+/// corresponding destination window.
+#[derive(Clone, Debug)]
+pub struct ConcatenatePlan {
+    input_dims: Vec<AxisVec<usize>>,
+    input_strides: Vec<AxisVec<isize>>,
+    dest_dims: AxisVec<usize>,
+    dest_strides: AxisVec<isize>,
+    dest_offset_deltas: Vec<isize>,
+    copy_plans: Vec<CopyPlan>,
+}
+
+impl SlicePlan {
+    /// Compile a static slice plan for one operand layout and destination layout.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile(
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        starts: &[usize],
+        limits: &[usize],
+        slice_strides: &[usize],
+    ) -> Result<Self> {
+        let rank = operand_dims.len();
+        if operand_strides.len() != rank || dest_dims.len() != rank || dest_strides.len() != rank {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        if starts.len() != rank {
+            return Err(StridedError::RankMismatch(starts.len(), rank));
+        }
+        if limits.len() != rank {
+            return Err(StridedError::RankMismatch(limits.len(), rank));
+        }
+        if slice_strides.len() != rank {
+            return Err(StridedError::RankMismatch(slice_strides.len(), rank));
+        }
+        checked_total_len(operand_dims)?;
+        checked_total_len(dest_dims)?;
+
+        let mut expected_dest_dims: AxisVec<usize> = AxisVec::with_capacity(rank);
+        let mut source_strides: AxisVec<isize> = AxisVec::with_capacity(rank);
+        let mut source_offset_delta = 0isize;
+        for axis in 0..rank {
+            let start = starts[axis];
+            let limit = limits[axis];
+            let stride = slice_strides[axis];
+            if start > limit || limit > operand_dims[axis] || stride == 0 {
+                return Err(StridedError::InvalidAxis { axis, rank });
+            }
+            let span = limit - start;
+            expected_dest_dims.push(span.div_ceil(stride));
+            source_strides.push(checked_stride_mul(operand_strides[axis], stride)?);
+            source_offset_delta =
+                checked_offset_add(source_offset_delta, operand_strides[axis], start)?;
+        }
+        if dest_dims != &expected_dest_dims[..] {
+            return Err(StridedError::ShapeMismatch(
+                dest_dims.to_vec(),
+                expected_dest_dims.to_vec(),
+            ));
+        }
+        let copy_plan = CopyPlan::compile(dest_dims, dest_strides, &source_strides)?;
+
+        Ok(Self {
+            operand_dims: operand_dims.into(),
+            operand_strides: operand_strides.into(),
+            dest_dims: dest_dims.into(),
+            dest_strides: dest_strides.into(),
+            source_strides,
+            source_offset_delta,
+            copy_plan,
+        })
+    }
+
+    /// Execute the prepared static slice traversal.
+    pub fn execute<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, operand)?;
+        let source_offset = operand
+            .offset()
+            .checked_add(self.source_offset_delta)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let source = unsafe {
+            RawStridedRef::new_unchecked(
+                operand.data(),
+                &self.dest_dims,
+                &self.source_strides,
+                source_offset,
+            )
+        };
+        self.copy_plan.execute(dest, &source)
+    }
+
+    fn check_call<T>(
+        &self,
+        dest: &RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()> {
+        if operand.dims() != &self.operand_dims[..]
+            || operand.strides() != &self.operand_strides[..]
+            || dest.dims() != &self.dest_dims[..]
+            || dest.strides() != &self.dest_strides[..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl PadPlan {
+    /// Compile a pad plan for one operand layout and destination layout.
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile(
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        edge_padding_low: &[i64],
+        edge_padding_high: &[i64],
+        interior_padding: &[i64],
+    ) -> Result<Self> {
+        let rank = operand_dims.len();
+        if operand_strides.len() != rank || dest_dims.len() != rank || dest_strides.len() != rank {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        if edge_padding_low.len() != rank {
+            return Err(StridedError::RankMismatch(edge_padding_low.len(), rank));
+        }
+        if edge_padding_high.len() != rank {
+            return Err(StridedError::RankMismatch(edge_padding_high.len(), rank));
+        }
+        if interior_padding.len() != rank {
+            return Err(StridedError::RankMismatch(interior_padding.len(), rank));
+        }
+
+        let operand_total = checked_total_len(operand_dims)?;
+        let dest_total = checked_total_len(dest_dims)?;
+        if !crate::fused::is_injective_layout(dest_dims, dest_strides) {
+            return Err(StridedError::NonInjectiveOutputLayout);
+        }
+
+        let mut expected_dest_dims: AxisVec<usize> = AxisVec::with_capacity(rank);
+        let mut interior_step: AxisVec<i64> = AxisVec::with_capacity(rank);
+        for axis in 0..rank {
+            if interior_padding[axis] < 0 {
+                return Err(StridedError::InvalidAxis { axis, rank });
+            }
+            let step = interior_padding[axis]
+                .checked_add(1)
+                .ok_or(StridedError::OffsetOverflow)?;
+            interior_step.push(step);
+            expected_dest_dims.push(checked_pad_output_dim(
+                operand_dims[axis],
+                edge_padding_low[axis],
+                edge_padding_high[axis],
+                step,
+                axis,
+                rank,
+            )?);
+        }
+        if dest_dims != &expected_dest_dims[..] {
+            return Err(StridedError::ShapeMismatch(
+                dest_dims.to_vec(),
+                expected_dest_dims.to_vec(),
+            ));
+        }
+
+        Ok(Self {
+            operand_dims: operand_dims.into(),
+            operand_strides: operand_strides.into(),
+            dest_dims: dest_dims.into(),
+            dest_strides: dest_strides.into(),
+            edge_padding_low: edge_padding_low.into(),
+            interior_step,
+            operand_total,
+            dest_total,
+        })
+    }
+
+    /// Execute the prepared pad traversal.
+    pub fn execute<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        fill: T,
+    ) -> Result<()>
+    where
+        T: Copy,
+    {
+        self.check_call(dest, operand)?;
+        let dest_offset_base = dest.offset();
+        let dest_strides = dest.strides();
+        let dest_data = dest.data_mut();
+
+        if self.dest_total != 0 {
+            let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
+            let dest_idx = dest_idx_storage.as_mut_slice();
+            for _ in 0..self.dest_total {
+                let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, dest_idx)?;
+                unsafe {
+                    *dest_data.as_mut_ptr().offset(dest_offset) = fill;
+                }
+                advance_col_major_index(dest_idx, &self.dest_dims);
+            }
+        }
+
+        if self.operand_total == 0 {
+            return Ok(());
+        }
+
+        let operand_offset_base = operand.offset();
+        let operand_strides = operand.strides();
+        let operand_data = operand.data();
+        let mut input_idx_storage = CoordScratch::new(self.operand_dims.len());
+        let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+        let input_idx = input_idx_storage.as_mut_slice();
+        let out_idx = out_idx_storage.as_mut_slice();
+
+        for _ in 0..self.operand_total {
+            let mut in_bounds = true;
+            for axis in 0..self.operand_dims.len() {
+                let out_pos = i128::from(self.edge_padding_low[axis])
+                    + input_idx[axis] as i128 * i128::from(self.interior_step[axis]);
+                if out_pos < 0 || out_pos >= self.dest_dims[axis] as i128 {
+                    in_bounds = false;
+                    break;
+                }
+                out_idx[axis] = out_pos as usize;
+            }
+            if in_bounds {
+                let operand_offset =
+                    checked_strided_offset(operand_offset_base, operand_strides, input_idx)?;
+                let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, out_idx)?;
+                unsafe {
+                    *dest_data.as_mut_ptr().offset(dest_offset) =
+                        *operand_data.as_ptr().offset(operand_offset);
+                }
+            }
+            advance_col_major_index(input_idx, &self.operand_dims);
+        }
+        Ok(())
+    }
+
+    fn check_call<T>(
+        &self,
+        dest: &RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()> {
+        if operand.dims() != &self.operand_dims[..]
+            || operand.strides() != &self.operand_strides[..]
+            || dest.dims() != &self.dest_dims[..]
+            || dest.strides() != &self.dest_strides[..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl ConcatenatePlan {
+    /// Compile a multi-input concatenate plan for fixed input and destination layouts.
+    pub fn compile(
+        input_dims: &[&[usize]],
+        input_strides: &[&[isize]],
+        dest_dims: &[usize],
+        dest_strides: &[isize],
+        axis: usize,
+    ) -> Result<Self> {
+        if input_dims.is_empty() {
+            return Err(StridedError::UnsupportedArity {
+                arity: 0,
+                max: usize::MAX,
+            });
+        }
+        if input_dims.len() != input_strides.len() {
+            return Err(StridedError::RankMismatch(
+                input_strides.len(),
+                input_dims.len(),
+            ));
+        }
+
+        let rank = input_dims[0].len();
+        if dest_dims.len() != rank || dest_strides.len() != rank {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        if axis >= rank {
+            return Err(StridedError::InvalidAxis { axis, rank });
+        }
+        checked_total_len(dest_dims)?;
+        if !crate::fused::is_injective_layout(dest_dims, dest_strides) {
+            return Err(StridedError::NonInjectiveOutputLayout);
+        }
+
+        let mut expected_dest_dims: AxisVec<usize> = input_dims[0].into();
+        expected_dest_dims[axis] = 0;
+        let mut stored_input_dims = Vec::with_capacity(input_dims.len());
+        let mut stored_input_strides = Vec::with_capacity(input_dims.len());
+        let mut dest_offset_deltas = Vec::with_capacity(input_dims.len());
+        let mut copy_plans = Vec::with_capacity(input_dims.len());
+        let mut axis_base = 0usize;
+
+        for (dims, strides) in input_dims.iter().zip(input_strides.iter()) {
+            if dims.len() != rank {
+                return Err(StridedError::RankMismatch(dims.len(), rank));
+            }
+            if strides.len() != rank {
+                return Err(StridedError::StrideLengthMismatch);
+            }
+            checked_total_len(dims)?;
+            for dim in 0..rank {
+                if dim == axis {
+                    expected_dest_dims[axis] = expected_dest_dims[axis]
+                        .checked_add(dims[axis])
+                        .ok_or(StridedError::OffsetOverflow)?;
+                } else if dims[dim] != input_dims[0][dim] {
+                    return Err(StridedError::ShapeMismatch(
+                        dims.to_vec(),
+                        input_dims[0].to_vec(),
+                    ));
+                }
+            }
+            dest_offset_deltas.push(checked_offset_add(0, dest_strides[axis], axis_base)?);
+            axis_base = axis_base
+                .checked_add(dims[axis])
+                .ok_or(StridedError::OffsetOverflow)?;
+            copy_plans.push(CopyPlan::compile(dims, dest_strides, strides)?);
+            stored_input_dims.push((*dims).into());
+            stored_input_strides.push((*strides).into());
+        }
+
+        if dest_dims != &expected_dest_dims[..] {
+            return Err(StridedError::ShapeMismatch(
+                dest_dims.to_vec(),
+                expected_dest_dims.to_vec(),
+            ));
+        }
+
+        Ok(Self {
+            input_dims: stored_input_dims,
+            input_strides: stored_input_strides,
+            dest_dims: dest_dims.into(),
+            dest_strides: dest_strides.into(),
+            dest_offset_deltas,
+            copy_plans,
+        })
+    }
+
+    /// Execute the prepared concatenate traversal.
+    pub fn execute<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        inputs: &[RawStridedRef<'_, T>],
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_dest_layout(dest)?;
+        if inputs.len() != self.input_dims.len() {
+            return Err(StridedError::RankMismatch(
+                inputs.len(),
+                self.input_dims.len(),
+            ));
+        }
+        for (position, input) in inputs.iter().enumerate() {
+            self.check_input_layout(position, input)?;
+            self.execute_segment(position, dest, input)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_dest_layout<T>(&self, dest: &RawStridedMut<'_, T>) -> Result<()> {
+        if dest.dims() != &self.dest_dims[..] || dest.strides() != &self.dest_strides[..] {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn check_input_layout<T>(
+        &self,
+        position: usize,
+        input: &RawStridedRef<'_, T>,
+    ) -> Result<()> {
+        if position >= self.input_dims.len()
+            || input.dims() != &self.input_dims[position][..]
+            || input.strides() != &self.input_strides[position][..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn input_count(&self) -> usize {
+        self.input_dims.len()
+    }
+
+    pub(crate) fn execute_segment<T>(
+        &self,
+        position: usize,
+        dest: &mut RawStridedMut<'_, T>,
+        input: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        let segment_offset = dest
+            .offset()
+            .checked_add(self.dest_offset_deltas[position])
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest_data = dest.data_mut();
+        let mut segment = unsafe {
+            RawStridedMut::new_unchecked(
+                dest_data,
+                &self.input_dims[position],
+                &self.dest_strides,
+                segment_offset,
+            )
+        };
+        self.copy_plans[position].execute(&mut segment, input)
+    }
+}
+
+impl ReversePlan {
+    /// Compile a reverse plan for one operand layout, destination layout, and axis set.
+    pub fn compile(
+        operand_dims: &[usize],
+        operand_strides: &[isize],
+        dest_strides: &[isize],
+        axes: &[usize],
+    ) -> Result<Self> {
+        let rank = operand_dims.len();
+        if operand_strides.len() != rank || dest_strides.len() != rank {
+            return Err(StridedError::StrideLengthMismatch);
+        }
+        checked_total_len(operand_dims)?;
+
+        let mut reverse_axis: AxisVec<bool> = (0..rank).map(|_| false).collect();
+        for &axis in axes {
+            if axis >= rank {
+                return Err(StridedError::InvalidAxis { axis, rank });
+            }
+            reverse_axis[axis] = true;
+        }
+
+        let mut source_strides: AxisVec<isize> = AxisVec::with_capacity(rank);
+        let mut source_offset_delta = 0isize;
+        for axis in 0..rank {
+            if reverse_axis[axis] {
+                source_strides.push(
+                    operand_strides[axis]
+                        .checked_neg()
+                        .ok_or(StridedError::OffsetOverflow)?,
+                );
+                if operand_dims[axis] > 0 {
+                    source_offset_delta = checked_offset_add(
+                        source_offset_delta,
+                        operand_strides[axis],
+                        operand_dims[axis] - 1,
+                    )?;
+                }
+            } else {
+                source_strides.push(operand_strides[axis]);
+            }
+        }
+        let copy_plan = CopyPlan::compile(operand_dims, dest_strides, &source_strides)?;
+
+        Ok(Self {
+            operand_dims: operand_dims.into(),
+            operand_strides: operand_strides.into(),
+            dest_strides: dest_strides.into(),
+            source_strides,
+            source_offset_delta,
+            copy_plan,
+        })
+    }
+
+    /// Execute the prepared reverse traversal.
+    pub fn execute<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, operand)?;
+        let source_offset = operand
+            .offset()
+            .checked_add(self.source_offset_delta)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let source = unsafe {
+            RawStridedRef::new_unchecked(
+                operand.data(),
+                &self.operand_dims,
+                &self.source_strides,
+                source_offset,
+            )
+        };
+        self.copy_plan.execute(dest, &source)
+    }
+
+    fn check_call<T>(
+        &self,
+        dest: &RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()> {
+        if operand.dims() != &self.operand_dims[..]
+            || operand.strides() != &self.operand_strides[..]
+            || dest.dims() != &self.operand_dims[..]
+            || dest.strides() != &self.dest_strides[..]
+        {
+            return Err(StridedError::PlanLayoutMismatch);
+        }
+        Ok(())
+    }
+}
+
+fn checked_total_len(dims: &[usize]) -> Result<usize> {
+    if dims.is_empty() {
+        return Ok(1);
+    }
+    dims.iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or(StridedError::OffsetOverflow)
+}
+
+fn checked_stride_mul(stride: isize, factor: usize) -> Result<isize> {
+    let factor = isize::try_from(factor).map_err(|_| StridedError::OffsetOverflow)?;
+    stride
+        .checked_mul(factor)
+        .ok_or(StridedError::OffsetOverflow)
+}
+
+fn checked_pad_output_dim(
+    input_extent: usize,
+    edge_low: i64,
+    edge_high: i64,
+    interior_step: i64,
+    axis: usize,
+    rank: usize,
+) -> Result<usize> {
+    let base = if input_extent == 0 {
+        0i128
+    } else {
+        (input_extent as i128 - 1)
+            .checked_mul(i128::from(interior_step))
+            .and_then(|value| value.checked_add(1))
+            .ok_or(StridedError::OffsetOverflow)?
+    };
+    let dim = i128::from(edge_low)
+        .checked_add(i128::from(edge_high))
+        .and_then(|value| value.checked_add(base))
+        .ok_or(StridedError::OffsetOverflow)?;
+    usize::try_from(dim).map_err(|_| StridedError::InvalidAxis { axis, rank })
+}
+
+fn checked_strided_offset(base: isize, strides: &[isize], index: &[usize]) -> Result<isize> {
+    let mut offset = base;
+    for (&stride, &coord) in strides.iter().zip(index.iter()) {
+        offset = checked_offset_add(offset, stride, coord)?;
+    }
+    Ok(offset)
+}
+
+fn checked_offset_add(base: isize, stride: isize, coord: usize) -> Result<isize> {
+    let coord = isize::try_from(coord).map_err(|_| StridedError::OffsetOverflow)?;
+    let scaled = stride
+        .checked_mul(coord)
+        .ok_or(StridedError::OffsetOverflow)?;
+    base.checked_add(scaled).ok_or(StridedError::OffsetOverflow)
+}
+
+fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
+    for axis in 0..index.len() {
+        index[axis] += 1;
+        if index[axis] < shape[axis] {
+            return;
+        }
+        index[axis] = 0;
+    }
+}
+
+struct CoordScratch {
+    inline: [usize; crate::RAW_FUSED_RANK_LIMIT],
+    heap: Option<Vec<usize>>,
+    len: usize,
+}
+
+impl CoordScratch {
+    fn new(len: usize) -> Self {
+        if len <= crate::RAW_FUSED_RANK_LIMIT {
+            Self {
+                inline: [0; crate::RAW_FUSED_RANK_LIMIT],
+                heap: None,
+                len,
+            }
+        } else {
+            Self {
+                inline: [0; crate::RAW_FUSED_RANK_LIMIT],
+                heap: Some(vec![0; len]),
+                len,
+            }
+        }
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [usize] {
+        match &mut self.heap {
+            Some(heap) => heap,
+            None => &mut self.inline[..self.len],
+        }
+    }
+}

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -10,8 +10,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use num_complex::Complex64;
 use strided_kernel::{
-    CopyPlan, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
-    ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ErasedScatterPlan, ExecContext,
+    CopyPlan, ErasedConcatenatePlan, ErasedCopyPlan, ErasedDynamicSlicePlan,
+    ErasedDynamicUpdateSlicePlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef,
+    ErasedReducePlan, ErasedReversePlan, ErasedScatterPlan, ErasedSlicePlan, ExecContext,
     KernelDType, RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec,
 };
 
@@ -376,4 +377,170 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased scatter execute must not allocate");
+
+    let starts_usize = [0usize; 8];
+    let limits = [2usize; 8];
+    let slice_steps = [1usize; 8];
+    let mut dst = vec![0.0f64; 256];
+    let plan = ErasedSlicePlan::compile(
+        KernelDType::F64,
+        &src_dims,
+        &src_strides,
+        &src_dims,
+        &src_strides,
+        &starts_usize,
+        &limits,
+        &slice_steps,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &source)
+                .unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "erased slice execute must not allocate");
+
+    let axes: Vec<usize> = (0..8).collect();
+    let mut dst = vec![0.0f64; 256];
+    let plan = ErasedReversePlan::compile(
+        KernelDType::F64,
+        &src_dims,
+        &src_strides,
+        &src_strides,
+        &axes,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &source)
+                .unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "erased reverse execute must not allocate");
+
+    let edge = [0i64; 8];
+    let interior = [0i64; 8];
+    let fill = [0.0f64];
+    let mut dst = vec![0.0f64; 256];
+    let plan = ErasedPadPlan::compile(
+        KernelDType::F64,
+        &src_dims,
+        &src_strides,
+        &src_dims,
+        &src_strides,
+        &edge,
+        &edge,
+        &interior,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source, as_bytes(&fill))
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &source, as_bytes(&fill))
+                .unwrap();
+        }
+    });
+    assert_eq!(allocations, 0, "erased pad execute must not allocate");
+
+    let mut left_dims = [2usize; 8];
+    left_dims[0] = 1;
+    let right_dims = left_dims;
+    let left_strides = col_major_strides(&left_dims);
+    let right_strides = left_strides.clone();
+    let left: Vec<f64> = (0..128).map(|value| value as f64).collect();
+    let right: Vec<f64> = (128..256).map(|value| value as f64).collect();
+    let mut dst = vec![0.0f64; 256];
+    let input_dims = [&left_dims[..], &right_dims[..]];
+    let input_strides = [&left_strides[..], &right_strides[..]];
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::F64,
+        &input_dims,
+        &input_strides,
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let left_ref = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&left),
+        &left_dims,
+        &left_strides,
+        0,
+    )
+    .unwrap();
+    let right_ref = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&right),
+        &right_dims,
+        &right_strides,
+        0,
+    )
+    .unwrap();
+    let inputs = [left_ref, right_ref];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute(&ExecContext::serial(), &mut dest, &inputs)
+                .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased concatenate execute must not allocate"
+    );
+}
+
+fn col_major_strides(dims: &[usize]) -> Vec<isize> {
+    let mut stride = 1isize;
+    dims.iter()
+        .map(|&dim| {
+            let current = stride;
+            stride *= dim as isize;
+            current
+        })
+        .collect()
 }

--- a/strided-kernel/tests/erased_static_indexing_plan.rs
+++ b/strided-kernel/tests/erased_static_indexing_plan.rs
@@ -1,0 +1,353 @@
+use strided_kernel::{
+    ErasedConcatenatePlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef,
+    ErasedReversePlan, ErasedSlicePlan, ExecContext, KernelDType, StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+#[test]
+fn erased_slice_plan_executes_strided_static_slice() {
+    let operand_dims = [4usize, 5];
+    let operand_strides = [1isize, 4];
+    let dest_dims = [2usize, 2];
+    let dest_strides = [1isize, 2];
+    let starts = [1usize, 1];
+    let limits = [4usize, 5];
+    let slice_strides = [2usize, 2];
+    let operand = [
+        0.0f64, 1.0, 2.0, 3.0, 10.0, 11.0, 12.0, 13.0, 20.0, 21.0, 22.0, 23.0, 30.0, 31.0, 32.0,
+        33.0, 40.0, 41.0, 42.0, 43.0,
+    ];
+    let mut dest = [0.0f64; 4];
+
+    let plan = ErasedSlicePlan::compile(
+        KernelDType::F64,
+        &operand_dims,
+        &operand_strides,
+        &dest_dims,
+        &dest_strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&operand),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest_ref, &operand_ref)
+        .unwrap();
+
+    assert_eq!(dest, [11.0, 13.0, 31.0, 33.0]);
+}
+
+#[test]
+fn erased_reverse_plan_executes_multi_axis_reverse() {
+    let dims = [2usize, 3, 2];
+    let strides = [1isize, 2, 6];
+    let axes = [0usize, 2];
+    let operand = [0i32, 1, 10, 11, 20, 21, 100, 101, 110, 111, 120, 121];
+    let mut dest = [0i32; 12];
+
+    let plan =
+        ErasedReversePlan::compile(KernelDType::I32, &dims, &strides, &strides, &axes).unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::I32,
+        as_bytes_mut(&mut dest),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(
+        &ExecContext::max_threads(1).unwrap(),
+        &mut dest_ref,
+        &operand_ref,
+    )
+    .unwrap();
+
+    assert_eq!(dest, [101, 100, 111, 110, 121, 120, 1, 0, 11, 10, 21, 20]);
+}
+
+#[test]
+fn erased_pad_plan_fills_output_and_copies_cropped_interior_padded_input() {
+    let operand_dims = [3usize];
+    let operand_strides = [1isize];
+    let dest_dims = [6usize];
+    let dest_strides = [1isize];
+    let edge_low = [-1i64];
+    let edge_high = [2i64];
+    let interior = [1i64];
+    let operand = [10i32, 11, 12];
+    let fill = [-1i32];
+    let mut dest = [0i32; 6];
+
+    let plan = ErasedPadPlan::compile(
+        KernelDType::I32,
+        &operand_dims,
+        &operand_strides,
+        &dest_dims,
+        &dest_strides,
+        &edge_low,
+        &edge_high,
+        &interior,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&operand),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::I32,
+        as_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(
+        &ExecContext::serial(),
+        &mut dest_ref,
+        &operand_ref,
+        as_bytes(&fill),
+    )
+    .unwrap();
+
+    assert_eq!(dest, [-1, 11, -1, 12, -1, -1]);
+}
+
+#[test]
+fn erased_concatenate_plan_executes_three_input_axis_concatenate() {
+    let input0_dims = [2usize, 1];
+    let input1_dims = [2usize, 2];
+    let input2_dims = [2usize, 1];
+    let input_strides = [1isize, 2];
+    let dest_dims = [2usize, 4];
+    let dest_strides = [1isize, 2];
+    let axis = 1usize;
+    let input0 = [0i64, 1];
+    let input1 = [10i64, 11, 20, 21];
+    let input2 = [30i64, 31];
+    let mut dest = [0i64; 8];
+    let input_dims = [&input0_dims[..], &input1_dims[..], &input2_dims[..]];
+    let input_strides_list = [&input_strides[..], &input_strides[..], &input_strides[..]];
+
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::I64,
+        &input_dims,
+        &input_strides_list,
+        &dest_dims,
+        &dest_strides,
+        axis,
+    )
+    .unwrap();
+    let input0_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&input0),
+        &input0_dims,
+        &input_strides,
+        0,
+    )
+    .unwrap();
+    let input1_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&input1),
+        &input1_dims,
+        &input_strides,
+        0,
+    )
+    .unwrap();
+    let input2_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&input2),
+        &input2_dims,
+        &input_strides,
+        0,
+    )
+    .unwrap();
+    let inputs = [input0_ref, input1_ref, input2_ref];
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::I64,
+        as_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest_ref, &inputs)
+        .unwrap();
+
+    assert_eq!(dest, [0, 1, 10, 11, 20, 21, 30, 31]);
+}
+
+#[test]
+fn erased_static_indexing_plans_expose_dtype_and_inner_plan() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let starts = [0usize];
+    let limits = [2usize];
+    let slice_strides = [1usize];
+    let edge = [0i64];
+    let interior = [0i64];
+    let input_dims = [&dims[..], &dims[..]];
+    let input_strides = [&strides[..], &strides[..]];
+    let dest_dims = [4usize];
+
+    let slice = ErasedSlicePlan::compile(
+        KernelDType::F32,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let reverse =
+        ErasedReversePlan::compile(KernelDType::F64, &dims, &strides, &strides, &[0]).unwrap();
+    let pad = ErasedPadPlan::compile(
+        KernelDType::Bool,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &edge,
+        &edge,
+        &interior,
+    )
+    .unwrap();
+    let concat = ErasedConcatenatePlan::compile(
+        KernelDType::C32,
+        &input_dims,
+        &input_strides,
+        &dest_dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    assert_eq!(slice.dtype(), KernelDType::F32);
+    assert!(format!("{:?}", slice.plan()).contains("SlicePlan"));
+    assert_eq!(reverse.dtype(), KernelDType::F64);
+    assert!(format!("{:?}", reverse.plan()).contains("ReversePlan"));
+    assert_eq!(pad.dtype(), KernelDType::Bool);
+    assert!(format!("{:?}", pad.plan()).contains("PadPlan"));
+    assert_eq!(concat.dtype(), KernelDType::C32);
+    assert!(format!("{:?}", concat.plan()).contains("ConcatenatePlan"));
+}
+
+#[test]
+fn erased_static_indexing_plans_reject_mismatches_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let starts = [0usize];
+    let limits = [2usize];
+    let slice_strides = [1usize];
+    let operand = [1.0f64, 2.0];
+    let mut f32_dest = [9.0f32, 9.0];
+
+    let slice = ErasedSlicePlan::compile(
+        KernelDType::F64,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::F32,
+        as_bytes_mut(&mut f32_dest),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let err = slice
+        .execute(&ExecContext::serial(), &mut dest_ref, &operand_ref)
+        .unwrap_err();
+    assert!(matches!(err, StridedError::DTypeMismatch { .. }));
+    assert_eq!(f32_dest, [9.0, 9.0]);
+
+    let edge = [0i64];
+    let interior = [0i64];
+    let pad = ErasedPadPlan::compile(
+        KernelDType::Bool,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &edge,
+        &edge,
+        &interior,
+    )
+    .unwrap();
+    let bool_operand = [true, false];
+    let mut bool_dest = [false, false];
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::Bool,
+        as_bytes(&bool_operand),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    let mut dest_ref = ErasedRawStridedMut::new(
+        KernelDType::Bool,
+        as_bytes_mut(&mut bool_dest),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let err = pad
+        .execute(&ExecContext::serial(), &mut dest_ref, &operand_ref, &[2u8])
+        .unwrap_err();
+    assert!(matches!(err, StridedError::InvalidBoolByte { value: 2 }));
+    assert_eq!(bool_dest, [false, false]);
+}


### PR DESCRIPTION
## Summary

Closes #159.

Adds Rust-side prepared/erased static-indexing plans in `strided-kernel`:

- `SlicePlan` / `ErasedSlicePlan` for static `starts`/`limits`/positive `slice_strides`
- `ReversePlan` / `ErasedReversePlan` via negative-stride source replay
- `PadPlan` / `ErasedPadPlan` with explicit fill scalar, negative edge crop support, and interior padding
- `ConcatenatePlan` / `ErasedConcatenatePlan` for multi-input concat along one axis

The new generic plans own reusable shape/stride traversal and delegate affine cases through `CopyPlan`; tensor semantics, allocation/cache ownership, runtime policy, and C ABI remain out of scope. Tenferro adoption/pin bump should happen as a separate downstream PR after this lands.

## Verification

- `cargo fmt --check`
- `cargo test -p strided-kernel --test erased_static_indexing_plan -j 64`
- `cargo test -p strided-kernel --test copy_plan_alloc -j 64`
- `cargo test -p strided-kernel --all-features -j 64`
- `cargo test --workspace -j 64`
- `cargo doc --workspace --no-deps -j 64`
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` -> 53/53 files passed
