### PR TITLE
Expose validated bilateral permutation fusion planning

### DIFF
--- a/strided-perm/Cargo.toml
+++ b/strided-perm/Cargo.toml
@@ -9,6 +9,7 @@ description = "Cache-efficient tensor permutation / transpose (HPTT-inspired)."
 
 [dependencies]
 strided-view.workspace = true
+thiserror.workspace = true
 rayon = { workspace = true, optional = true }
 
 [features]

--- a/strided-perm/src/fuse.rs
+++ b/strided-perm/src/fuse.rs
@@ -155,49 +155,111 @@ pub fn compute_costs<S: AsRef<[isize]>>(all_strides: &[S]) -> Vec<isize> {
     costs
 }
 
-/// Bilateral dimension fusion for src + dst stride patterns.
+/// Validated result of fusing adjacent dimensions that are contiguous in
+/// both source and destination layouts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BilateralFusionPlan {
+    /// Fused non-trivial dimensions in iteration order.
+    pub dims: Vec<usize>,
+    /// Source strides corresponding to [`Self::dims`].
+    pub src_strides: Vec<isize>,
+    /// Destination strides corresponding to [`Self::dims`].
+    pub dst_strides: Vec<isize>,
+}
+
+/// Failure while validating or constructing a bilateral fusion plan.
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum FusionPlanError {
+    /// Shape and stride ranks do not agree.
+    #[error(
+        "metadata lengths differ: dims={dims}, src_strides={src_strides}, \
+         dst_strides={dst_strides}"
+    )]
+    LengthMismatch {
+        /// Number of dimensions.
+        dims: usize,
+        /// Number of source strides.
+        src_strides: usize,
+        /// Number of destination strides.
+        dst_strides: usize,
+    },
+    /// A dimension cannot be represented for stride arithmetic, or a fused
+    /// dimension product exceeds `usize`.
+    #[error("fused dimension product overflows usize")]
+    DimensionOverflow,
+}
+
+/// Plan bilateral dimension fusion for source and destination layouts.
 ///
-/// Two dimensions `i` and `i+1` can be fused if BOTH src and dst strides
-/// are contiguous for those dimensions. Returns the fused (dims, src_strides, dst_strides).
-pub fn fuse_dims_bilateral(
+/// Size-one axes are removed. Two remaining adjacent axes are fused only when
+/// each layout is affine-contiguous across the boundary. Negative strides are
+/// supported; stride multiplication overflow simply prevents fusion.
+///
+/// # Errors
+///
+/// Returns [`FusionPlanError::LengthMismatch`] when the metadata ranks differ,
+/// and [`FusionPlanError::DimensionOverflow`] when a dimension cannot
+/// participate safely in `isize` stride arithmetic or a fused extent
+/// overflows `usize`.
+pub fn plan_bilateral_fusion(
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) -> Result<BilateralFusionPlan, FusionPlanError> {
+    if dims.len() != src_strides.len() || dims.len() != dst_strides.len() {
+        return Err(FusionPlanError::LengthMismatch {
+            dims: dims.len(),
+            src_strides: src_strides.len(),
+            dst_strides: dst_strides.len(),
+        });
+    }
+
+    let mut plan = BilateralFusionPlan {
+        dims: Vec::with_capacity(dims.len()),
+        src_strides: Vec::with_capacity(dims.len()),
+        dst_strides: Vec::with_capacity(dims.len()),
+    };
+
+    for ((&dim, &src_stride), &dst_stride) in dims.iter().zip(src_strides).zip(dst_strides) {
+        if dim == 1 {
+            continue;
+        }
+        isize::try_from(dim).map_err(|_| FusionPlanError::DimensionOverflow)?;
+
+        if let Some(last) = plan.dims.len().checked_sub(1) {
+            let current_dim =
+                isize::try_from(plan.dims[last]).map_err(|_| FusionPlanError::DimensionOverflow)?;
+            let src_contiguous = plan.src_strides[last]
+                .checked_mul(current_dim)
+                .is_some_and(|expected| src_stride == expected);
+            let dst_contiguous = plan.dst_strides[last]
+                .checked_mul(current_dim)
+                .is_some_and(|expected| dst_stride == expected);
+
+            if src_contiguous && dst_contiguous {
+                plan.dims[last] = plan.dims[last]
+                    .checked_mul(dim)
+                    .ok_or(FusionPlanError::DimensionOverflow)?;
+                continue;
+            }
+        }
+
+        plan.dims.push(dim);
+        plan.src_strides.push(src_stride);
+        plan.dst_strides.push(dst_stride);
+    }
+
+    Ok(plan)
+}
+
+#[cfg(test)]
+fn fuse_dims_bilateral(
     dims: &[usize],
     src_strides: &[isize],
     dst_strides: &[isize],
 ) -> (Vec<usize>, Vec<isize>, Vec<isize>) {
-    let n = dims.len();
-    if n <= 1 {
-        return (dims.to_vec(), src_strides.to_vec(), dst_strides.to_vec());
-    }
-
-    let mut fused_dims = Vec::with_capacity(n);
-    let mut fused_src = Vec::with_capacity(n);
-    let mut fused_dst = Vec::with_capacity(n);
-
-    fused_dims.push(dims[0]);
-    fused_src.push(src_strides[0]);
-    fused_dst.push(dst_strides[0]);
-
-    for i in 1..n {
-        let last = fused_dims.len() - 1;
-        let d_prev = fused_dims[last];
-        let ss_prev = fused_src[last];
-        let ds_prev = fused_dst[last];
-
-        // Check if dim i is contiguous with the previous fused dim in BOTH src and dst
-        let src_contiguous = src_strides[i] == ss_prev * d_prev as isize;
-        let dst_contiguous = dst_strides[i] == ds_prev * d_prev as isize;
-
-        if src_contiguous && dst_contiguous {
-            // Fuse: multiply the last fused dim
-            fused_dims[last] *= dims[i];
-        } else {
-            fused_dims.push(dims[i]);
-            fused_src.push(src_strides[i]);
-            fused_dst.push(dst_strides[i]);
-        }
-    }
-
-    (fused_dims, fused_src, fused_dst)
+    let plan = plan_bilateral_fusion(dims, src_strides, dst_strides).unwrap();
+    (plan.dims, plan.src_strides, plan.dst_strides)
 }
 
 #[cfg(test)]

--- a/strided-perm/src/hptt/plan.rs
+++ b/strided-perm/src/hptt/plan.rs
@@ -3,7 +3,7 @@
 //! Mirrors HPTT C++'s plan construction: bilateral fusion → identify stride-1
 //! dims → determine execution mode → compute loop order → build ComputeNode chain.
 
-use crate::fuse::fuse_dims_bilateral;
+use crate::fuse::plan_bilateral_fusion;
 use crate::hptt::micro_kernel::{MicroKernel, ScalarKernel};
 
 /// A node in the recursive loop structure.
@@ -94,7 +94,11 @@ pub(crate) fn build_permute_plan(
     elem_size: usize,
 ) -> PermutePlan {
     // Phase 1: Bilateral dimension fusion
-    let (fused_dims, fused_src, fused_dst) = fuse_dims_bilateral(dims, src_strides, dst_strides);
+    let fusion = plan_bilateral_fusion(dims, src_strides, dst_strides)
+        .expect("HPTT permutation metadata is prevalidated");
+    let fused_dims = fusion.dims;
+    let fused_src = fusion.src_strides;
+    let fused_dst = fusion.dst_strides;
 
     let rank = fused_dims.len();
     if rank == 0 {

--- a/strided-perm/src/lib.rs
+++ b/strided-perm/src/lib.rs
@@ -26,6 +26,7 @@ mod order;
 pub use copy::{copy_into, copy_into_col_major};
 #[cfg(feature = "parallel")]
 pub use copy::{copy_into_col_major_par, copy_into_par};
+pub use fuse::{plan_bilateral_fusion, BilateralFusionPlan, FusionPlanError};
 
 // Constants
 pub const BLOCK_MEMORY_SIZE: usize = 32 * 1024;

--- a/strided-perm/tests/bilateral_fusion_plan.rs
+++ b/strided-perm/tests/bilateral_fusion_plan.rs
@@ -1,0 +1,131 @@
+use strided_perm::{plan_bilateral_fusion, BilateralFusionPlan, FusionPlanError};
+
+fn plan(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> BilateralFusionPlan {
+    plan_bilateral_fusion(dims, src_strides, dst_strides).unwrap()
+}
+
+#[test]
+fn empty_metadata_stays_rank_zero() {
+    assert_eq!(
+        plan(&[], &[], &[]),
+        BilateralFusionPlan {
+            dims: vec![],
+            src_strides: vec![],
+            dst_strides: vec![],
+        }
+    );
+}
+
+#[test]
+fn size_one_axes_are_removed_including_scalar_like_shapes() {
+    assert_eq!(
+        plan(&[1, 1], &[7, -3], &[9, 4]),
+        BilateralFusionPlan {
+            dims: vec![],
+            src_strides: vec![],
+            dst_strides: vec![],
+        }
+    );
+    assert_eq!(
+        plan(&[1, 5, 1], &[100, 1, -20], &[80, 1, 9]),
+        BilateralFusionPlan {
+            dims: vec![5],
+            src_strides: vec![1],
+            dst_strides: vec![1],
+        }
+    );
+}
+
+#[test]
+fn identity_layout_collapses_to_one_axis() {
+    assert_eq!(
+        plan(&[2, 3, 4], &[1, 2, 6], &[1, 2, 6]),
+        BilateralFusionPlan {
+            dims: vec![24],
+            src_strides: vec![1],
+            dst_strides: vec![1],
+        }
+    );
+}
+
+#[test]
+fn only_bilaterally_contiguous_axes_fuse() {
+    assert_eq!(
+        plan(&[2, 3, 4], &[1, 2, 100], &[1, 2, 6]),
+        BilateralFusionPlan {
+            dims: vec![6, 4],
+            src_strides: vec![1, 100],
+            dst_strides: vec![1, 6],
+        }
+    );
+    assert_eq!(
+        plan(&[2, 3, 4], &[1, 10, 40], &[1, 2, 6]),
+        BilateralFusionPlan {
+            dims: vec![2, 3, 4],
+            src_strides: vec![1, 10, 40],
+            dst_strides: vec![1, 2, 6],
+        }
+    );
+}
+
+#[test]
+fn two_dimensional_transpose_does_not_fuse() {
+    assert_eq!(
+        plan(&[3, 2], &[2, 1], &[1, 3]),
+        BilateralFusionPlan {
+            dims: vec![3, 2],
+            src_strides: vec![2, 1],
+            dst_strides: vec![1, 3],
+        }
+    );
+}
+
+#[test]
+fn negative_contiguous_strides_can_fuse() {
+    assert_eq!(
+        plan(&[2, 3], &[-1, -2], &[1, 2]),
+        BilateralFusionPlan {
+            dims: vec![6],
+            src_strides: vec![-1],
+            dst_strides: vec![1],
+        }
+    );
+}
+
+#[test]
+fn rank_24_contiguous_tensor_collapses_to_one_axis() {
+    let mut dims = vec![64];
+    dims.extend([2; 23]);
+    let mut strides = vec![1isize];
+    for axis in 1..dims.len() {
+        strides.push(strides[axis - 1] * dims[axis - 1] as isize);
+    }
+    assert_eq!(
+        plan(&dims, &strides, &strides),
+        BilateralFusionPlan {
+            dims: vec![dims.iter().product()],
+            src_strides: vec![1],
+            dst_strides: vec![1],
+        }
+    );
+}
+
+#[test]
+fn mismatched_metadata_lengths_are_rejected() {
+    assert_eq!(
+        plan_bilateral_fusion(&[2, 3], &[1], &[1, 2]),
+        Err(FusionPlanError::LengthMismatch {
+            dims: 2,
+            src_strides: 1,
+            dst_strides: 2,
+        })
+    );
+}
+
+#[test]
+fn unrepresentable_or_overflowing_dimensions_are_rejected() {
+    assert_eq!(
+        plan_bilateral_fusion(&[usize::MAX, 2], &[1, isize::MAX], &[1, isize::MAX]),
+        Err(FusionPlanError::DimensionOverflow)
+    );
+}


### PR DESCRIPTION
## Summary

- expose the validated bilateral dimension-fusion planner used by HPTT
- share source/destination fusion planning without duplicating permutation logic
- add coverage for valid fusion, invalid shapes, overflow, and rank edge cases

## Why

Issue tensor4all/tenferro-rs#1507 needs CUDA native and WebGPU permutation routes to consume the same host-side dimension-fusion plan. Publishing this planner keeps validation and fusion semantics in `strided-perm` instead of porting divergent logic into tenferro.

## Checks

- `strided-perm` workspace tests passed
- focused bilateral fusion planner tests passed

## Related

- tensor4all/tenferro-rs#1507
- tenferro-rs consumes commit `f342fca6d1790a1e2f4f5b32b73bd7404975feb6`
