### PR TITLE
Honor erased policy thresholds in indexed replay

### DIFF
--- a/docs/erased-policy-threshold-benchmarks.md
+++ b/docs/erased-policy-threshold-benchmarks.md
@@ -27,6 +27,34 @@ Additive scatter remains order-sensitive when updates overlap. Treat its
 benchmark as evidence for future design, not as permission for a blanket
 parallel implementation.
 
+## Initial Threshold Decision
+
+The initial implementation uses the repository threading threshold,
+`threading::MINTHREADLENGTH` (`1 << 15` elements), as the single source of
+truth. A family enters a parallel replay only when:
+
+- the active execution policy exposes more than one worker;
+- the family-specific independent output/update/copy domain has more than
+  `MINTHREADLENGTH` logical elements.
+
+Small tensors, `ExecContext::serial()`, `ExecContext::max_threads(1)`, nested
+fanout, and single-thread pools remain on the serial replay path.
+
+The policy-aware parallel replay covers:
+
+- axis reductions by partitioning the output domain while preserving the serial
+  reduction order inside each output element;
+- gather;
+- dynamic slice;
+- dynamic-update-slice overwrite phase after the serial copy phase;
+- pad fill and input-copy phases.
+
+Additive scatter still applies overlapping additive updates in deterministic
+serial order. Raw `CopyPlan` replay also remains serial for now: the initial
+range-partitioned prototype was slower than the serial fused loop for large
+contiguous copies in an exploratory 2-thread run. A parallel raw-copy path
+needs a chunked inner-run design, not per-element coordinate replay.
+
 ## Running
 
 The benchmark defaults to a conservative two-thread comparison when

--- a/docs/erased-policy-threshold-benchmarks.md
+++ b/docs/erased-policy-threshold-benchmarks.md
@@ -1,0 +1,82 @@
+# Erased Policy Threshold Benchmarks
+
+This note describes how to collect evidence for issue #163. It intentionally
+does not publish benchmark results. Keep durable result tables in the external
+`tensor4all/strided-rs-benchmark-suite` repository.
+
+## Scope
+
+The `erased_policy_thresholds` benchmark compares the same erased prepared plan
+under:
+
+- `ExecContext::serial()`;
+- `ExecContext::max_threads(n)`.
+
+The benchmark covers the erased plan families that still contain serial loops
+or serial raw replay paths:
+
+- axis/multi-axis sum reduction;
+- gather / indexed read;
+- dynamic slice;
+- dynamic update slice;
+- pad;
+- raw copy replay;
+- additive scatter as a measurement target only.
+
+Additive scatter remains order-sensitive when updates overlap. Treat its
+benchmark as evidence for future design, not as permission for a blanket
+parallel implementation.
+
+## Running
+
+The benchmark defaults to a conservative two-thread comparison when
+`STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS` is not set. Set the thread count
+explicitly for threshold work.
+
+Run threshold-setting measurements only on a quiet machine. If other heavy
+processes are running, mark the run as exploratory and do not use it to choose
+thresholds.
+
+Recommended threshold run:
+
+```bash
+git rev-parse HEAD
+lscpu
+RAYON_NUM_THREADS=64 \
+STRIDED_KERNEL_ERASED_POLICY_BENCH_PROFILE=threshold \
+STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS=64 \
+cargo bench -p strided-kernel --features parallel --bench erased_policy_thresholds
+```
+
+Repeat the threshold run with each intended bounded thread count, for example
+2, 8, and the high-core production budget. Each run compares that bounded
+thread count against the serial context.
+
+For a quick harness check:
+
+```bash
+STRIDED_KERNEL_ERASED_POLICY_BENCH_PROFILE=smoke \
+STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS=2 \
+cargo bench -p strided-kernel --features parallel --bench erased_policy_thresholds
+```
+
+Do not run threshold-setting benchmark jobs concurrently with other benchmark
+jobs. Do not mix BLAS/OpenMP provider thread policies into the same run.
+
+## Result Note Template
+
+Record at least:
+
+- strided-rs commit;
+- CPU model and logical CPU count;
+- OS and scheduler/affinity constraints, if any;
+- `RAYON_NUM_THREADS`;
+- `STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS`;
+- benchmark profile;
+- whether the machine was idle or known competing processes were present;
+- per-family serial versus `max_threads(n)` results;
+- variance notes;
+- proposed family-specific threshold or rationale for staying serial.
+
+Choose thresholds only from quiet or explicitly isolated runs. Keep small-size
+serial fallback when scheduler overhead dominates.

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -59,3 +59,8 @@ harness = false
 [[bench]]
 name = "fused_elementwise"
 harness = false
+
+[[bench]]
+name = "erased_policy_thresholds"
+harness = false
+required-features = ["parallel"]

--- a/strided-kernel/benches/erased_policy_thresholds.rs
+++ b/strided-kernel/benches/erased_policy_thresholds.rs
@@ -1,0 +1,545 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::time::Duration;
+use strided_kernel::{
+    col_major_strides, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
+    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan,
+    ErasedScatterPlan, ExecContext, GatherSpec, KernelDType, ReduceOp, ScatterSpec,
+};
+
+#[derive(Clone, Copy)]
+struct BenchCase {
+    label: &'static str,
+    len: usize,
+    threads: usize,
+}
+
+fn profile_cases() -> Vec<BenchCase> {
+    let profile = std::env::var("STRIDED_KERNEL_ERASED_POLICY_BENCH_PROFILE")
+        .unwrap_or_else(|_| "quick".to_string());
+    let default_threads = rayon::current_num_threads().min(2);
+    let threads = std::env::var("STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(default_threads);
+    let sizes: &[(&str, usize)] = match profile.as_str() {
+        "smoke" => &[("small", 1 << 12)],
+        "threshold" => &[
+            ("small", 1 << 12),
+            ("near_threshold", 1 << 15),
+            ("medium", 1 << 18),
+            ("large", 1 << 20),
+        ],
+        _ => &[("small", 1 << 12), ("near_threshold", 1 << 15)],
+    };
+
+    sizes
+        .iter()
+        .flat_map(|&(label, len)| {
+            let serial = BenchCase {
+                label,
+                len,
+                threads: 1,
+            };
+            if threads == 1 {
+                vec![serial]
+            } else {
+                vec![
+                    serial,
+                    BenchCase {
+                        label,
+                        len,
+                        threads,
+                    },
+                ]
+            }
+        })
+        .collect()
+}
+
+fn context(case: BenchCase) -> ExecContext {
+    if case.threads == 1 {
+        ExecContext::serial()
+    } else {
+        ExecContext::max_threads(case.threads).unwrap()
+    }
+}
+
+fn context_label(case: BenchCase) -> String {
+    if case.threads == 1 {
+        "serial".to_string()
+    } else {
+        format!("max_threads_{}", case.threads)
+    }
+}
+
+fn bench_id(case: BenchCase) -> BenchmarkId {
+    BenchmarkId::new(context_label(case), format!("{}_n{}", case.label, case.len))
+}
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn patterned_f64(len: usize) -> Vec<f64> {
+    (0..len)
+        .map(|index| (index % 251) as f64 * 0.25 + 1.0)
+        .collect()
+}
+
+fn patterned_i32(len: usize) -> Vec<i32> {
+    (0..len).map(|index| (index % 97) as i32 - 31).collect()
+}
+
+fn bench_axis_reduce(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_axis_reduce_sum");
+    for case in profile_cases() {
+        let rows = 64usize;
+        let columns = (case.len / rows).max(1);
+        let src_dims = [rows, columns];
+        let src_strides = col_major_strides(&src_dims);
+        let dest_dims = [columns];
+        let dest_strides = [1isize];
+        let input = patterned_f64(rows * columns);
+        let plan = ErasedReducePlan::compile_axes(
+            KernelDType::F64,
+            ReduceOp::Sum,
+            &src_dims,
+            &src_strides,
+            &dest_dims,
+            &dest_strides,
+            &[0],
+        )
+        .unwrap();
+        let source = ErasedRawStridedRef::new(
+            KernelDType::F64,
+            as_bytes(&input),
+            &src_dims,
+            &src_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0.0f64; columns];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::F64,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &source).unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_gather_take(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_gather_take");
+    for case in profile_cases() {
+        let operand_dims = [case.len];
+        let operand_strides = [1isize];
+        let index_dims = [case.len];
+        let index_strides = [1isize];
+        let dest_dims = [case.len];
+        let dest_strides = [1isize];
+        let operand = patterned_f64(case.len);
+        let indices = (0..case.len)
+            .map(|index| (case.len - 1 - index) as i64)
+            .collect::<Vec<_>>();
+        let spec = GatherSpec {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0],
+            start_index_map: vec![0],
+            index_vector_dim: 1,
+            slice_sizes: vec![1],
+        };
+        let plan = ErasedGatherPlan::compile(
+            KernelDType::F64,
+            KernelDType::I64,
+            &operand_dims,
+            &operand_strides,
+            &index_dims,
+            &index_strides,
+            &dest_dims,
+            &dest_strides,
+            spec,
+        )
+        .unwrap();
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::F64,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let index_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&indices),
+            &index_dims,
+            &index_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0.0f64; case.len];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::F64,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &operand_ref, &index_ref)
+                    .unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_dynamic_slice(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_dynamic_slice");
+    for case in profile_cases() {
+        let operand_dims = [case.len + 128];
+        let operand_strides = [1isize];
+        let starts_dims = [1usize];
+        let starts_strides = [1isize];
+        let dest_dims = [case.len];
+        let dest_strides = [1isize];
+        let slice_sizes = [case.len];
+        let operand = patterned_f64(case.len + 128);
+        let starts = [64i64];
+        let plan = ErasedDynamicSlicePlan::compile(
+            KernelDType::F64,
+            KernelDType::I64,
+            &operand_dims,
+            &operand_strides,
+            &starts_dims,
+            &starts_strides,
+            &dest_dims,
+            &dest_strides,
+            &slice_sizes,
+        )
+        .unwrap();
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::F64,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let starts_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&starts),
+            &starts_dims,
+            &starts_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0.0f64; case.len];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::F64,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &operand_ref, &starts_ref)
+                    .unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_dynamic_update_slice(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_dynamic_update_slice");
+    for case in profile_cases() {
+        let operand_dims = [case.len + 128];
+        let operand_strides = [1isize];
+        let starts_dims = [1usize];
+        let starts_strides = [1isize];
+        let update_dims = [case.len];
+        let update_strides = [1isize];
+        let dest_dims = [case.len + 128];
+        let dest_strides = [1isize];
+        let operand = patterned_i32(case.len + 128);
+        let update = patterned_i32(case.len);
+        let starts = [64i32];
+        let plan = ErasedDynamicUpdateSlicePlan::compile(
+            KernelDType::I32,
+            KernelDType::I32,
+            &operand_dims,
+            &operand_strides,
+            &starts_dims,
+            &starts_strides,
+            &update_dims,
+            &update_strides,
+            &dest_dims,
+            &dest_strides,
+        )
+        .unwrap();
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let update_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&update),
+            &update_dims,
+            &update_strides,
+            0,
+        )
+        .unwrap();
+        let starts_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&starts),
+            &starts_dims,
+            &starts_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0i32; case.len + 128];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::I32,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &operand_ref, &update_ref, &starts_ref)
+                    .unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_pad_fill_and_copy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_pad_fill_and_copy");
+    for case in profile_cases() {
+        let operand_len = (case.len / 2).max(1);
+        let edge = (case.len - operand_len) / 2;
+        let operand_dims = [operand_len];
+        let operand_strides = [1isize];
+        let dest_dims = [operand_len + edge * 2];
+        let dest_strides = [1isize];
+        let edge_low = [edge as i64];
+        let edge_high = [edge as i64];
+        let interior = [0i64];
+        let fill = [-1i32];
+        let operand = patterned_i32(operand_len);
+        let plan = ErasedPadPlan::compile(
+            KernelDType::I32,
+            &operand_dims,
+            &operand_strides,
+            &dest_dims,
+            &dest_strides,
+            &edge_low,
+            &edge_high,
+            &interior,
+        )
+        .unwrap();
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0i32; dest_dims[0]];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::I32,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &operand_ref, as_bytes(&fill))
+                    .unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_copy_raw_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_copy_raw_path");
+    for case in profile_cases() {
+        let dims = [case.len];
+        let strides = [1isize];
+        let source_data = patterned_f64(case.len);
+        let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
+        let source =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&source_data), &dims, &strides, 0)
+                .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0.0f64; case.len];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::F64,
+                as_bytes_mut(&mut output),
+                &dims,
+                &strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &source).unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_scatter_additive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("erased_scatter_additive_serial_semantics");
+    for case in profile_cases() {
+        let operand_dims = [case.len];
+        let operand_strides = [1isize];
+        let index_dims = [case.len, 1];
+        let index_strides = [1isize, case.len as isize];
+        let update_dims = [case.len];
+        let update_strides = [1isize];
+        let dest_dims = [case.len];
+        let dest_strides = [1isize];
+        let operand = patterned_f64(case.len);
+        let updates = patterned_f64(case.len);
+        let indices = (0..case.len)
+            .map(|index| (index % case.len.max(1)) as i64)
+            .collect::<Vec<_>>();
+        let spec = ScatterSpec {
+            update_window_dims: vec![],
+            inserted_window_dims: vec![0],
+            scatter_dims_to_operand_dims: vec![0],
+            index_vector_dim: 1,
+        };
+        let plan = ErasedScatterPlan::compile(
+            KernelDType::F64,
+            KernelDType::I64,
+            &operand_dims,
+            &operand_strides,
+            &index_dims,
+            &index_strides,
+            &update_dims,
+            &update_strides,
+            &dest_dims,
+            &dest_strides,
+            spec,
+        )
+        .unwrap();
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::F64,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let index_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&indices),
+            &index_dims,
+            &index_strides,
+            0,
+        )
+        .unwrap();
+        let update_ref = ErasedRawStridedRef::new(
+            KernelDType::F64,
+            as_bytes(&updates),
+            &update_dims,
+            &update_strides,
+            0,
+        )
+        .unwrap();
+        let ctx = context(case);
+
+        group.bench_function(bench_id(case), |bencher| {
+            let mut output = vec![0.0f64; case.len];
+            let mut dest = ErasedRawStridedMut::new(
+                KernelDType::F64,
+                as_bytes_mut(&mut output),
+                &dest_dims,
+                &dest_strides,
+                0,
+            )
+            .unwrap();
+            bencher.iter(|| {
+                plan.execute(&ctx, &mut dest, &operand_ref, &index_ref, &update_ref)
+                    .unwrap();
+                black_box(&mut dest);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(300))
+        .measurement_time(Duration::from_secs(1));
+    targets =
+        bench_axis_reduce,
+        bench_gather_take,
+        bench_dynamic_slice,
+        bench_dynamic_update_slice,
+        bench_pad_fill_and_copy,
+        bench_copy_raw_path,
+        bench_scatter_additive
+}
+criterion_main!(benches);

--- a/strided-kernel/benches/erased_policy_thresholds.rs
+++ b/strided-kernel/benches/erased_policy_thresholds.rs
@@ -108,7 +108,7 @@ fn patterned_i32(len: usize) -> Vec<i32> {
 fn bench_axis_reduce(c: &mut Criterion) {
     let mut group = c.benchmark_group("erased_axis_reduce_sum");
     for case in profile_cases() {
-        let rows = 64usize;
+        let rows = 2usize;
         let columns = (case.len / rows).max(1);
         let src_dims = [rows, columns];
         let src_strides = col_major_strides(&src_dims);

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -1477,7 +1477,7 @@ fn execute_pad<T>(
     fill: &[u8],
 ) -> Result<()>
 where
-    T: Copy,
+    T: Copy + crate::MaybeSendSync,
 {
     let fill = read_unaligned_scalar::<T>(fill);
     let operand_data = typed_slice::<T>(operand.data());
@@ -1627,10 +1627,84 @@ where
         return Ok(());
     }
 
+    if ctx.is_serial() {
+        execute_reduce_axes_serial::<T>(op, dest, src, layout)
+    } else {
+        ctx.run(|| execute_reduce_axes_policy::<T>(op, dest, src, layout))
+    }
+}
+
+fn execute_reduce_axes_policy<T>(
+    op: ReduceOp,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+    layout: AxesLayout<'_>,
+) -> Result<()>
+where
+    T: ErasedReduceScalar,
+{
     let source_data = typed_slice::<T>(src.data());
     let dest_offset_base = dest.offset();
     let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    #[cfg(feature = "parallel")]
+    {
+        let nthreads = crate::threading::parallel_threads_for_len(layout.dest_total);
+        if nthreads > 1 {
+            return execute_reduce_axes_parallel(
+                op,
+                dest_offset_base,
+                dest_data,
+                src.offset(),
+                source_data,
+                layout,
+                nthreads,
+            );
+        }
+    }
 
+    execute_reduce_axes_serial_data(
+        op,
+        dest_offset_base,
+        dest_data,
+        src.offset(),
+        source_data,
+        layout,
+    )
+}
+
+fn execute_reduce_axes_serial<T>(
+    op: ReduceOp,
+    dest: &mut ErasedRawStridedMut<'_>,
+    src: &ErasedRawStridedRef<'_>,
+    layout: AxesLayout<'_>,
+) -> Result<()>
+where
+    T: ErasedReduceScalar,
+{
+    let source_data = typed_slice::<T>(src.data());
+    let dest_offset_base = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    execute_reduce_axes_serial_data(
+        op,
+        dest_offset_base,
+        dest_data,
+        src.offset(),
+        source_data,
+        layout,
+    )
+}
+
+fn execute_reduce_axes_serial_data<T>(
+    op: ReduceOp,
+    dest_offset_base: isize,
+    dest_data: &mut [T],
+    source_offset_base: isize,
+    source_data: &[T],
+    layout: AxesLayout<'_>,
+) -> Result<()>
+where
+    T: ErasedReduceScalar,
+{
     let mut out_idx_storage = CoordScratch::new(layout.dest_dims.len());
     let mut reduce_idx_storage = CoordScratch::new(layout.reduce_dims.len());
     let mut src_idx_storage = CoordScratch::new(layout.src_dims.len());
@@ -1650,7 +1724,8 @@ where
             for (reduce_axis, &src_axis) in layout.axes.iter().enumerate() {
                 src_idx[src_axis] = reduce_idx[reduce_axis];
             }
-            let source_offset = checked_strided_offset(src.offset(), layout.src_strides, src_idx)?;
+            let source_offset =
+                checked_strided_offset(source_offset_base, layout.src_strides, src_idx)?;
             let value = unsafe { *source_data.as_ptr().offset(source_offset) };
             acc = reduce_values(op, acc, value);
             advance_col_major_index(reduce_idx, layout.reduce_dims);
@@ -1663,6 +1738,70 @@ where
         advance_col_major_index(out_idx, layout.dest_dims);
     }
     Ok(())
+}
+
+#[cfg(feature = "parallel")]
+fn execute_reduce_axes_parallel<T>(
+    op: ReduceOp,
+    dest_offset_base: isize,
+    dest_data: &mut [T],
+    source_offset_base: isize,
+    source_data: &[T],
+    layout: AxesLayout<'_>,
+    nthreads: usize,
+) -> Result<()>
+where
+    T: ErasedReduceScalar,
+{
+    let dest_ptr = crate::threading::SendPtr(dest_data.as_mut_ptr());
+    let source_ptr = crate::threading::SendPtr(source_data.as_ptr() as *mut T);
+    crate::threading::parallel_map_reduce(
+        0..layout.dest_total,
+        nthreads,
+        &|range| {
+            let mut out_idx_storage = CoordScratch::new(layout.dest_dims.len());
+            let mut reduce_idx_storage = CoordScratch::new(layout.reduce_dims.len());
+            let mut src_idx_storage = CoordScratch::new(layout.src_dims.len());
+            let out_idx = out_idx_storage.as_mut_slice();
+            let reduce_idx = reduce_idx_storage.as_mut_slice();
+            let src_idx = src_idx_storage.as_mut_slice();
+            fill_col_major_index(range.start, layout.dest_dims, out_idx);
+            let dest_ptr = dest_ptr.as_ptr();
+            let source_ptr = source_ptr.as_const();
+
+            for _ in range {
+                src_idx.fill(0);
+                for (dest_axis, &src_axis) in layout.kept_axes.iter().enumerate() {
+                    src_idx[src_axis] = out_idx[dest_axis];
+                }
+
+                let mut acc = reduce_identity(op);
+                reduce_idx.fill(0);
+                for _ in 0..layout.reduce_total {
+                    for (reduce_axis, &src_axis) in layout.axes.iter().enumerate() {
+                        src_idx[src_axis] = reduce_idx[reduce_axis];
+                    }
+                    let source_offset =
+                        checked_strided_offset(source_offset_base, layout.src_strides, src_idx)?;
+                    let value = unsafe { *source_ptr.offset(source_offset) };
+                    acc = reduce_values(op, acc, value);
+                    advance_col_major_index(reduce_idx, layout.reduce_dims);
+                }
+
+                let dest_offset =
+                    checked_strided_offset(dest_offset_base, layout.dest_strides, out_idx)?;
+                unsafe {
+                    // SAFETY: axis reduction writes exactly one scalar per
+                    // logical output position, and compile rejected
+                    // non-injective destination layouts.
+                    *dest_ptr.offset(dest_offset) = acc;
+                }
+                advance_col_major_index(out_idx, layout.dest_dims);
+            }
+            Ok(())
+        },
+        &|left, right| left.and(right),
+    )
 }
 
 #[inline]
@@ -1768,6 +1907,15 @@ fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
             return;
         }
         index[axis] = 0;
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn fill_col_major_index(mut linear: usize, shape: &[usize], out: &mut [usize]) {
+    for (axis, coord) in out.iter_mut().enumerate() {
+        let dim = shape[axis];
+        *coord = linear % dim;
+        linear /= dim;
     }
 }
 

--- a/strided-kernel/src/gather_plan.rs
+++ b/strided-kernel/src/gather_plan.rs
@@ -68,6 +68,7 @@ pub struct GatherPlan {
     spec: GatherSpec,
     batch_shape: AxisVec<usize>,
     out_axis_to_operand_dim: AxisVec<Option<usize>>,
+    total: usize,
 }
 
 /// Scatter configuration shared by generic and erased replay.
@@ -160,7 +161,7 @@ impl GatherPlan {
         }
         checked_total_len(operand_dims)?;
         checked_total_len(index_dims)?;
-        checked_total_len(dest_dims)?;
+        let total = checked_total_len(dest_dims)?;
         if !crate::fused::is_injective_layout(dest_dims, dest_strides) {
             return Err(StridedError::NonInjectiveOutputLayout);
         }
@@ -257,6 +258,7 @@ impl GatherPlan {
             spec,
             batch_shape,
             out_axis_to_operand_dim,
+            total,
         })
     }
 
@@ -282,9 +284,15 @@ impl GatherPlan {
         I: GatherIndex,
     {
         self.check_call(dest, operand, start_indices)?;
-        let total = checked_total_len(&self.dest_dims)?;
-        if total == 0 {
+        if self.total == 0 {
             return Ok(());
+        }
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.total);
+            if nthreads > 1 {
+                return self.execute_parallel(dest, operand, start_indices, nthreads);
+            }
         }
 
         let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
@@ -306,7 +314,7 @@ impl GatherPlan {
         let index_data = start_indices.data();
         let dest_data = dest.data_mut();
 
-        for _ in 0..total {
+        for _ in 0..self.total {
             window_offsets.fill(0);
             let mut batch_axis = 0usize;
             for (out_axis, &operand_dim) in self.out_axis_to_operand_dim.iter().enumerate() {
@@ -345,6 +353,92 @@ impl GatherPlan {
             advance_col_major_index(out_idx, &self.dest_dims);
         }
         Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn execute_parallel<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        start_indices: &RawStridedRef<'_, I>,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+        I: GatherIndex,
+    {
+        let dest_offset_base = dest.offset();
+        let operand_offset_base = operand.offset();
+        let index_offset_base = start_indices.offset();
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+        let operand_ptr = crate::threading::SendPtr(operand.data().as_ptr() as *mut T);
+        let index_ptr = crate::threading::SendPtr(start_indices.data().as_ptr() as *mut I);
+
+        crate::threading::parallel_map_reduce(
+            0..self.total,
+            nthreads,
+            &|range| {
+                let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+                let mut batch_idx_storage = CoordScratch::new(self.batch_shape.len());
+                let mut operand_idx_storage = CoordScratch::new(self.operand_dims.len());
+                let mut window_offsets_storage = CoordScratch::new(self.operand_dims.len());
+                let out_idx = out_idx_storage.as_mut_slice();
+                let batch_idx = batch_idx_storage.as_mut_slice();
+                let operand_idx = operand_idx_storage.as_mut_slice();
+                let window_offsets = window_offsets_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.dest_dims, out_idx);
+                let dest_ptr = dest_ptr.as_ptr();
+                let operand_ptr = operand_ptr.as_const();
+                let index_ptr = index_ptr.as_const();
+
+                for _ in range {
+                    window_offsets.fill(0);
+                    let mut batch_axis = 0usize;
+                    for (out_axis, &operand_dim) in self.out_axis_to_operand_dim.iter().enumerate()
+                    {
+                        match operand_dim {
+                            Some(axis) => window_offsets[axis] = out_idx[out_axis],
+                            None => {
+                                batch_idx[batch_axis] = out_idx[out_axis];
+                                batch_axis += 1;
+                            }
+                        }
+                    }
+
+                    operand_idx.fill(0);
+                    for (component, &operand_dim) in self.spec.start_index_map.iter().enumerate() {
+                        let start = self.index_component_ptr(
+                            start_indices.dims(),
+                            index_offset_base,
+                            index_ptr,
+                            batch_idx,
+                            component,
+                        )?;
+                        operand_idx[operand_dim] = self.clamp_window_start(start, operand_dim);
+                    }
+                    for axis in 0..operand_idx.len() {
+                        operand_idx[axis] += window_offsets[axis];
+                    }
+
+                    let dest_offset =
+                        checked_strided_offset(dest_offset_base, &self.dest_strides, out_idx)?;
+                    let operand_offset = checked_strided_offset(
+                        operand_offset_base,
+                        &self.operand_strides,
+                        operand_idx,
+                    )?;
+                    unsafe {
+                        // SAFETY: gather writes one value per logical output,
+                        // and compile rejected non-injective destination
+                        // layouts.
+                        *dest_ptr.offset(dest_offset) = *operand_ptr.offset(operand_offset);
+                    }
+                    advance_col_major_index(out_idx, &self.dest_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
     }
 
     fn check_call<T, I>(
@@ -390,6 +484,33 @@ impl GatherPlan {
             offset = checked_offset_add(offset, index_strides[axis], coord)?;
         }
         Ok(unsafe { *index_data.as_ptr().offset(offset) }.to_i64())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn index_component_ptr<I>(
+        &self,
+        index_dims: &[usize],
+        index_offset_base: isize,
+        index_ptr: *const I,
+        batch_idx: &[usize],
+        component: usize,
+    ) -> Result<i64>
+    where
+        I: GatherIndex,
+    {
+        let mut offset = index_offset_base;
+        let mut batch_axis = 0usize;
+        for axis in 0..index_dims.len() {
+            let coord = if axis == self.spec.index_vector_dim {
+                component
+            } else {
+                let coord = batch_idx[batch_axis];
+                batch_axis += 1;
+                coord
+            };
+            offset = checked_offset_add(offset, self.index_strides[axis], coord)?;
+        }
+        Ok(unsafe { *index_ptr.offset(offset) }.to_i64())
     }
 
     #[inline]
@@ -469,9 +590,14 @@ impl DynamicSlicePlan {
         if self.total == 0 {
             return Ok(());
         }
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.total);
+            if nthreads > 1 {
+                return self.execute_parallel(dest, operand, starts, nthreads);
+            }
+        }
 
-        // Serial replay keeps this fixed-window primitive deterministic until
-        // the execution-policy layer grows indexed-domain partitioning.
         let mut starts_storage = CoordScratch::new(self.operand_dims.len());
         let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
         let mut operand_idx_storage = CoordScratch::new(self.operand_dims.len());
@@ -506,6 +632,68 @@ impl DynamicSlicePlan {
             advance_col_major_index(dest_idx, &self.dest_dims);
         }
         Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn execute_parallel<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        starts: &RawStridedRef<'_, I>,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+        I: GatherIndex,
+    {
+        let mut clamped_starts: AxisVec<usize> = (0..self.operand_dims.len()).map(|_| 0).collect();
+        read_clamped_starts(
+            starts,
+            &self.operand_dims,
+            &self.slice_sizes,
+            &mut clamped_starts,
+        )?;
+
+        let operand_offset_base = operand.offset();
+        let dest_offset_base = dest.offset();
+        let operand_ptr = crate::threading::SendPtr(operand.data().as_ptr() as *mut T);
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+
+        crate::threading::parallel_map_reduce(
+            0..self.total,
+            nthreads,
+            &|range| {
+                let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
+                let mut operand_idx_storage = CoordScratch::new(self.operand_dims.len());
+                let dest_idx = dest_idx_storage.as_mut_slice();
+                let operand_idx = operand_idx_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.dest_dims, dest_idx);
+                let operand_ptr = operand_ptr.as_const();
+                let dest_ptr = dest_ptr.as_ptr();
+
+                for _ in range {
+                    for axis in 0..operand_idx.len() {
+                        operand_idx[axis] = clamped_starts[axis] + dest_idx[axis];
+                    }
+                    let operand_offset = checked_strided_offset(
+                        operand_offset_base,
+                        &self.operand_strides,
+                        operand_idx,
+                    )?;
+                    let dest_offset =
+                        checked_strided_offset(dest_offset_base, &self.dest_strides, dest_idx)?;
+                    unsafe {
+                        // SAFETY: dynamic slice writes one value per logical
+                        // output, and compile rejected non-injective
+                        // destination layouts.
+                        *dest_ptr.offset(dest_offset) = *operand_ptr.offset(operand_offset);
+                    }
+                    advance_col_major_index(dest_idx, &self.dest_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
     }
 
     fn check_call<T, I>(
@@ -603,9 +791,14 @@ impl DynamicUpdateSlicePlan {
         if self.total == 0 {
             return Ok(());
         }
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.total);
+            if nthreads > 1 {
+                return self.execute_update_parallel(dest, update, starts, nthreads);
+            }
+        }
 
-        // Serial replay keeps the copy-then-overwrite boundary explicit until
-        // indexed-domain partitioning is available in the execution policy.
         let mut starts_storage = CoordScratch::new(self.operand_dims.len());
         let mut update_idx_storage = CoordScratch::new(self.update_dims.len());
         let mut dest_idx_storage = CoordScratch::new(self.operand_dims.len());
@@ -640,6 +833,68 @@ impl DynamicUpdateSlicePlan {
             advance_col_major_index(update_idx, &self.update_dims);
         }
         Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn execute_update_parallel<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        update: &RawStridedRef<'_, T>,
+        starts: &RawStridedRef<'_, I>,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+        I: GatherIndex,
+    {
+        let mut clamped_starts: AxisVec<usize> = (0..self.operand_dims.len()).map(|_| 0).collect();
+        read_clamped_starts(
+            starts,
+            &self.operand_dims,
+            &self.update_dims,
+            &mut clamped_starts,
+        )?;
+
+        let update_offset_base = update.offset();
+        let dest_offset_base = dest.offset();
+        let update_ptr = crate::threading::SendPtr(update.data().as_ptr() as *mut T);
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+
+        crate::threading::parallel_map_reduce(
+            0..self.total,
+            nthreads,
+            &|range| {
+                let mut update_idx_storage = CoordScratch::new(self.update_dims.len());
+                let mut dest_idx_storage = CoordScratch::new(self.operand_dims.len());
+                let update_idx = update_idx_storage.as_mut_slice();
+                let dest_idx = dest_idx_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.update_dims, update_idx);
+                let update_ptr = update_ptr.as_const();
+                let dest_ptr = dest_ptr.as_ptr();
+
+                for _ in range {
+                    for axis in 0..dest_idx.len() {
+                        dest_idx[axis] = clamped_starts[axis] + update_idx[axis];
+                    }
+                    let update_offset = checked_strided_offset(
+                        update_offset_base,
+                        &self.update_strides,
+                        update_idx,
+                    )?;
+                    let dest_offset =
+                        checked_strided_offset(dest_offset_base, &self.dest_strides, dest_idx)?;
+                    unsafe {
+                        // SAFETY: each update-domain logical index maps to a
+                        // distinct destination position for a fixed window, and
+                        // compile rejected non-injective destination layouts.
+                        *dest_ptr.offset(dest_offset) = *update_ptr.offset(update_offset);
+                    }
+                    advance_col_major_index(update_idx, &self.update_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
     }
 
     fn check_call<T, I>(
@@ -1075,6 +1330,15 @@ fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
             return;
         }
         index[axis] = 0;
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn fill_col_major_index(mut linear: usize, shape: &[usize], out: &mut [usize]) {
+    for (axis, coord) in out.iter_mut().enumerate() {
+        let dim = shape[axis];
+        *coord = linear % dim;
+        linear /= dim;
     }
 }
 

--- a/strided-kernel/src/static_indexing_plan.rs
+++ b/strided-kernel/src/static_indexing_plan.rs
@@ -252,32 +252,122 @@ impl PadPlan {
         fill: T,
     ) -> Result<()>
     where
-        T: Copy,
+        T: Copy + MaybeSendSync,
     {
         self.check_call(dest, operand)?;
-        let dest_offset_base = dest.offset();
-        let dest_strides = dest.strides();
-        let dest_data = dest.data_mut();
-
-        if self.dest_total != 0 {
-            let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
-            let dest_idx = dest_idx_storage.as_mut_slice();
-            for _ in 0..self.dest_total {
-                let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, dest_idx)?;
-                unsafe {
-                    *dest_data.as_mut_ptr().offset(dest_offset) = fill;
-                }
-                advance_col_major_index(dest_idx, &self.dest_dims);
-            }
-        }
+        self.fill_dest(dest, fill)?;
 
         if self.operand_total == 0 {
             return Ok(());
         }
+        self.copy_operand(dest, operand)
+    }
 
+    fn fill_dest<T>(&self, dest: &mut RawStridedMut<'_, T>, fill: T) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        if self.dest_total == 0 {
+            return Ok(());
+        }
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.dest_total);
+            if nthreads > 1 {
+                return self.fill_dest_parallel(dest, fill, nthreads);
+            }
+        }
+        self.fill_dest_serial(dest, fill)
+    }
+
+    fn fill_dest_serial<T>(&self, dest: &mut RawStridedMut<'_, T>, fill: T) -> Result<()>
+    where
+        T: Copy,
+    {
+        let dest_offset_base = dest.offset();
+        let dest_strides = dest.strides();
+        let dest_data = dest.data_mut();
+        let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
+        let dest_idx = dest_idx_storage.as_mut_slice();
+        for _ in 0..self.dest_total {
+            let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, dest_idx)?;
+            unsafe {
+                *dest_data.as_mut_ptr().offset(dest_offset) = fill;
+            }
+            advance_col_major_index(dest_idx, &self.dest_dims);
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn fill_dest_parallel<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        fill: T,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        let dest_offset_base = dest.offset();
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+        crate::threading::parallel_map_reduce(
+            0..self.dest_total,
+            nthreads,
+            &|range| {
+                let mut dest_idx_storage = CoordScratch::new(self.dest_dims.len());
+                let dest_idx = dest_idx_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.dest_dims, dest_idx);
+                let dest_ptr = dest_ptr.as_ptr();
+                for _ in range {
+                    let dest_offset =
+                        checked_strided_offset(dest_offset_base, &self.dest_strides, dest_idx)?;
+                    unsafe {
+                        // SAFETY: `compile` rejected non-injective destination
+                        // layouts, and each logical destination index is visited
+                        // by exactly one range partition.
+                        *dest_ptr.offset(dest_offset) = fill;
+                    }
+                    advance_col_major_index(dest_idx, &self.dest_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
+    }
+
+    fn copy_operand<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.operand_total);
+            if nthreads > 1 {
+                return self.copy_operand_parallel(dest, operand, nthreads);
+            }
+        }
+        self.copy_operand_serial(dest, operand)
+    }
+
+    fn copy_operand_serial<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy,
+    {
         let operand_offset_base = operand.offset();
         let operand_strides = operand.strides();
         let operand_data = operand.data();
+        let dest_offset_base = dest.offset();
+        let dest_strides = dest.strides();
+        let dest_data = dest.data_mut();
         let mut input_idx_storage = CoordScratch::new(self.operand_dims.len());
         let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
         let input_idx = input_idx_storage.as_mut_slice();
@@ -306,6 +396,67 @@ impl PadPlan {
             advance_col_major_index(input_idx, &self.operand_dims);
         }
         Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn copy_operand_parallel<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        let operand_offset_base = operand.offset();
+        let operand_ptr = crate::threading::SendPtr(operand.data().as_ptr() as *mut T);
+        let dest_offset_base = dest.offset();
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+        crate::threading::parallel_map_reduce(
+            0..self.operand_total,
+            nthreads,
+            &|range| {
+                let mut input_idx_storage = CoordScratch::new(self.operand_dims.len());
+                let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+                let input_idx = input_idx_storage.as_mut_slice();
+                let out_idx = out_idx_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.operand_dims, input_idx);
+                let operand_ptr = operand_ptr.as_const();
+                let dest_ptr = dest_ptr.as_ptr();
+
+                for _ in range {
+                    let mut in_bounds = true;
+                    for axis in 0..self.operand_dims.len() {
+                        let out_pos = i128::from(self.edge_padding_low[axis])
+                            + input_idx[axis] as i128 * i128::from(self.interior_step[axis]);
+                        if out_pos < 0 || out_pos >= self.dest_dims[axis] as i128 {
+                            in_bounds = false;
+                            break;
+                        }
+                        out_idx[axis] = out_pos as usize;
+                    }
+                    if in_bounds {
+                        let operand_offset = checked_strided_offset(
+                            operand_offset_base,
+                            &self.operand_strides,
+                            input_idx,
+                        )?;
+                        let dest_offset =
+                            checked_strided_offset(dest_offset_base, &self.dest_strides, out_idx)?;
+                        unsafe {
+                            // SAFETY: positive interior steps make the
+                            // input-to-output mapping injective for in-bounds
+                            // positions; the destination layout is also
+                            // injective.
+                            *dest_ptr.offset(dest_offset) = *operand_ptr.offset(operand_offset);
+                        }
+                    }
+                    advance_col_major_index(input_idx, &self.operand_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
     }
 
     fn check_call<T>(
@@ -643,6 +794,15 @@ fn advance_col_major_index(index: &mut [usize], shape: &[usize]) {
             return;
         }
         index[axis] = 0;
+    }
+}
+
+#[cfg(feature = "parallel")]
+fn fill_col_major_index(mut linear: usize, shape: &[usize], out: &mut [usize]) {
+    for (axis, coord) in out.iter_mut().enumerate() {
+        let dim = shape[axis];
+        *coord = linear % dim;
+        linear /= dim;
     }
 }
 

--- a/strided-kernel/src/threading.rs
+++ b/strided-kernel/src/threading.rs
@@ -59,6 +59,19 @@ impl<T> SendPtr<T> {
 pub(crate) const MINTHREADLENGTH: usize = 1 << 15;
 
 #[cfg(feature = "parallel")]
+pub(crate) fn parallel_threads_for_len(len: usize) -> usize {
+    if len <= MINTHREADLENGTH {
+        return 1;
+    }
+    let nthreads = crate::execution_policy::rayon_threads();
+    if nthreads > 1 {
+        nthreads
+    } else {
+        1
+    }
+}
+
+#[cfg(feature = "parallel")]
 fn join_with_policy<A, B, RA, RB>(policy: crate::ExecutionPolicy, left: A, right: B) -> (RA, RB)
 where
     A: FnOnce() -> RA + Send,
@@ -477,6 +490,23 @@ mod tests {
 
         // Single dimension
         assert_eq!(streaming_lastargmax(&[100], &[2]), 0);
+    }
+
+    #[test]
+    fn parallel_threads_for_len_honors_policy_and_threshold() {
+        let two = NonZeroUsize::new(2).unwrap();
+        let four = NonZeroUsize::new(4).unwrap();
+
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: two }, || {
+            assert_eq!(parallel_threads_for_len(MINTHREADLENGTH), 1);
+            assert_eq!(parallel_threads_for_len(MINTHREADLENGTH + 1), 2);
+        });
+        with_execution_policy(ExecutionPolicy::Rayon { max_threads: four }, || {
+            assert_eq!(parallel_threads_for_len(MINTHREADLENGTH + 1), 4);
+        });
+        with_execution_policy(ExecutionPolicy::Sequential, || {
+            assert_eq!(parallel_threads_for_len(MINTHREADLENGTH + 1), 1);
+        });
     }
 
     #[test]

--- a/strided-kernel/tests/erased_policy_parallel.rs
+++ b/strided-kernel/tests/erased_policy_parallel.rs
@@ -1,0 +1,396 @@
+#![cfg(feature = "parallel")]
+
+use strided_kernel::{
+    ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedGatherPlan,
+    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ErasedScatterPlan,
+    ExecContext, GatherSpec, KernelDType, ReduceOp, ScatterSpec,
+};
+
+const LARGE_LEN: usize = (1 << 15) + 65;
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn bounded_context() -> ExecContext {
+    ExecContext::max_threads(2).unwrap()
+}
+
+#[test]
+fn large_erased_copy_matches_serial() {
+    const ROWS: usize = 257;
+    const COLS: usize = 129;
+    const LEN: usize = ROWS * COLS;
+    let dims = [ROWS, COLS];
+    let src_strides = [COLS as isize, 1isize];
+    let dest_strides = [1isize, ROWS as isize];
+    let source: Vec<i64> = (0..LEN).map(|index| index as i64 - 17).collect();
+    let plan =
+        ErasedCopyPlan::compile(KernelDType::I64, &dims, &dest_strides, &src_strides).unwrap();
+
+    let run = |ctx: ExecContext| {
+        let source_ref =
+            ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&source), &dims, &src_strides, 0)
+                .unwrap();
+        let mut output = vec![0i64; LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::I64,
+            as_bytes_mut(&mut output),
+            &dims,
+            &dest_strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ctx, &mut dest, &source_ref).unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}
+
+#[test]
+fn large_erased_axis_reduce_matches_serial() {
+    let src_dims = [LARGE_LEN, 2usize];
+    let src_strides = [1isize, LARGE_LEN as isize];
+    let dest_dims = [LARGE_LEN];
+    let dest_strides = [1isize];
+    let source: Vec<i32> = (0..LARGE_LEN * 2)
+        .map(|index| (index % 251) as i32 - 113)
+        .collect();
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::I32,
+        ReduceOp::Sum,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[1],
+    )
+    .unwrap();
+
+    let run = |ctx: ExecContext| {
+        let source_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&source),
+            &src_dims,
+            &src_strides,
+            0,
+        )
+        .unwrap();
+        let mut output = vec![0i32; LARGE_LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::I32,
+            as_bytes_mut(&mut output),
+            &dest_dims,
+            &dest_strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ctx, &mut dest, &source_ref).unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}
+
+#[test]
+fn large_erased_gather_matches_serial() {
+    let dims = [LARGE_LEN];
+    let strides = [1isize];
+    let operand: Vec<f64> = (0..LARGE_LEN).map(|index| index as f64 * 0.5).collect();
+    let indices: Vec<i64> = (0..LARGE_LEN)
+        .map(|index| (LARGE_LEN - 1 - index) as i64)
+        .collect();
+    let spec = GatherSpec {
+        offset_dims: vec![],
+        collapsed_slice_dims: vec![0],
+        start_index_map: vec![0],
+        index_vector_dim: 1,
+        slice_sizes: vec![1],
+    };
+    let plan = ErasedGatherPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        spec,
+    )
+    .unwrap();
+
+    let run = |ctx: ExecContext| {
+        let operand_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0)
+                .unwrap();
+        let index_ref =
+            ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&indices), &dims, &strides, 0)
+                .unwrap();
+        let mut output = vec![0.0f64; LARGE_LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut output),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ctx, &mut dest, &operand_ref, &index_ref)
+            .unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}
+
+#[test]
+fn large_erased_dynamic_slice_and_update_match_serial() {
+    let operand_dims = [LARGE_LEN + 128];
+    let operand_strides = [1isize];
+    let starts_dims = [1usize];
+    let starts_strides = [1isize];
+    let window_dims = [LARGE_LEN];
+    let window_strides = [1isize];
+    let operand: Vec<i32> = (0..LARGE_LEN + 128)
+        .map(|index| (index % 997) as i32 - 411)
+        .collect();
+    let update: Vec<i32> = (0..LARGE_LEN)
+        .map(|index| 1000 + (index % 31) as i32)
+        .collect();
+    let starts = [64i64];
+
+    let slice = ErasedDynamicSlicePlan::compile(
+        KernelDType::I32,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &starts_dims,
+        &starts_strides,
+        &window_dims,
+        &window_strides,
+        &window_dims,
+    )
+    .unwrap();
+    let update_slice = ErasedDynamicUpdateSlicePlan::compile(
+        KernelDType::I32,
+        KernelDType::I64,
+        &operand_dims,
+        &operand_strides,
+        &starts_dims,
+        &starts_strides,
+        &window_dims,
+        &window_strides,
+        &operand_dims,
+        &operand_strides,
+    )
+    .unwrap();
+
+    let run_slice = |ctx: ExecContext| {
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let starts_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&starts),
+            &starts_dims,
+            &starts_strides,
+            0,
+        )
+        .unwrap();
+        let mut output = vec![0i32; LARGE_LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::I32,
+            as_bytes_mut(&mut output),
+            &window_dims,
+            &window_strides,
+            0,
+        )
+        .unwrap();
+        slice
+            .execute(&ctx, &mut dest, &operand_ref, &starts_ref)
+            .unwrap();
+        output
+    };
+    let run_update = |ctx: ExecContext| {
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let update_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&update),
+            &window_dims,
+            &window_strides,
+            0,
+        )
+        .unwrap();
+        let starts_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&starts),
+            &starts_dims,
+            &starts_strides,
+            0,
+        )
+        .unwrap();
+        let mut output = vec![0i32; LARGE_LEN + 128];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::I32,
+            as_bytes_mut(&mut output),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        update_slice
+            .execute(&ctx, &mut dest, &operand_ref, &update_ref, &starts_ref)
+            .unwrap();
+        output
+    };
+
+    assert_eq!(
+        run_slice(bounded_context()),
+        run_slice(ExecContext::serial())
+    );
+    assert_eq!(
+        run_update(bounded_context()),
+        run_update(ExecContext::serial())
+    );
+}
+
+#[test]
+fn large_erased_pad_matches_serial() {
+    let operand_dims = [LARGE_LEN];
+    let operand_strides = [1isize];
+    let dest_dims = [LARGE_LEN + 128];
+    let dest_strides = [1isize];
+    let edge_low = [64i64];
+    let edge_high = [64i64];
+    let interior = [0i64];
+    let fill = [-7i32];
+    let operand: Vec<i32> = (0..LARGE_LEN).map(|index| index as i32).collect();
+    let plan = ErasedPadPlan::compile(
+        KernelDType::I32,
+        &operand_dims,
+        &operand_strides,
+        &dest_dims,
+        &dest_strides,
+        &edge_low,
+        &edge_high,
+        &interior,
+    )
+    .unwrap();
+
+    let run = |ctx: ExecContext| {
+        let operand_ref = ErasedRawStridedRef::new(
+            KernelDType::I32,
+            as_bytes(&operand),
+            &operand_dims,
+            &operand_strides,
+            0,
+        )
+        .unwrap();
+        let mut output = vec![0i32; LARGE_LEN + 128];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::I32,
+            as_bytes_mut(&mut output),
+            &dest_dims,
+            &dest_strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ctx, &mut dest, &operand_ref, as_bytes(&fill))
+            .unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}
+
+#[test]
+fn large_erased_scatter_matches_serial_with_overlaps() {
+    let dims = [LARGE_LEN];
+    let strides = [1isize];
+    let index_dims = [LARGE_LEN, 1usize];
+    let index_strides = [1isize, LARGE_LEN as isize];
+    let operand: Vec<f64> = (0..LARGE_LEN).map(|index| index as f64).collect();
+    let updates: Vec<f64> = (0..LARGE_LEN)
+        .map(|index| (index % 17) as f64 - 3.0)
+        .collect();
+    let indices: Vec<i64> = (0..LARGE_LEN).map(|index| (index % 1024) as i64).collect();
+    let spec = ScatterSpec {
+        update_window_dims: vec![],
+        inserted_window_dims: vec![0],
+        scatter_dims_to_operand_dims: vec![0],
+        index_vector_dim: 1,
+    };
+    let plan = ErasedScatterPlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &dims,
+        &strides,
+        &index_dims,
+        &index_strides,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        spec,
+    )
+    .unwrap();
+
+    let run = |ctx: ExecContext| {
+        let operand_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0)
+                .unwrap();
+        let index_ref = ErasedRawStridedRef::new(
+            KernelDType::I64,
+            as_bytes(&indices),
+            &index_dims,
+            &index_strides,
+            0,
+        )
+        .unwrap();
+        let update_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&updates), &dims, &strides, 0)
+                .unwrap();
+        let mut output = vec![0.0f64; LARGE_LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut output),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        plan.execute(&ctx, &mut dest, &operand_ref, &index_ref, &update_ref)
+            .unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}


### PR DESCRIPTION
## Summary

- keep the `erased_policy_thresholds` Criterion bench target for policy-aware serial vs bounded-thread comparisons
- add `threading::parallel_threads_for_len` so erased replay uses `MINTHREADLENGTH` (`1 << 15`) as the single threshold source
- parallelize eligible large erased replay loops for axis reductions, gather, dynamic slice, dynamic-update overwrite, and pad fill/copy when `ExecContext::max_threads(n)` exposes more than one worker
- keep raw `CopyPlan` replay and additive scatter update serial for now; the raw-copy prototype regressed large contiguous copies, and additive scatter keeps deterministic overlapping-write semantics

Refs #163.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p strided-kernel --features parallel threading::tests::parallel_threads_for_len_honors_policy_and_threshold`
- `cargo test -p strided-kernel --features parallel --test erased_policy_parallel --quiet`
- `cargo test -p strided-kernel --features parallel --quiet`
- `cargo test -p strided-kernel --quiet`
- `cargo bench -p strided-kernel --features parallel --bench erased_policy_thresholds --no-run`
- `cargo test --workspace --quiet`
- exploratory threshold run: `nice -n 10 env RAYON_NUM_THREADS=2 STRIDED_KERNEL_ERASED_POLICY_BENCH_PROFILE=threshold STRIDED_KERNEL_ERASED_POLICY_BENCH_THREADS=2 cargo bench -p strided-kernel --features parallel --bench erased_policy_thresholds`

Benchmark note: the threshold run used two Rayon threads on a development machine and is recorded as an initial threshold decision, not a final high-core campaign.
