### PR TITLE
Add compile-free erased map and zip entry points

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -20,10 +20,10 @@ use num_traits::{One, Zero};
 
 use crate::{
     fused_elementwise_into, ConcatenatePlan, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
-    ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, FusedPlan, FusedScalar, GatherIndex,
-    GatherPlan, GatherSpec, Identity, KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result,
-    ReversePlan, ScatterPlan, ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut,
-    RAW_FUSED_RANK_LIMIT,
+    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ExecContext, FusedPlan,
+    FusedScalar, GatherIndex, GatherPlan, GatherSpec, Identity, KernelDType, PadPlan,
+    RawStridedMut, RawStridedRef, Result, ReversePlan, ScatterPlan, ScatterSpec, SlicePlan,
+    StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -80,34 +80,43 @@ impl ErasedZipOp {
 ///
 /// The destination must not overlap the input. Real and complex dtypes support
 /// every [`ErasedMapOp`], signed integers use wrapping negate/abs semantics,
-/// and `bool` supports only [`ErasedMapOp::Conj`].
+/// and `bool` supports only [`ErasedMapOp::Conj`]. Complex absolute value has
+/// the real output contract `c32 -> f32` and `c64 -> f64`; all other supported
+/// unary operations preserve dtype.
 ///
 /// # Errors
 ///
 /// Returns a typed [`StridedError`] for dtype, shape, output-layout, overlap,
 /// or unsupported dtype/op contracts. Validation completes before any write.
 pub fn erased_map_into(
-    dtype: KernelDType,
+    input_dtype: KernelDType,
     op: ErasedMapOp,
     ctx: &ExecContext,
     dest: &mut ErasedRawStridedMut<'_>,
-    input: &ErasedRawStridedRef<'_>,
+    input: &ErasedRawStridedPtr<'_>,
 ) -> Result<()> {
-    check_dtype(dtype, dest.dtype())?;
-    check_dtype(dtype, input.dtype())?;
+    check_dtype(input_dtype, input.dtype())?;
+    check_dtype(map_output_dtype(input_dtype, op)?, dest.dtype())?;
     validate_no_overlap(dest, input, 0)?;
     dest.validate_data_if_needed()?;
+    let input = validated_input_ref(input)?;
 
-    let result = ctx.run(|| match dtype {
-        KernelDType::F32 => execute_one_shot_map::<f32>(op, dest, input),
-        KernelDType::F64 => execute_one_shot_map::<f64>(op, dest, input),
-        KernelDType::I32 => execute_one_shot_map::<i32>(op, dest, input),
-        KernelDType::I64 => execute_one_shot_map::<i64>(op, dest, input),
-        KernelDType::Bool => execute_one_shot_map::<bool>(op, dest, input),
-        KernelDType::C32 => execute_one_shot_map::<Complex32>(op, dest, input),
-        KernelDType::C64 => execute_one_shot_map::<Complex64>(op, dest, input),
+    let result = ctx.run(|| match (input_dtype, op) {
+        (KernelDType::C32, ErasedMapOp::Abs) => {
+            execute_one_shot_map_with::<f32, Complex32>(dest, &input, |value| value.norm())
+        }
+        (KernelDType::C64, ErasedMapOp::Abs) => {
+            execute_one_shot_map_with::<f64, Complex64>(dest, &input, |value| value.norm())
+        }
+        (KernelDType::F32, _) => execute_one_shot_map::<f32>(op, dest, &input),
+        (KernelDType::F64, _) => execute_one_shot_map::<f64>(op, dest, &input),
+        (KernelDType::I32, _) => execute_one_shot_map::<i32>(op, dest, &input),
+        (KernelDType::I64, _) => execute_one_shot_map::<i64>(op, dest, &input),
+        (KernelDType::Bool, _) => execute_one_shot_map::<bool>(op, dest, &input),
+        (KernelDType::C32, _) => execute_one_shot_map::<Complex32>(op, dest, &input),
+        (KernelDType::C64, _) => execute_one_shot_map::<Complex64>(op, dest, &input),
         _ => Err(StridedError::UnsupportedDType {
-            dtype: dtype.label(),
+            dtype: input_dtype.label(),
         }),
     });
     if result.is_ok() {
@@ -122,9 +131,9 @@ pub fn erased_map_into(
 /// Apply one runtime-selected binary operation without compiling a plan.
 ///
 /// The destination must not overlap either input. Real dtypes support every
-/// [`ErasedZipOp`]. Signed integers support add/subtract/multiply/min/max, and
-/// complex dtypes support add/subtract/multiply/divide. `bool` has no binary
-/// one-shot operations.
+/// [`ErasedZipOp`]. Signed integers support every operation with wrapping
+/// arithmetic and a pre-write zero-divisor check. Complex dtypes support
+/// add/subtract/multiply/divide. `bool` has no binary one-shot operations.
 ///
 /// # Errors
 ///
@@ -135,8 +144,8 @@ pub fn erased_zip_into(
     op: ErasedZipOp,
     ctx: &ExecContext,
     dest: &mut ErasedRawStridedMut<'_>,
-    lhs: &ErasedRawStridedRef<'_>,
-    rhs: &ErasedRawStridedRef<'_>,
+    lhs: &ErasedRawStridedPtr<'_>,
+    rhs: &ErasedRawStridedPtr<'_>,
 ) -> Result<()> {
     check_dtype(dtype, dest.dtype())?;
     check_dtype(dtype, lhs.dtype())?;
@@ -144,15 +153,17 @@ pub fn erased_zip_into(
     validate_no_overlap(dest, lhs, 0)?;
     validate_no_overlap(dest, rhs, 1)?;
     dest.validate_data_if_needed()?;
+    let lhs = validated_input_ref(lhs)?;
+    let rhs = validated_input_ref(rhs)?;
 
     let result = ctx.run(|| match dtype {
-        KernelDType::F32 => execute_one_shot_zip::<f32>(op, dest, lhs, rhs),
-        KernelDType::F64 => execute_one_shot_zip::<f64>(op, dest, lhs, rhs),
-        KernelDType::I32 => execute_one_shot_zip::<i32>(op, dest, lhs, rhs),
-        KernelDType::I64 => execute_one_shot_zip::<i64>(op, dest, lhs, rhs),
-        KernelDType::Bool => execute_one_shot_zip::<bool>(op, dest, lhs, rhs),
-        KernelDType::C32 => execute_one_shot_zip::<Complex32>(op, dest, lhs, rhs),
-        KernelDType::C64 => execute_one_shot_zip::<Complex64>(op, dest, lhs, rhs),
+        KernelDType::F32 => execute_one_shot_zip::<f32>(op, dest, &lhs, &rhs),
+        KernelDType::F64 => execute_one_shot_zip::<f64>(op, dest, &lhs, &rhs),
+        KernelDType::I32 => execute_one_shot_zip::<i32>(op, dest, &lhs, &rhs),
+        KernelDType::I64 => execute_one_shot_zip::<i64>(op, dest, &lhs, &rhs),
+        KernelDType::Bool => execute_one_shot_zip::<bool>(op, dest, &lhs, &rhs),
+        KernelDType::C32 => execute_one_shot_zip::<Complex32>(op, dest, &lhs, &rhs),
+        KernelDType::C64 => execute_one_shot_zip::<Complex64>(op, dest, &lhs, &rhs),
         _ => Err(StridedError::UnsupportedDType {
             dtype: dtype.label(),
         }),
@@ -1412,6 +1423,26 @@ fn execute_one_shot_map<T: OneShotScalar>(
     crate::map_view::map_raw_into::<T, T, Identity>(&mut dest, &input, |value| T::map(op, value))
 }
 
+fn execute_one_shot_map_with<D, A>(
+    dest: &mut ErasedRawStridedMut<'_>,
+    input: &ErasedRawStridedRef<'_>,
+    map: impl Fn(A) -> D + crate::MaybeSync,
+) -> Result<()>
+where
+    D: Copy + crate::MaybeSendSync,
+    A: Copy + crate::MaybeSendSync,
+{
+    validate_one_shot_destination(dest)?;
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<D>(dest.data_mut());
+    let mut dest =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    let input = erased_raw_ref::<A>(input);
+    crate::map_view::map_raw_into::<D, A, Identity>(&mut dest, &input, map)
+}
+
 fn execute_one_shot_zip<T: OneShotScalar>(
     op: ErasedZipOp,
     dest: &mut ErasedRawStridedMut<'_>,
@@ -1434,6 +1465,12 @@ fn execute_one_shot_zip<T: OneShotScalar>(
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     let lhs = erased_raw_ref::<T>(lhs);
     let rhs = erased_raw_ref::<T>(rhs);
+    if matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
+        && T::INTEGER
+        && raw_any(&rhs, T::is_zero)
+    {
+        return Err(StridedError::IntegerDivisionByZero { op: op.label() });
+    }
 
     crate::map_view::zip_map2_raw_into::<T, T, T, Identity, Identity>(
         &mut dest,
@@ -1444,7 +1481,7 @@ fn execute_one_shot_zip<T: OneShotScalar>(
 }
 
 fn validate_one_shot_destination(dest: &ErasedRawStridedMut<'_>) -> Result<()> {
-    if crate::fused::is_provably_injective_layout(dest.dims(), dest.strides()) {
+    if crate::fused::is_injective_layout_without_alloc(dest.dims(), dest.strides()) {
         Ok(())
     } else {
         Err(StridedError::NonInjectiveOutputLayout)
@@ -1453,15 +1490,15 @@ fn validate_one_shot_destination(dest: &ErasedRawStridedMut<'_>) -> Result<()> {
 
 fn validate_no_overlap(
     dest: &ErasedRawStridedMut<'_>,
-    input: &ErasedRawStridedRef<'_>,
+    input: &ErasedRawStridedPtr<'_>,
     input_index: usize,
 ) -> Result<()> {
     let dest_start = dest.data().as_ptr() as usize;
-    let input_start = input.data().as_ptr() as usize;
+    let input_start = input.data_ptr() as usize;
     let Some(dest_end) = dest_start.checked_add(dest.data().len()) else {
         return Err(StridedError::OffsetOverflow);
     };
-    let Some(input_end) = input_start.checked_add(input.data().len()) else {
+    let Some(input_end) = input_start.checked_add(input.byte_len()) else {
         return Err(StridedError::OffsetOverflow);
     };
     if dest_start < input_end && input_start < dest_end {
@@ -1472,6 +1509,10 @@ fn validate_no_overlap(
 }
 
 trait OneShotScalar: Copy + crate::MaybeSendSync + 'static {
+    const INTEGER: bool = false;
+    fn is_zero(_value: Self) -> bool {
+        false
+    }
     fn one_shot_dtype_label() -> &'static str;
     fn supports_map(op: ErasedMapOp) -> bool;
     fn supports_zip(op: ErasedZipOp) -> bool;
@@ -1521,15 +1562,19 @@ macro_rules! impl_real_one_shot_scalar {
                     ErasedZipOp::Maximum => {
                         if lhs.is_nan() || rhs.is_nan() {
                             <$ty>::NAN
+                        } else if lhs >= rhs {
+                            lhs
                         } else {
-                            lhs.max(rhs)
+                            rhs
                         }
                     }
                     ErasedZipOp::Minimum => {
                         if lhs.is_nan() || rhs.is_nan() {
                             <$ty>::NAN
+                        } else if lhs <= rhs {
+                            lhs
                         } else {
-                            lhs.min(rhs)
+                            rhs
                         }
                     }
                 }
@@ -1541,6 +1586,11 @@ macro_rules! impl_real_one_shot_scalar {
 macro_rules! impl_integer_one_shot_scalar {
     ($ty:ty, $label:literal) => {
         impl OneShotScalar for $ty {
+            const INTEGER: bool = true;
+
+            fn is_zero(value: Self) -> bool {
+                value == 0
+            }
             fn one_shot_dtype_label() -> &'static str {
                 $label
             }
@@ -1549,8 +1599,8 @@ macro_rules! impl_integer_one_shot_scalar {
                 true
             }
 
-            fn supports_zip(op: ErasedZipOp) -> bool {
-                !matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
+            fn supports_zip(_op: ErasedZipOp) -> bool {
+                true
             }
 
             #[inline(always)]
@@ -1571,9 +1621,8 @@ macro_rules! impl_integer_one_shot_scalar {
                     ErasedZipOp::Multiply => lhs.wrapping_mul(rhs),
                     ErasedZipOp::Maximum => lhs.max(rhs),
                     ErasedZipOp::Minimum => lhs.min(rhs),
-                    ErasedZipOp::Divide | ErasedZipOp::Remainder => {
-                        unreachable!("unsupported integer one-shot op")
-                    }
+                    ErasedZipOp::Divide => lhs.wrapping_div(rhs),
+                    ErasedZipOp::Remainder => lhs.wrapping_rem(rhs),
                 }
             }
         }
@@ -1607,9 +1656,9 @@ macro_rules! impl_complex_one_shot_scalar {
                     ErasedMapOp::Sign => {
                         let norm = value.norm();
                         if norm == 0.0 {
-                            value
+                            Self::new(0.0, 0.0)
                         } else {
-                            value / norm
+                            value / Self::new(norm, 0.0)
                         }
                     }
                 }
@@ -1666,6 +1715,56 @@ impl OneShotScalar for bool {
 fn erased_raw_ref<'a, T>(src: &ErasedRawStridedRef<'a>) -> RawStridedRef<'a, T> {
     let data = typed_slice::<T>(src.data());
     unsafe { RawStridedRef::new_unchecked(data, src.dims(), src.strides(), src.offset()) }
+}
+
+fn validated_input_ref<'a>(input: &ErasedRawStridedPtr<'a>) -> Result<ErasedRawStridedRef<'a>> {
+    // SAFETY: the pointer descriptor promises readable, dtype-valid storage,
+    // and the caller has already ruled out overlap with the mutable output.
+    let data = unsafe { input.data_unchecked() };
+    ErasedRawStridedRef::new(
+        input.dtype(),
+        data,
+        input.dims(),
+        input.strides(),
+        input.offset(),
+    )
+}
+
+fn map_output_dtype(dtype: KernelDType, op: ErasedMapOp) -> Result<KernelDType> {
+    match (dtype, op) {
+        (KernelDType::C32, ErasedMapOp::Abs) => Ok(KernelDType::F32),
+        (KernelDType::C64, ErasedMapOp::Abs) => Ok(KernelDType::F64),
+        (KernelDType::Bool, ErasedMapOp::Conj) => Ok(KernelDType::Bool),
+        (KernelDType::Bool, _) => Err(StridedError::UnsupportedOp {
+            op: op.label(),
+            dtype: dtype.label(),
+        }),
+        _ => Ok(dtype),
+    }
+}
+
+fn raw_any<T: Copy>(src: &RawStridedRef<'_, T>, predicate: impl Fn(T) -> bool + Copy) -> bool {
+    fn visit<T: Copy>(
+        src: &RawStridedRef<'_, T>,
+        axis: usize,
+        offset: isize,
+        predicate: impl Fn(T) -> bool + Copy,
+    ) -> bool {
+        if axis == src.dims().len() {
+            // SAFETY: RawStridedRef construction validated every reachable offset.
+            return predicate(unsafe { *src.data().as_ptr().offset(offset) });
+        }
+        let mut offset = offset;
+        for _ in 0..src.dims()[axis] {
+            if visit(src, axis + 1, offset, predicate) {
+                return true;
+            }
+            offset += src.strides()[axis];
+        }
+        false
+    }
+
+    visit(src, 0, src.offset(), predicate)
 }
 
 fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -1411,6 +1411,10 @@ fn execute_one_shot_map<T: OneShotScalar>(
         });
     }
     validate_one_shot_destination(dest)?;
+    crate::kernel::ensure_same_shape(dest.dims(), input.dims())?;
+    if dest.dims().contains(&0) {
+        return Ok(());
+    }
 
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
@@ -1433,6 +1437,10 @@ where
     A: Copy + crate::MaybeSendSync,
 {
     validate_one_shot_destination(dest)?;
+    crate::kernel::ensure_same_shape(dest.dims(), input.dims())?;
+    if dest.dims().contains(&0) {
+        return Ok(());
+    }
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
@@ -1456,22 +1464,26 @@ fn execute_one_shot_zip<T: OneShotScalar>(
         });
     }
     validate_one_shot_destination(dest)?;
+    crate::kernel::ensure_same_shape(dest.dims(), lhs.dims())?;
+    crate::kernel::ensure_same_shape(dest.dims(), rhs.dims())?;
+    if dest.dims().contains(&0) {
+        return Ok(());
+    }
 
+    let lhs = erased_raw_ref::<T>(lhs);
+    let rhs = erased_raw_ref::<T>(rhs);
+    if matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
+        && T::INTEGER
+        && raw_any(&rhs, T::is_zero)?
+    {
+        return Err(StridedError::IntegerDivisionByZero { op: op.label() });
+    }
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
     let dest_data = typed_slice_mut::<T>(dest.data_mut());
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
-    let lhs = erased_raw_ref::<T>(lhs);
-    let rhs = erased_raw_ref::<T>(rhs);
-    if matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
-        && T::INTEGER
-        && raw_any(&rhs, T::is_zero)
-    {
-        return Err(StridedError::IntegerDivisionByZero { op: op.label() });
-    }
-
     crate::map_view::zip_map2_raw_into::<T, T, T, Identity, Identity>(
         &mut dest,
         &lhs,
@@ -1743,28 +1755,35 @@ fn map_output_dtype(dtype: KernelDType, op: ErasedMapOp) -> Result<KernelDType> 
     }
 }
 
-fn raw_any<T: Copy>(src: &RawStridedRef<'_, T>, predicate: impl Fn(T) -> bool + Copy) -> bool {
-    fn visit<T: Copy>(
-        src: &RawStridedRef<'_, T>,
-        axis: usize,
-        offset: isize,
-        predicate: impl Fn(T) -> bool + Copy,
-    ) -> bool {
-        if axis == src.dims().len() {
-            // SAFETY: RawStridedRef construction validated every reachable offset.
-            return predicate(unsafe { *src.data().as_ptr().offset(offset) });
+fn raw_any<T: Copy>(
+    src: &RawStridedRef<'_, T>,
+    predicate: impl Fn(T) -> bool + Copy,
+) -> Result<bool> {
+    let total = src
+        .dims()
+        .iter()
+        .try_fold(1usize, |total, &dim| total.checked_mul(dim))
+        .ok_or(StridedError::OffsetOverflow)?;
+    for linear in 0..total {
+        let mut remainder = linear;
+        let mut offset = src.offset();
+        for (&dim, &stride) in src.dims().iter().zip(src.strides()) {
+            let index = remainder % dim;
+            remainder /= dim;
+            offset = offset
+                .checked_add(
+                    stride
+                        .checked_mul(index as isize)
+                        .ok_or(StridedError::OffsetOverflow)?,
+                )
+                .ok_or(StridedError::OffsetOverflow)?;
         }
-        let mut offset = offset;
-        for _ in 0..src.dims()[axis] {
-            if visit(src, axis + 1, offset, predicate) {
-                return true;
-            }
-            offset += src.strides()[axis];
+        // SAFETY: RawStridedRef construction validated every reachable offset.
+        if predicate(unsafe { *src.data().as_ptr().offset(offset) }) {
+            return Ok(true);
         }
-        false
     }
-
-    visit(src, 0, src.offset(), predicate)
+    Ok(false)
 }
 
 fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -21,12 +21,150 @@ use num_traits::{One, Zero};
 use crate::{
     fused_elementwise_into, ConcatenatePlan, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
     ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, FusedPlan, FusedScalar, GatherIndex,
-    GatherPlan, GatherSpec, KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result,
+    GatherPlan, GatherSpec, Identity, KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result,
     ReversePlan, ScatterPlan, ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut,
     RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
+
+/// Runtime unary operation for [`erased_map_into`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErasedMapOp {
+    Negate,
+    Conj,
+    Abs,
+    Sign,
+}
+
+impl ErasedMapOp {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Negate => "negate",
+            Self::Conj => "conj",
+            Self::Abs => "abs",
+            Self::Sign => "sign",
+        }
+    }
+}
+
+/// Runtime binary operation for [`erased_zip_into`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ErasedZipOp {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Remainder,
+    Maximum,
+    Minimum,
+}
+
+impl ErasedZipOp {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Subtract => "subtract",
+            Self::Multiply => "multiply",
+            Self::Divide => "divide",
+            Self::Remainder => "remainder",
+            Self::Maximum => "maximum",
+            Self::Minimum => "minimum",
+        }
+    }
+}
+
+/// Apply one runtime-selected unary operation without compiling a plan.
+///
+/// The destination must not overlap the input. Real and complex dtypes support
+/// every [`ErasedMapOp`], signed integers use wrapping negate/abs semantics,
+/// and `bool` supports only [`ErasedMapOp::Conj`].
+///
+/// # Errors
+///
+/// Returns a typed [`StridedError`] for dtype, shape, output-layout, overlap,
+/// or unsupported dtype/op contracts. Validation completes before any write.
+pub fn erased_map_into(
+    dtype: KernelDType,
+    op: ErasedMapOp,
+    ctx: &ExecContext,
+    dest: &mut ErasedRawStridedMut<'_>,
+    input: &ErasedRawStridedRef<'_>,
+) -> Result<()> {
+    check_dtype(dtype, dest.dtype())?;
+    check_dtype(dtype, input.dtype())?;
+    validate_no_overlap(dest, input, 0)?;
+    dest.validate_data_if_needed()?;
+
+    let result = ctx.run(|| match dtype {
+        KernelDType::F32 => execute_one_shot_map::<f32>(op, dest, input),
+        KernelDType::F64 => execute_one_shot_map::<f64>(op, dest, input),
+        KernelDType::I32 => execute_one_shot_map::<i32>(op, dest, input),
+        KernelDType::I64 => execute_one_shot_map::<i64>(op, dest, input),
+        KernelDType::Bool => execute_one_shot_map::<bool>(op, dest, input),
+        KernelDType::C32 => execute_one_shot_map::<Complex32>(op, dest, input),
+        KernelDType::C64 => execute_one_shot_map::<Complex64>(op, dest, input),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    });
+    if result.is_ok() {
+        // SAFETY: the scalar map writes valid values of the descriptor dtype.
+        unsafe {
+            dest.assume_data_valid();
+        }
+    }
+    result
+}
+
+/// Apply one runtime-selected binary operation without compiling a plan.
+///
+/// The destination must not overlap either input. Real dtypes support every
+/// [`ErasedZipOp`]. Signed integers support add/subtract/multiply/min/max, and
+/// complex dtypes support add/subtract/multiply/divide. `bool` has no binary
+/// one-shot operations.
+///
+/// # Errors
+///
+/// Returns a typed [`StridedError`] for dtype, shape, output-layout, overlap,
+/// or unsupported dtype/op contracts. Validation completes before any write.
+pub fn erased_zip_into(
+    dtype: KernelDType,
+    op: ErasedZipOp,
+    ctx: &ExecContext,
+    dest: &mut ErasedRawStridedMut<'_>,
+    lhs: &ErasedRawStridedRef<'_>,
+    rhs: &ErasedRawStridedRef<'_>,
+) -> Result<()> {
+    check_dtype(dtype, dest.dtype())?;
+    check_dtype(dtype, lhs.dtype())?;
+    check_dtype(dtype, rhs.dtype())?;
+    validate_no_overlap(dest, lhs, 0)?;
+    validate_no_overlap(dest, rhs, 1)?;
+    dest.validate_data_if_needed()?;
+
+    let result = ctx.run(|| match dtype {
+        KernelDType::F32 => execute_one_shot_zip::<f32>(op, dest, lhs, rhs),
+        KernelDType::F64 => execute_one_shot_zip::<f64>(op, dest, lhs, rhs),
+        KernelDType::I32 => execute_one_shot_zip::<i32>(op, dest, lhs, rhs),
+        KernelDType::I64 => execute_one_shot_zip::<i64>(op, dest, lhs, rhs),
+        KernelDType::Bool => execute_one_shot_zip::<bool>(op, dest, lhs, rhs),
+        KernelDType::C32 => execute_one_shot_zip::<Complex32>(op, dest, lhs, rhs),
+        KernelDType::C64 => execute_one_shot_zip::<Complex64>(op, dest, lhs, rhs),
+        _ => Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        }),
+    });
+    if result.is_ok() {
+        // SAFETY: the scalar zip writes valid values of the descriptor dtype.
+        unsafe {
+            dest.assume_data_valid();
+        }
+    }
+    result
+}
 
 /// Dtype-erased wrapper around [`CopyPlan`].
 #[derive(Clone, Debug)]
@@ -1248,6 +1386,286 @@ impl ErasedScatterPlan {
         }
         result
     }
+}
+
+fn execute_one_shot_map<T: OneShotScalar>(
+    op: ErasedMapOp,
+    dest: &mut ErasedRawStridedMut<'_>,
+    input: &ErasedRawStridedRef<'_>,
+) -> Result<()> {
+    if !T::supports_map(op) {
+        return Err(StridedError::UnsupportedOp {
+            op: op.label(),
+            dtype: T::one_shot_dtype_label(),
+        });
+    }
+    validate_one_shot_destination(dest)?;
+
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let mut dest =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    let input = erased_raw_ref::<T>(input);
+
+    crate::map_view::map_raw_into::<T, T, Identity>(&mut dest, &input, |value| T::map(op, value))
+}
+
+fn execute_one_shot_zip<T: OneShotScalar>(
+    op: ErasedZipOp,
+    dest: &mut ErasedRawStridedMut<'_>,
+    lhs: &ErasedRawStridedRef<'_>,
+    rhs: &ErasedRawStridedRef<'_>,
+) -> Result<()> {
+    if !T::supports_zip(op) {
+        return Err(StridedError::UnsupportedOp {
+            op: op.label(),
+            dtype: T::one_shot_dtype_label(),
+        });
+    }
+    validate_one_shot_destination(dest)?;
+
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let mut dest =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    let lhs = erased_raw_ref::<T>(lhs);
+    let rhs = erased_raw_ref::<T>(rhs);
+
+    crate::map_view::zip_map2_raw_into::<T, T, T, Identity, Identity>(
+        &mut dest,
+        &lhs,
+        &rhs,
+        |lhs, rhs| T::zip(op, lhs, rhs),
+    )
+}
+
+fn validate_one_shot_destination(dest: &ErasedRawStridedMut<'_>) -> Result<()> {
+    if crate::fused::is_provably_injective_layout(dest.dims(), dest.strides()) {
+        Ok(())
+    } else {
+        Err(StridedError::NonInjectiveOutputLayout)
+    }
+}
+
+fn validate_no_overlap(
+    dest: &ErasedRawStridedMut<'_>,
+    input: &ErasedRawStridedRef<'_>,
+    input_index: usize,
+) -> Result<()> {
+    let dest_start = dest.data().as_ptr() as usize;
+    let input_start = input.data().as_ptr() as usize;
+    let Some(dest_end) = dest_start.checked_add(dest.data().len()) else {
+        return Err(StridedError::OffsetOverflow);
+    };
+    let Some(input_end) = input_start.checked_add(input.data().len()) else {
+        return Err(StridedError::OffsetOverflow);
+    };
+    if dest_start < input_end && input_start < dest_end {
+        Err(StridedError::OverlappingInputOutput { input: input_index })
+    } else {
+        Ok(())
+    }
+}
+
+trait OneShotScalar: Copy + crate::MaybeSendSync + 'static {
+    fn one_shot_dtype_label() -> &'static str;
+    fn supports_map(op: ErasedMapOp) -> bool;
+    fn supports_zip(op: ErasedZipOp) -> bool;
+    fn map(op: ErasedMapOp, value: Self) -> Self;
+    fn zip(op: ErasedZipOp, lhs: Self, rhs: Self) -> Self;
+}
+
+macro_rules! impl_real_one_shot_scalar {
+    ($ty:ty, $label:literal) => {
+        impl OneShotScalar for $ty {
+            fn one_shot_dtype_label() -> &'static str {
+                $label
+            }
+
+            fn supports_map(_op: ErasedMapOp) -> bool {
+                true
+            }
+
+            fn supports_zip(_op: ErasedZipOp) -> bool {
+                true
+            }
+
+            #[inline(always)]
+            fn map(op: ErasedMapOp, value: Self) -> Self {
+                match op {
+                    ErasedMapOp::Negate => -value,
+                    ErasedMapOp::Conj => value,
+                    ErasedMapOp::Abs => value.abs(),
+                    ErasedMapOp::Sign => {
+                        if value == 0.0 {
+                            0.0
+                        } else {
+                            value.signum()
+                        }
+                    }
+                }
+            }
+
+            #[inline(always)]
+            fn zip(op: ErasedZipOp, lhs: Self, rhs: Self) -> Self {
+                match op {
+                    ErasedZipOp::Add => lhs + rhs,
+                    ErasedZipOp::Subtract => lhs - rhs,
+                    ErasedZipOp::Multiply => lhs * rhs,
+                    ErasedZipOp::Divide => lhs / rhs,
+                    ErasedZipOp::Remainder => lhs % rhs,
+                    ErasedZipOp::Maximum => {
+                        if lhs.is_nan() || rhs.is_nan() {
+                            <$ty>::NAN
+                        } else {
+                            lhs.max(rhs)
+                        }
+                    }
+                    ErasedZipOp::Minimum => {
+                        if lhs.is_nan() || rhs.is_nan() {
+                            <$ty>::NAN
+                        } else {
+                            lhs.min(rhs)
+                        }
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_integer_one_shot_scalar {
+    ($ty:ty, $label:literal) => {
+        impl OneShotScalar for $ty {
+            fn one_shot_dtype_label() -> &'static str {
+                $label
+            }
+
+            fn supports_map(_op: ErasedMapOp) -> bool {
+                true
+            }
+
+            fn supports_zip(op: ErasedZipOp) -> bool {
+                !matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
+            }
+
+            #[inline(always)]
+            fn map(op: ErasedMapOp, value: Self) -> Self {
+                match op {
+                    ErasedMapOp::Negate => value.wrapping_neg(),
+                    ErasedMapOp::Conj => value,
+                    ErasedMapOp::Abs => value.wrapping_abs(),
+                    ErasedMapOp::Sign => value.signum(),
+                }
+            }
+
+            #[inline(always)]
+            fn zip(op: ErasedZipOp, lhs: Self, rhs: Self) -> Self {
+                match op {
+                    ErasedZipOp::Add => lhs.wrapping_add(rhs),
+                    ErasedZipOp::Subtract => lhs.wrapping_sub(rhs),
+                    ErasedZipOp::Multiply => lhs.wrapping_mul(rhs),
+                    ErasedZipOp::Maximum => lhs.max(rhs),
+                    ErasedZipOp::Minimum => lhs.min(rhs),
+                    ErasedZipOp::Divide | ErasedZipOp::Remainder => {
+                        unreachable!("unsupported integer one-shot op")
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_complex_one_shot_scalar {
+    ($ty:ty, $label:literal) => {
+        impl OneShotScalar for $ty {
+            fn one_shot_dtype_label() -> &'static str {
+                $label
+            }
+
+            fn supports_map(_op: ErasedMapOp) -> bool {
+                true
+            }
+
+            fn supports_zip(op: ErasedZipOp) -> bool {
+                !matches!(
+                    op,
+                    ErasedZipOp::Remainder | ErasedZipOp::Maximum | ErasedZipOp::Minimum
+                )
+            }
+
+            #[inline(always)]
+            fn map(op: ErasedMapOp, value: Self) -> Self {
+                match op {
+                    ErasedMapOp::Negate => -value,
+                    ErasedMapOp::Conj => value.conj(),
+                    ErasedMapOp::Abs => Self::new(value.norm(), 0.0),
+                    ErasedMapOp::Sign => {
+                        let norm = value.norm();
+                        if norm == 0.0 {
+                            value
+                        } else {
+                            value / norm
+                        }
+                    }
+                }
+            }
+
+            #[inline(always)]
+            fn zip(op: ErasedZipOp, lhs: Self, rhs: Self) -> Self {
+                match op {
+                    ErasedZipOp::Add => lhs + rhs,
+                    ErasedZipOp::Subtract => lhs - rhs,
+                    ErasedZipOp::Multiply => lhs * rhs,
+                    ErasedZipOp::Divide => lhs / rhs,
+                    ErasedZipOp::Remainder | ErasedZipOp::Maximum | ErasedZipOp::Minimum => {
+                        unreachable!("unsupported complex one-shot op")
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_real_one_shot_scalar!(f32, "f32");
+impl_real_one_shot_scalar!(f64, "f64");
+impl_integer_one_shot_scalar!(i32, "i32");
+impl_integer_one_shot_scalar!(i64, "i64");
+impl_complex_one_shot_scalar!(Complex32, "c32");
+impl_complex_one_shot_scalar!(Complex64, "c64");
+
+impl OneShotScalar for bool {
+    fn one_shot_dtype_label() -> &'static str {
+        "bool"
+    }
+
+    fn supports_map(op: ErasedMapOp) -> bool {
+        matches!(op, ErasedMapOp::Conj)
+    }
+
+    fn supports_zip(_op: ErasedZipOp) -> bool {
+        false
+    }
+
+    fn map(op: ErasedMapOp, value: Self) -> Self {
+        match op {
+            ErasedMapOp::Conj => value,
+            _ => unreachable!("unsupported bool one-shot op"),
+        }
+    }
+
+    fn zip(_op: ErasedZipOp, _lhs: Self, _rhs: Self) -> Self {
+        unreachable!("unsupported bool one-shot op")
+    }
+}
+
+fn erased_raw_ref<'a, T>(src: &ErasedRawStridedRef<'a>) -> RawStridedRef<'a, T> {
+    let data = typed_slice::<T>(src.data());
+    unsafe { RawStridedRef::new_unchecked(data, src.dims(), src.strides(), src.offset()) }
 }
 
 fn check_dtype(expected: KernelDType, actual: KernelDType) -> Result<()> {

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -704,11 +704,40 @@ pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
     has_disjoint_stride_spans(dims, strides)
 }
 
-pub(crate) fn is_provably_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
+pub(crate) fn is_injective_layout_without_alloc(dims: &[usize], strides: &[isize]) -> bool {
     let Some(total) = validate_injective_layout_inputs(dims, strides) else {
         return false;
     };
-    total <= 1 || has_disjoint_stride_spans(dims, strides)
+    if total <= 1 || has_disjoint_stride_spans(dims, strides) {
+        return true;
+    }
+
+    const EXACT_CHECK_LIMIT: usize = 4096;
+    total <= EXACT_CHECK_LIMIT && has_unique_offsets_pairwise(dims, strides, total)
+}
+
+fn offset_for_linear_index(dims: &[usize], strides: &[isize], mut linear: usize) -> Option<isize> {
+    let mut offset = 0isize;
+    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+        let index = linear % dim;
+        linear /= dim;
+        offset = offset.checked_add(stride.checked_mul(index as isize)?)?;
+    }
+    Some(offset)
+}
+
+fn has_unique_offsets_pairwise(dims: &[usize], strides: &[isize], total: usize) -> bool {
+    for lhs in 0..total {
+        let Some(lhs_offset) = offset_for_linear_index(dims, strides, lhs) else {
+            return false;
+        };
+        for rhs in (lhs + 1)..total {
+            if offset_for_linear_index(dims, strides, rhs) == Some(lhs_offset) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 fn validate_injective_layout_inputs(dims: &[usize], strides: &[isize]) -> Option<usize> {

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -689,25 +689,11 @@ fn validate_destination_layout<T>(dest: &StridedViewMut<'_, T>) -> Result<()> {
 }
 
 pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
-    if dims.len() != strides.len() {
-        return false;
-    }
-
-    let Some(total) = dims
-        .iter()
-        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-    else {
+    let Some(total) = validate_injective_layout_inputs(dims, strides) else {
         return false;
     };
     if total <= 1 {
         return true;
-    }
-    if dims
-        .iter()
-        .zip(strides.iter())
-        .any(|(&dim, &stride)| dim > 1 && stride == 0)
-    {
-        return false;
     }
 
     const EXACT_CHECK_LIMIT: usize = 4096;
@@ -716,6 +702,34 @@ pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
     }
 
     has_disjoint_stride_spans(dims, strides)
+}
+
+pub(crate) fn is_provably_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
+    let Some(total) = validate_injective_layout_inputs(dims, strides) else {
+        return false;
+    };
+    total <= 1 || has_disjoint_stride_spans(dims, strides)
+}
+
+fn validate_injective_layout_inputs(dims: &[usize], strides: &[isize]) -> Option<usize> {
+    if dims.len() != strides.len() {
+        return None;
+    }
+
+    let total = dims
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))?;
+    if total <= 1 {
+        return Some(total);
+    }
+    if dims
+        .iter()
+        .zip(strides.iter())
+        .any(|(&dim, &stride)| dim > 1 && stride == 0)
+    {
+        return None;
+    }
+    Some(total)
 }
 
 fn has_unique_offsets_exact(dims: &[usize], strides: &[isize], total: usize) -> bool {
@@ -754,21 +768,30 @@ fn has_unique_offsets_exact(dims: &[usize], strides: &[isize], total: usize) -> 
 }
 
 fn has_disjoint_stride_spans(dims: &[usize], strides: &[isize]) -> bool {
-    let mut axes = Vec::with_capacity(dims.len());
-    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
-        if dim <= 1 {
-            continue;
-        }
-        let stride_abs = match stride.checked_abs() {
-            Some(stride_abs) => stride_abs as u128,
-            None => return false,
-        };
-        axes.push((stride_abs, dim as u128 - 1));
-    }
-    axes.sort_unstable_by_key(|&(stride, _)| stride);
-
     let mut covered_span = 0u128;
-    for (stride, extent) in axes {
+    let mut previous_axis = None;
+    let active_axes = dims.iter().filter(|&&dim| dim > 1).count();
+    for _ in 0..active_axes {
+        let mut next = None;
+        for (axis, (&dim, &stride)) in dims.iter().zip(strides.iter()).enumerate() {
+            if dim <= 1 {
+                continue;
+            }
+            let stride = match stride.checked_abs() {
+                Some(stride) => stride as u128,
+                None => return false,
+            };
+            let key = (stride, axis);
+            if previous_axis.is_some_and(|previous| key <= previous) {
+                continue;
+            }
+            if next.is_none_or(|(best, _)| key < best) {
+                next = Some((key, dim as u128 - 1));
+            }
+        }
+        let Some(((stride, axis), extent)) = next else {
+            return false;
+        };
         if stride <= covered_span {
             return false;
         }
@@ -779,6 +802,7 @@ fn has_disjoint_stride_spans(dims: &[usize], strides: &[isize]) -> bool {
             Some(covered_span) => covered_span,
             None => return false,
         };
+        previous_axis = Some((stride, axis));
     }
 
     true

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -87,8 +87,9 @@ mod reduce_view;
 pub use strided_view::view;
 pub use strided_view::{
     col_major_strides, row_major_strides, Adjoint, ComposableElementOp, Compose, Conj, ElementOp,
-    ElementOpApply, ErasedRawStridedMut, ErasedRawStridedRef, Identity, KernelDType, RawStridedMut,
-    RawStridedRef, Result, StridedArray, StridedError, StridedView, StridedViewMut, Transpose,
+    ElementOpApply, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, Identity,
+    KernelDType, RawStridedMut, RawStridedRef, Result, StridedArray, StridedError, StridedView,
+    StridedViewMut, Transpose,
 };
 
 // ============================================================================

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -128,9 +128,10 @@ pub use raw_ops::{
 // ============================================================================
 pub use copy_plan::CopyPlan;
 pub use erased::{
-    ErasedConcatenatePlan, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
-    ErasedFusedPlan, ErasedGatherPlan, ErasedPadPlan, ErasedReducePlan, ErasedReversePlan,
-    ErasedScatterPlan, ErasedSlicePlan, ReduceOp,
+    erased_map_into, erased_zip_into, ErasedConcatenatePlan, ErasedCopyPlan,
+    ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedFusedPlan, ErasedGatherPlan,
+    ErasedMapOp, ErasedPadPlan, ErasedReducePlan, ErasedReversePlan, ErasedScatterPlan,
+    ErasedSlicePlan, ErasedZipOp, ReduceOp,
 };
 pub use exec_context::ExecContext;
 pub use gather_plan::{

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -864,13 +864,44 @@ pub fn map_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<
     src: &StridedView<A, Op>,
     f: impl Fn(A) -> D + MaybeSync,
 ) -> Result<()> {
-    ensure_same_shape(dest.dims(), src.dims())?;
+    map_parts_into::<D, A, Op>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        src.ptr(),
+        src.dims(),
+        src.strides(),
+        f,
+    )
+}
 
-    let dst_ptr = dest.as_mut_ptr();
-    let src_ptr = src.ptr();
-    let dst_dims = dest.dims();
-    let dst_strides = dest.strides();
-    let src_strides = src.strides();
+pub(crate) fn map_raw_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<A>>(
+    dest: &mut crate::RawStridedMut<'_, D>,
+    src: &crate::RawStridedRef<'_, A>,
+    f: impl Fn(A) -> D + MaybeSync,
+) -> Result<()> {
+    map_parts_into::<D, A, Op>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        src.ptr(),
+        src.dims(),
+        src.strides(),
+        f,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn map_parts_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<A>>(
+    dst_ptr: *mut D,
+    dst_dims: &[usize],
+    dst_strides: &[isize],
+    src_ptr: *const A,
+    src_dims: &[usize],
+    src_strides: &[isize],
+    f: impl Fn(A) -> D + MaybeSync,
+) -> Result<()> {
+    ensure_same_shape(dst_dims, src_dims)?;
 
     if sequential_contiguous_layout(dst_dims, &[dst_strides, src_strides]).is_some() {
         let len = total_len(dst_dims);
@@ -966,17 +997,67 @@ pub fn zip_map2_into<
     b: &StridedView<B, OpB>,
     f: impl Fn(A, B) -> D + MaybeSync,
 ) -> Result<()> {
-    ensure_same_shape(dest.dims(), a.dims())?;
-    ensure_same_shape(dest.dims(), b.dims())?;
+    zip_map2_parts_into::<D, A, B, OpA, OpB>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        a.ptr(),
+        a.dims(),
+        a.strides(),
+        b.ptr(),
+        b.dims(),
+        b.strides(),
+        f,
+    )
+}
 
-    let dst_ptr = dest.as_mut_ptr();
-    let dst_dims = dest.dims();
-    let dst_strides = dest.strides();
-    let a_ptr = a.ptr();
-    let b_ptr = b.ptr();
+pub(crate) fn zip_map2_raw_into<
+    D: Copy + MaybeSendSync,
+    A: Copy + MaybeSendSync,
+    B: Copy + MaybeSendSync,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dest: &mut crate::RawStridedMut<'_, D>,
+    a: &crate::RawStridedRef<'_, A>,
+    b: &crate::RawStridedRef<'_, B>,
+    f: impl Fn(A, B) -> D + MaybeSync,
+) -> Result<()> {
+    zip_map2_parts_into::<D, A, B, OpA, OpB>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        a.ptr(),
+        a.dims(),
+        a.strides(),
+        b.ptr(),
+        b.dims(),
+        b.strides(),
+        f,
+    )
+}
 
-    let a_strides = a.strides();
-    let b_strides = b.strides();
+#[allow(clippy::too_many_arguments)]
+fn zip_map2_parts_into<
+    D: Copy + MaybeSendSync,
+    A: Copy + MaybeSendSync,
+    B: Copy + MaybeSendSync,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dst_ptr: *mut D,
+    dst_dims: &[usize],
+    dst_strides: &[isize],
+    a_ptr: *const A,
+    a_dims: &[usize],
+    a_strides: &[isize],
+    b_ptr: *const B,
+    b_dims: &[usize],
+    b_strides: &[isize],
+    f: impl Fn(A, B) -> D + MaybeSync,
+) -> Result<()> {
+    ensure_same_shape(dst_dims, a_dims)?;
+    ensure_same_shape(dst_dims, b_dims)?;
 
     if sequential_contiguous_layout(dst_dims, &[dst_strides, a_strides, b_strides]).is_some() {
         let len = total_len(dst_dims);

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -10,10 +10,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use num_complex::Complex64;
 use strided_kernel::{
-    CopyPlan, ErasedConcatenatePlan, ErasedCopyPlan, ErasedDynamicSlicePlan,
-    ErasedDynamicUpdateSlicePlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef,
-    ErasedReducePlan, ErasedReversePlan, ErasedScatterPlan, ErasedSlicePlan, ExecContext,
-    KernelDType, RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec,
+    erased_map_into, erased_zip_into, map_into, zip_map2_into, CopyPlan, ErasedConcatenatePlan,
+    ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedMapOp,
+    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ErasedReversePlan,
+    ErasedScatterPlan, ErasedSlicePlan, ErasedZipOp, ExecContext, Identity, KernelDType,
+    RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec, StridedView, StridedViewMut,
 };
 
 struct CountingAllocator;
@@ -137,6 +138,67 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased execute must not allocate");
+
+    let dims = [256usize];
+    let strides = [1isize];
+    let lhs: Vec<f64> = (0..256).map(|value| value as f64).collect();
+    let rhs: Vec<f64> = (0..256).map(|value| (value + 1) as f64).collect();
+    let lhs_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+    let rhs_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let mut dst = vec![0.0f64; 256];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
+            .unwrap();
+
+    erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut dest,
+        &lhs_ref,
+        &rhs_ref,
+    )
+    .unwrap();
+    let mut typed_dst = vec![0.0f64; 256];
+    let lhs_view: StridedView<'_, f64, Identity> =
+        StridedView::new(&lhs, &dims, &strides, 0).unwrap();
+    let rhs_view: StridedView<'_, f64, Identity> =
+        StridedView::new(&rhs, &dims, &strides, 0).unwrap();
+    let mut typed_dest = StridedViewMut::new(&mut typed_dst, &dims, &strides, 0).unwrap();
+    zip_map2_into(&mut typed_dest, &lhs_view, &rhs_view, |lhs, rhs| lhs + rhs).unwrap();
+    let kernel_allocations = count_allocations(|| {
+        for _ in 0..16 {
+            zip_map2_into(&mut typed_dest, &lhs_view, &rhs_view, |lhs, rhs| lhs + rhs).unwrap();
+            map_into(&mut typed_dest, &lhs_view, |value| -value).unwrap();
+        }
+    });
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            erased_zip_into(
+                KernelDType::F64,
+                ErasedZipOp::Add,
+                &ExecContext::serial(),
+                &mut dest,
+                &lhs_ref,
+                &rhs_ref,
+            )
+            .unwrap();
+            erased_map_into(
+                KernelDType::F64,
+                ErasedMapOp::Negate,
+                &ExecContext::serial(),
+                &mut dest,
+                &lhs_ref,
+            )
+            .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, kernel_allocations,
+        "one-shot erased map/zip must not allocate beyond the typed kernels"
+    );
 
     let src_dims = [2usize; 8];
     let src_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -12,9 +12,9 @@ use num_complex::Complex64;
 use strided_kernel::{
     erased_map_into, erased_zip_into, map_into, zip_map2_into, CopyPlan, ErasedConcatenatePlan,
     ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedMapOp,
-    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ErasedReversePlan,
-    ErasedScatterPlan, ErasedSlicePlan, ErasedZipOp, ExecContext, Identity, KernelDType,
-    RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec, StridedView, StridedViewMut,
+    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedReducePlan,
+    ErasedReversePlan, ErasedScatterPlan, ErasedSlicePlan, ErasedZipOp, ExecContext, Identity,
+    KernelDType, RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec, StridedView, StridedViewMut,
 };
 
 struct CountingAllocator;
@@ -157,8 +157,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         ErasedZipOp::Add,
         &ExecContext::serial(),
         &mut dest,
-        &lhs_ref,
-        &rhs_ref,
+        &ErasedRawStridedPtr::from_ref(&lhs_ref),
+        &ErasedRawStridedPtr::from_ref(&rhs_ref),
     )
     .unwrap();
     let mut typed_dst = vec![0.0f64; 256];
@@ -181,8 +181,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
                 ErasedZipOp::Add,
                 &ExecContext::serial(),
                 &mut dest,
-                &lhs_ref,
-                &rhs_ref,
+                &ErasedRawStridedPtr::from_ref(&lhs_ref),
+                &ErasedRawStridedPtr::from_ref(&rhs_ref),
             )
             .unwrap();
             erased_map_into(
@@ -190,7 +190,7 @@ fn execute_is_allocation_free_up_to_rank_limit() {
                 ErasedMapOp::Negate,
                 &ExecContext::serial(),
                 &mut dest,
-                &lhs_ref,
+                &ErasedRawStridedPtr::from_ref(&lhs_ref),
             )
             .unwrap();
         }

--- a/strided-kernel/tests/erased_one_shot.rs
+++ b/strided-kernel/tests/erased_one_shot.rs
@@ -1,8 +1,9 @@
 use num_complex::{Complex32, Complex64};
+use std::ptr::NonNull;
 use strided_kernel::{
     erased_map_into, erased_zip_into, ErasedFusedPlan, ErasedMapOp, ErasedRawStridedMut,
-    ErasedRawStridedRef, ErasedZipOp, ExecContext, FusedInst, FusedOp, FusedPlan, KernelDType,
-    StridedError,
+    ErasedRawStridedPtr, ErasedRawStridedRef, ErasedZipOp, ExecContext, FusedInst, FusedOp,
+    FusedPlan, KernelDType, StridedError,
 };
 
 fn as_bytes<T>(data: &[T]) -> &[u8] {
@@ -52,7 +53,7 @@ fn assert_unary_matches_plan<T>(
             one_shot_op,
             &ExecContext::serial(),
             &mut output,
-            &input,
+            &ErasedRawStridedPtr::from_ref(&input),
         )
         .unwrap();
     }
@@ -96,8 +97,8 @@ fn assert_binary_matches_plan<T>(
             one_shot_op,
             &ExecContext::serial(),
             &mut output,
-            &lhs,
-            &rhs,
+            &ErasedRawStridedPtr::from_ref(&lhs),
+            &ErasedRawStridedPtr::from_ref(&rhs),
         )
         .unwrap();
     }
@@ -188,7 +189,7 @@ fn one_shot_covers_required_unary_and_binary_ops() {
         ErasedMapOp::Sign,
         &ExecContext::serial(),
         &mut output,
-        &input_ref,
+        &ErasedRawStridedPtr::from_ref(&input_ref),
     )
     .unwrap();
     assert_eq!(signed, [-1.0, 0.0, 1.0]);
@@ -215,8 +216,8 @@ fn one_shot_covers_required_unary_and_binary_ops() {
             op,
             &ExecContext::serial(),
             &mut output,
-            &lhs_ref,
-            &rhs_ref,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+            &ErasedRawStridedPtr::from_ref(&rhs_ref),
         )
         .unwrap();
         assert_eq!(actual, expected);
@@ -249,8 +250,8 @@ fn one_shot_handles_borrowed_noncontiguous_metadata() {
         ErasedZipOp::Add,
         &ExecContext::serial(),
         &mut dest,
-        &lhs,
-        &rhs,
+        &ErasedRawStridedPtr::from_ref(&lhs),
+        &ErasedRawStridedPtr::from_ref(&rhs),
     )
     .unwrap();
 
@@ -279,7 +280,7 @@ fn one_shot_empty_output_is_a_noop_for_degenerate_strides() {
         ErasedMapOp::Negate,
         &ExecContext::serial(),
         &mut output,
-        &input,
+        &ErasedRawStridedPtr::from_ref(&input),
     )
     .unwrap();
 }
@@ -309,8 +310,8 @@ fn one_shot_rejects_unsupported_ops_before_writing() {
         ErasedZipOp::Add,
         &ExecContext::serial(),
         &mut dest,
-        &lhs,
-        &rhs,
+        &ErasedRawStridedPtr::from_ref(&lhs),
+        &ErasedRawStridedPtr::from_ref(&rhs),
     )
     .unwrap_err();
 
@@ -322,4 +323,227 @@ fn one_shot_rejects_unsupported_ops_before_writing() {
         }
     ));
     assert_eq!(dst, [true, true]);
+}
+
+#[test]
+fn one_shot_complex_abs_uses_real_output_dtype() {
+    macro_rules! check {
+        ($input_ty:ty, $output_ty:ty, $input_dtype:expr, $output_dtype:expr) => {{
+            let dims = [2usize];
+            let strides = [1isize];
+            let input = [<$input_ty>::new(3.0, 4.0), <$input_ty>::new(5.0, 12.0)];
+            let input =
+                ErasedRawStridedRef::new($input_dtype, as_bytes(&input), &dims, &strides, 0)
+                    .unwrap();
+            let mut actual = [0.0 as $output_ty; 2];
+            let mut output = ErasedRawStridedMut::new(
+                $output_dtype,
+                as_bytes_mut(&mut actual),
+                &dims,
+                &strides,
+                0,
+            )
+            .unwrap();
+            erased_map_into(
+                $input_dtype,
+                ErasedMapOp::Abs,
+                &ExecContext::serial(),
+                &mut output,
+                &ErasedRawStridedPtr::from_ref(&input),
+            )
+            .unwrap();
+            assert_eq!(actual, [5.0, 13.0]);
+        }};
+    }
+
+    check!(Complex32, f32, KernelDType::C32, KernelDType::F32);
+    check!(Complex64, f64, KernelDType::C64, KernelDType::F64);
+}
+
+#[test]
+fn one_shot_integer_division_is_wrapping_and_zero_is_preflighted() {
+    macro_rules! check {
+        ($ty:ty, $dtype:expr) => {{
+            let dims = [2usize];
+            let strides = [1isize];
+            let lhs = [<$ty>::MIN, 7];
+            let rhs = [-1 as $ty, 3];
+            for (op, expected) in [
+                (ErasedZipOp::Divide, [<$ty>::MIN, 2]),
+                (ErasedZipOp::Remainder, [0, 1]),
+            ] {
+                let lhs =
+                    ErasedRawStridedRef::new($dtype, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+                let rhs =
+                    ErasedRawStridedRef::new($dtype, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+                let mut actual = [99 as $ty; 2];
+                let mut output =
+                    ErasedRawStridedMut::new($dtype, as_bytes_mut(&mut actual), &dims, &strides, 0)
+                        .unwrap();
+                erased_zip_into(
+                    $dtype,
+                    op,
+                    &ExecContext::serial(),
+                    &mut output,
+                    &ErasedRawStridedPtr::from_ref(&lhs),
+                    &ErasedRawStridedPtr::from_ref(&rhs),
+                )
+                .unwrap();
+                assert_eq!(actual, expected);
+            }
+
+            let rhs = [1 as $ty, 0];
+            let lhs = ErasedRawStridedRef::new($dtype, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+            let rhs = ErasedRawStridedRef::new($dtype, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+            let mut actual = [99 as $ty; 2];
+            let mut output =
+                ErasedRawStridedMut::new($dtype, as_bytes_mut(&mut actual), &dims, &strides, 0)
+                    .unwrap();
+            let error = erased_zip_into(
+                $dtype,
+                ErasedZipOp::Divide,
+                &ExecContext::serial(),
+                &mut output,
+                &ErasedRawStridedPtr::from_ref(&lhs),
+                &ErasedRawStridedPtr::from_ref(&rhs),
+            )
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                StridedError::IntegerDivisionByZero { op: "divide" }
+            ));
+            assert_eq!(actual, [99, 99]);
+        }};
+    }
+
+    check!(i32, KernelDType::I32);
+    check!(i64, KernelDType::I64);
+}
+
+#[test]
+fn one_shot_preserves_tenferro_numeric_edge_semantics() {
+    let dims = [2usize];
+    let strides = [1isize];
+
+    for op in [ErasedZipOp::Maximum, ErasedZipOp::Minimum] {
+        let lhs = [0.0f64, -0.0];
+        let rhs = [-0.0f64, 0.0];
+        let lhs_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+        let rhs_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let mut actual = [1.0f64; 2];
+        let mut output = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut actual),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        erased_zip_into(
+            KernelDType::F64,
+            op,
+            &ExecContext::serial(),
+            &mut output,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+            &ErasedRawStridedPtr::from_ref(&rhs_ref),
+        )
+        .unwrap();
+        assert_eq!(actual[0].to_bits(), lhs[0].to_bits());
+        assert_eq!(actual[1].to_bits(), lhs[1].to_bits());
+    }
+
+    let input = [Complex64::new(-0.0, 0.0), Complex64::new(3.0, 4.0)];
+    let input =
+        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut actual = [Complex64::new(1.0, 1.0); 2];
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::C64,
+        as_bytes_mut(&mut actual),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    erased_map_into(
+        KernelDType::C64,
+        ErasedMapOp::Sign,
+        &ExecContext::serial(),
+        &mut output,
+        &ErasedRawStridedPtr::from_ref(&input),
+    )
+    .unwrap();
+    assert_eq!(actual[0].re.to_bits(), 0.0f64.to_bits());
+    assert_eq!(actual[0].im.to_bits(), 0.0f64.to_bits());
+    assert_eq!(actual[1], Complex64::new(0.6, 0.8));
+}
+
+#[test]
+fn one_shot_rejects_overlap_before_forming_input_reference() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let mut storage = [1.0f64, 2.0];
+    let ptr = NonNull::new(storage.as_mut_ptr().cast::<u8>()).unwrap();
+    let input = unsafe {
+        ErasedRawStridedPtr::new(
+            KernelDType::F64,
+            ptr,
+            core::mem::size_of_val(&storage),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap()
+    };
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut storage),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    let error = erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut output,
+        &input,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        StridedError::OverlappingInputOutput { input: 0 }
+    ));
+    assert_eq!(storage, [1.0, 2.0]);
+}
+
+#[test]
+fn one_shot_accepts_small_injective_layout_without_allocating() {
+    let dims = [3usize, 2];
+    let input_strides = [1isize, 3];
+    let output_strides = [2isize, 3];
+    let input = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let input =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &input_strides, 0)
+            .unwrap();
+    let mut actual = [0.0f64; 8];
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut actual),
+        &dims,
+        &output_strides,
+        0,
+    )
+    .unwrap();
+    erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut output,
+        &ErasedRawStridedPtr::from_ref(&input),
+    )
+    .unwrap();
+    assert_eq!(actual, [-1.0, 0.0, -2.0, -4.0, -3.0, -5.0, 0.0, -6.0]);
 }

--- a/strided-kernel/tests/erased_one_shot.rs
+++ b/strided-kernel/tests/erased_one_shot.rs
@@ -1,0 +1,325 @@
+use num_complex::{Complex32, Complex64};
+use strided_kernel::{
+    erased_map_into, erased_zip_into, ErasedFusedPlan, ErasedMapOp, ErasedRawStridedMut,
+    ErasedRawStridedRef, ErasedZipOp, ExecContext, FusedInst, FusedOp, FusedPlan, KernelDType,
+    StridedError,
+};
+
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe { core::slice::from_raw_parts(data.as_ptr().cast::<u8>(), core::mem::size_of_val(data)) }
+}
+
+fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            core::mem::size_of_val(data),
+        )
+    }
+}
+
+fn single_op_plan(input_count: usize, op: FusedOp) -> FusedPlan {
+    FusedPlan {
+        input_count,
+        outputs: vec![input_count],
+        ops: vec![FusedInst {
+            op,
+            inputs: (0..input_count).collect(),
+        }],
+    }
+}
+
+fn assert_unary_matches_plan<T>(
+    dtype: KernelDType,
+    input: &[T],
+    one_shot_op: ErasedMapOp,
+    plan_op: FusedOp,
+) where
+    T: Copy + Default + PartialEq + core::fmt::Debug,
+{
+    let dims = [input.len()];
+    let strides = [1isize];
+    let mut one_shot = vec![T::default(); input.len()];
+    let mut planned = vec![T::default(); input.len()];
+
+    {
+        let input = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let mut output =
+            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut one_shot), &dims, &strides, 0)
+                .unwrap();
+        erased_map_into(
+            dtype,
+            one_shot_op,
+            &ExecContext::serial(),
+            &mut output,
+            &input,
+        )
+        .unwrap();
+    }
+
+    {
+        let input = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let mut output =
+            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut planned), &dims, &strides, 0)
+                .unwrap();
+        ErasedFusedPlan::compile(dtype, single_op_plan(1, plan_op))
+            .unwrap()
+            .execute(&ExecContext::serial(), &mut output, &[input])
+            .unwrap();
+    }
+
+    assert_eq!(one_shot, planned);
+}
+
+fn assert_binary_matches_plan<T>(
+    dtype: KernelDType,
+    lhs: &[T],
+    rhs: &[T],
+    one_shot_op: ErasedZipOp,
+    plan_op: FusedOp,
+) where
+    T: Copy + Default + PartialEq + core::fmt::Debug,
+{
+    let dims = [lhs.len()];
+    let strides = [1isize];
+    let mut one_shot = vec![T::default(); lhs.len()];
+    let mut planned = vec![T::default(); lhs.len()];
+
+    {
+        let lhs = ErasedRawStridedRef::new(dtype, as_bytes(lhs), &dims, &strides, 0).unwrap();
+        let rhs = ErasedRawStridedRef::new(dtype, as_bytes(rhs), &dims, &strides, 0).unwrap();
+        let mut output =
+            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut one_shot), &dims, &strides, 0)
+                .unwrap();
+        erased_zip_into(
+            dtype,
+            one_shot_op,
+            &ExecContext::serial(),
+            &mut output,
+            &lhs,
+            &rhs,
+        )
+        .unwrap();
+    }
+
+    {
+        let lhs = ErasedRawStridedRef::new(dtype, as_bytes(lhs), &dims, &strides, 0).unwrap();
+        let rhs = ErasedRawStridedRef::new(dtype, as_bytes(rhs), &dims, &strides, 0).unwrap();
+        let mut output =
+            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut planned), &dims, &strides, 0)
+                .unwrap();
+        ErasedFusedPlan::compile(dtype, single_op_plan(2, plan_op))
+            .unwrap()
+            .execute(&ExecContext::serial(), &mut output, &[lhs, rhs])
+            .unwrap();
+    }
+
+    assert_eq!(one_shot, planned);
+}
+
+#[test]
+fn one_shot_matches_plan_for_every_kernel_dtype() {
+    macro_rules! assert_add {
+        ($dtype:expr, $lhs:expr, $rhs:expr) => {
+            assert_binary_matches_plan($dtype, $lhs, $rhs, ErasedZipOp::Add, FusedOp::Add)
+        };
+    }
+
+    assert_add!(KernelDType::F32, &[1.0f32, -2.0], &[3.0, 4.0]);
+    assert_add!(KernelDType::F64, &[1.0f64, -2.0], &[3.0, 4.0]);
+    assert_add!(KernelDType::I32, &[1i32, -2], &[3, 4]);
+    assert_add!(KernelDType::I64, &[1i64, -2], &[3, 4]);
+    assert_add!(
+        KernelDType::C32,
+        &[Complex32::new(1.0, 2.0), Complex32::new(-2.0, 1.0)],
+        &[Complex32::new(3.0, -1.0), Complex32::new(4.0, 2.0)]
+    );
+    assert_add!(
+        KernelDType::C64,
+        &[Complex64::new(1.0, 2.0), Complex64::new(-2.0, 1.0)],
+        &[Complex64::new(3.0, -1.0), Complex64::new(4.0, 2.0)]
+    );
+    assert_unary_matches_plan(
+        KernelDType::Bool,
+        &[true, false],
+        ErasedMapOp::Conj,
+        FusedOp::Conj,
+    );
+}
+
+#[test]
+fn one_shot_covers_required_unary_and_binary_ops() {
+    let input = [-3.0f64, 0.0, 2.0];
+    for (one_shot_op, plan_op) in [
+        (ErasedMapOp::Negate, FusedOp::Negate),
+        (ErasedMapOp::Conj, FusedOp::Conj),
+        (ErasedMapOp::Abs, FusedOp::Abs),
+    ] {
+        assert_unary_matches_plan(KernelDType::F64, &input, one_shot_op, plan_op);
+    }
+
+    let lhs = [5.0f64, -4.0, 9.0];
+    let rhs = [2.0f64, 3.0, 4.0];
+    for (one_shot_op, plan_op) in [
+        (ErasedZipOp::Add, FusedOp::Add),
+        (ErasedZipOp::Multiply, FusedOp::Multiply),
+        (ErasedZipOp::Divide, FusedOp::Divide),
+        (ErasedZipOp::Maximum, FusedOp::Maximum),
+        (ErasedZipOp::Minimum, FusedOp::Minimum),
+    ] {
+        assert_binary_matches_plan(KernelDType::F64, &lhs, &rhs, one_shot_op, plan_op);
+    }
+
+    let dims = [3usize];
+    let strides = [1isize];
+    let input_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut signed = [0.0f64; 3];
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut signed),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Sign,
+        &ExecContext::serial(),
+        &mut output,
+        &input_ref,
+    )
+    .unwrap();
+    assert_eq!(signed, [-1.0, 0.0, 1.0]);
+
+    for (op, expected) in [
+        (ErasedZipOp::Subtract, [3.0, -7.0, 5.0]),
+        (ErasedZipOp::Remainder, [1.0, -1.0, 1.0]),
+    ] {
+        let lhs_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+        let rhs_ref =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let mut actual = [0.0f64; 3];
+        let mut output = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut actual),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        erased_zip_into(
+            KernelDType::F64,
+            op,
+            &ExecContext::serial(),
+            &mut output,
+            &lhs_ref,
+            &rhs_ref,
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn one_shot_handles_borrowed_noncontiguous_metadata() {
+    let dims = [2usize, 3];
+    let src_strides = [3isize, 1];
+    let dst_strides = [1isize, 2];
+    let lhs = [0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0];
+    let rhs = [100.0f64, 101.0, 102.0, 110.0, 111.0, 112.0];
+    let mut dst = [0.0f64; 6];
+    let lhs =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &src_strides, 0).unwrap();
+    let rhs =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &src_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &dst_strides,
+        0,
+    )
+    .unwrap();
+
+    erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut dest,
+        &lhs,
+        &rhs,
+    )
+    .unwrap();
+
+    assert_eq!(dst, [100.0, 120.0, 102.0, 122.0, 104.0, 124.0]);
+}
+
+#[test]
+fn one_shot_empty_output_is_a_noop_for_degenerate_strides() {
+    let dims = [0usize, 2];
+    let strides = [1isize, 0];
+    let input: [f64; 0] = [];
+    let mut output: [f64; 0] = [];
+    let input =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut output,
+        &input,
+    )
+    .unwrap();
+}
+
+#[test]
+fn one_shot_rejects_unsupported_ops_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let lhs = [true, false];
+    let rhs = [false, true];
+    let mut dst = [true, true];
+    let lhs =
+        ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+    let rhs =
+        ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::Bool,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let error = erased_zip_into(
+        KernelDType::Bool,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut dest,
+        &lhs,
+        &rhs,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        StridedError::UnsupportedOp {
+            op: "add",
+            dtype: "bool"
+        }
+    ));
+    assert_eq!(dst, [true, true]);
+}

--- a/strided-kernel/tests/erased_one_shot.rs
+++ b/strided-kernel/tests/erased_one_shot.rs
@@ -264,14 +264,20 @@ fn one_shot_empty_output_is_a_noop_for_degenerate_strides() {
     let strides = [1isize, 0];
     let input: [f64; 0] = [];
     let mut output: [f64; 0] = [];
-    let input =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let input = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &dims,
+        &strides,
+        isize::MAX,
+    )
+    .unwrap();
     let mut output = ErasedRawStridedMut::new(
         KernelDType::F64,
         as_bytes_mut(&mut output),
         &dims,
         &strides,
-        0,
+        isize::MAX,
     )
     .unwrap();
 
@@ -280,6 +286,16 @@ fn one_shot_empty_output_is_a_noop_for_degenerate_strides() {
         ErasedMapOp::Negate,
         &ExecContext::serial(),
         &mut output,
+        &ErasedRawStridedPtr::from_ref(&input),
+    )
+    .unwrap();
+
+    erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut output,
+        &ErasedRawStridedPtr::from_ref(&input),
         &ErasedRawStridedPtr::from_ref(&input),
     )
     .unwrap();
@@ -546,4 +562,36 @@ fn one_shot_accepts_small_injective_layout_without_allocating() {
     )
     .unwrap();
     assert_eq!(actual, [-1.0, 0.0, -2.0, -4.0, -3.0, -5.0, 0.0, -6.0]);
+}
+
+#[test]
+fn integer_division_preflight_handles_high_rank_iteratively() {
+    const RANK: usize = 20_000;
+    let dims = vec![1usize; RANK];
+    let strides = vec![0isize; RANK];
+    let lhs = [i32::MIN];
+    let rhs = [-1i32];
+    let lhs =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+    let rhs =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let mut actual = [0i32];
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::I32,
+        as_bytes_mut(&mut actual),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+    erased_zip_into(
+        KernelDType::I32,
+        ErasedZipOp::Divide,
+        &ExecContext::serial(),
+        &mut output,
+        &ErasedRawStridedPtr::from_ref(&lhs),
+        &ErasedRawStridedPtr::from_ref(&rhs),
+    )
+    .unwrap();
+    assert_eq!(actual, [i32::MIN]);
 }

--- a/strided-kernel/tests/erased_policy_parallel.rs
+++ b/strided-kernel/tests/erased_policy_parallel.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "parallel")]
 
 use strided_kernel::{
-    ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedGatherPlan,
-    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ErasedScatterPlan,
-    ExecContext, GatherSpec, KernelDType, ReduceOp, ScatterSpec,
+    erased_zip_into, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
+    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan,
+    ErasedScatterPlan, ErasedZipOp, ExecContext, GatherSpec, KernelDType, ReduceOp, ScatterSpec,
 };
 
 const LARGE_LEN: usize = (1 << 15) + 65;
@@ -28,6 +28,44 @@ fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
 
 fn bounded_context() -> ExecContext {
     ExecContext::max_threads(2).unwrap()
+}
+
+#[test]
+fn large_one_shot_zip_matches_serial() {
+    let dims = [LARGE_LEN];
+    let strides = [1isize];
+    let lhs: Vec<f64> = (0..LARGE_LEN).map(|index| index as f64).collect();
+    let rhs: Vec<f64> = (0..LARGE_LEN)
+        .map(|index| (LARGE_LEN - index) as f64)
+        .collect();
+
+    let run = |ctx: ExecContext| {
+        let lhs =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
+        let rhs =
+            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let mut output = vec![0.0f64; LARGE_LEN];
+        let mut dest = ErasedRawStridedMut::new(
+            KernelDType::F64,
+            as_bytes_mut(&mut output),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap();
+        erased_zip_into(
+            KernelDType::F64,
+            ErasedZipOp::Add,
+            &ctx,
+            &mut dest,
+            &lhs,
+            &rhs,
+        )
+        .unwrap();
+        output
+    };
+
+    assert_eq!(run(bounded_context()), run(ExecContext::serial()));
 }
 
 #[test]

--- a/strided-kernel/tests/erased_policy_parallel.rs
+++ b/strided-kernel/tests/erased_policy_parallel.rs
@@ -2,8 +2,9 @@
 
 use strided_kernel::{
     erased_zip_into, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
-    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan,
-    ErasedScatterPlan, ErasedZipOp, ExecContext, GatherSpec, KernelDType, ReduceOp, ScatterSpec,
+    ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
+    ErasedReducePlan, ErasedScatterPlan, ErasedZipOp, ExecContext, GatherSpec, KernelDType,
+    ReduceOp, ScatterSpec,
 };
 
 const LARGE_LEN: usize = (1 << 15) + 65;
@@ -58,8 +59,8 @@ fn large_one_shot_zip_matches_serial() {
             ErasedZipOp::Add,
             &ctx,
             &mut dest,
-            &lhs,
-            &rhs,
+            &ErasedRawStridedPtr::from_ref(&lhs),
+            &ErasedRawStridedPtr::from_ref(&rhs),
         )
         .unwrap();
         output

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -34,7 +34,8 @@ pub use element_op::{
 // View-based types
 // ============================================================================
 pub use raw::{
-    ErasedRawStridedMut, ErasedRawStridedRef, KernelDType, RawStridedMut, RawStridedRef,
+    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, KernelDType, RawStridedMut,
+    RawStridedRef,
 };
 pub use view::{col_major_strides, row_major_strides, StridedArray, StridedView, StridedViewMut};
 
@@ -127,6 +128,10 @@ pub enum StridedError {
     /// A mutable destination overlaps one of the operation inputs.
     #[error("destination overlaps input {input}")]
     OverlappingInputOutput { input: usize },
+
+    /// Integer division or remainder encountered a zero divisor.
+    #[error("integer {op} encountered a zero divisor")]
+    IntegerDivisionByZero { op: &'static str },
 
     /// The operation arity is unsupported by this entry point.
     #[error("unsupported arity {arity}; maximum supported arity is {max}")]

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -124,6 +124,10 @@ pub enum StridedError {
         dtype: &'static str,
     },
 
+    /// A mutable destination overlaps one of the operation inputs.
+    #[error("destination overlaps input {input}")]
+    OverlappingInputOutput { input: usize },
+
     /// The operation arity is unsupported by this entry point.
     #[error("unsupported arity {arity}; maximum supported arity is {max}")]
     UnsupportedArity { arity: usize, max: usize },

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -7,6 +7,8 @@
 
 use crate::element_op::Identity;
 use crate::view::validate_bounds;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
 use num_complex::{Complex32, Complex64};
 
 use crate::{Result, StridedError, StridedView, StridedViewMut};
@@ -103,6 +105,128 @@ fn validate_erased_buffer(dtype: KernelDType, data: &[u8]) -> Result<usize> {
         }
     }
     Ok(element_count)
+}
+
+fn validate_erased_buffer_layout(
+    dtype: KernelDType,
+    data: NonNull<u8>,
+    byte_len: usize,
+) -> Result<usize> {
+    let element_size = dtype.size_of();
+    if byte_len % element_size != 0 {
+        return Err(StridedError::ByteLengthMismatch {
+            dtype: dtype.label(),
+            byte_len,
+            element_size,
+        });
+    }
+    if byte_len != 0 && data.as_ptr() as usize % dtype.alignment() != 0 {
+        return Err(StridedError::DataAlignmentMismatch {
+            dtype: dtype.label(),
+            alignment: dtype.alignment(),
+        });
+    }
+    Ok(byte_len / element_size)
+}
+
+/// Pointer-backed dtype-erased input used by one-shot write entry points.
+///
+/// Unlike [`ErasedRawStridedRef`], this descriptor does not create a shared
+/// Rust reference at construction time. That lets the entry point reject an
+/// input/output overlap before forming references to either side.
+#[derive(Clone, Copy, Debug)]
+pub struct ErasedRawStridedPtr<'a> {
+    dtype: KernelDType,
+    data: NonNull<u8>,
+    byte_len: usize,
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+    marker: PhantomData<&'a [u8]>,
+}
+
+impl<'a> ErasedRawStridedPtr<'a> {
+    /// Create a pointer-backed descriptor.
+    ///
+    /// # Safety
+    ///
+    /// `data..data + byte_len` must remain readable and allocated for `'a`.
+    /// Its bytes must contain valid values for `dtype`. The allocation may
+    /// overlap a destination passed to a one-shot entry point; overlap is
+    /// checked before the pointer is dereferenced.
+    pub unsafe fn new(
+        dtype: KernelDType,
+        data: NonNull<u8>,
+        byte_len: usize,
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let element_count = validate_erased_buffer_layout(dtype, data, byte_len)?;
+        validate_bounds(element_count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            byte_len,
+            dims,
+            strides,
+            offset,
+            marker: PhantomData,
+        })
+    }
+
+    /// Borrow a safe erased input as a pointer descriptor.
+    pub fn from_ref(input: &ErasedRawStridedRef<'a>) -> Self {
+        Self {
+            dtype: input.dtype,
+            data: NonNull::new(input.data.as_ptr().cast_mut()).unwrap_or_else(NonNull::dangling),
+            byte_len: input.data.len(),
+            dims: input.dims,
+            strides: input.strides,
+            offset: input.offset,
+            marker: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.byte_len
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+
+    /// Materialize the shared byte slice after the caller has ruled out a
+    /// concurrent mutable alias.
+    ///
+    /// # Safety
+    ///
+    /// No live mutable reference may overlap the returned slice.
+    pub unsafe fn data_unchecked(&self) -> &'a [u8] {
+        core::slice::from_raw_parts(self.data.as_ptr(), self.byte_len)
+    }
 }
 
 /// Borrowed dtype-erased raw strided input layout.

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -468,7 +468,11 @@ impl<'a, T> RawStridedRef<'a, T> {
 
     #[inline]
     pub fn ptr(&self) -> *const T {
-        unsafe { self.data.as_ptr().offset(self.offset) }
+        if self.dims.iter().any(|&dim| dim == 0) {
+            NonNull::<T>::dangling().as_ptr()
+        } else {
+            unsafe { self.data.as_ptr().offset(self.offset) }
+        }
     }
 
     /// Convert to an immutable owning-metadata view.
@@ -556,12 +560,20 @@ impl<'a, T> RawStridedMut<'a, T> {
 
     #[inline]
     pub fn ptr(&self) -> *const T {
-        unsafe { self.data.as_ptr().offset(self.offset) }
+        if self.dims.iter().any(|&dim| dim == 0) {
+            NonNull::<T>::dangling().as_ptr()
+        } else {
+            unsafe { self.data.as_ptr().offset(self.offset) }
+        }
     }
 
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        unsafe { self.data.as_mut_ptr().offset(self.offset) }
+        if self.dims.iter().any(|&dim| dim == 0) {
+            NonNull::<T>::dangling().as_ptr()
+        } else {
+            unsafe { self.data.as_mut_ptr().offset(self.offset) }
+        }
     }
 
     /// Convert to an immutable owning-metadata view.
@@ -586,6 +598,20 @@ impl<'a, T> RawStridedMut<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_raw_views_use_dangling_base_pointers_for_extreme_offsets() {
+        let dims = [0usize];
+        let strides = [1isize];
+        let data: [f64; 0] = [];
+        let raw = RawStridedRef::new(&data, &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(raw.ptr(), NonNull::<f64>::dangling().as_ptr());
+
+        let mut data: [f64; 0] = [];
+        let mut raw = RawStridedMut::new(&mut data, &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(raw.ptr(), NonNull::<f64>::dangling().as_ptr());
+        assert_eq!(raw.as_mut_ptr(), NonNull::<f64>::dangling().as_ptr());
+    }
 
     #[test]
     fn raw_ref_rejects_out_of_bounds_layout() {

--- a/strided-view/src/view.rs
+++ b/strided-view/src/view.rs
@@ -822,7 +822,11 @@ impl<T> StridedArray<T> {
 
     /// Create an immutable view over this tensor.
     pub fn view(&self) -> StridedView<'_, T> {
-        let ptr = unsafe { self.data.as_ptr().offset(self.offset) };
+        let ptr = if self.is_empty() {
+            empty_const_ptr()
+        } else {
+            unsafe { self.data.as_ptr().offset(self.offset) }
+        };
         StridedView {
             ptr,
             data: &self.data,
@@ -835,7 +839,11 @@ impl<T> StridedArray<T> {
 
     /// Create a mutable view over this tensor.
     pub fn view_mut(&mut self) -> StridedViewMut<'_, T> {
-        let ptr = unsafe { self.data.as_mut_ptr().offset(self.offset) };
+        let ptr = if self.is_empty() {
+            empty_mut_ptr()
+        } else {
+            unsafe { self.data.as_mut_ptr().offset(self.offset) }
+        };
         StridedViewMut {
             ptr,
             data: &mut self.data,
@@ -1014,6 +1022,16 @@ mod tests {
 
         let mut data: [f64; 0] = [];
         let view = StridedViewMut::new(&mut data, &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(view.ptr(), empty_const_ptr());
+        assert_eq!(view.as_mut_ptr(), empty_mut_ptr());
+
+        let array =
+            StridedArray::<f64>::from_parts(Vec::new(), &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(array.view().ptr(), empty_const_ptr());
+
+        let mut array =
+            StridedArray::<f64>::from_parts(Vec::new(), &dims, &strides, isize::MAX).unwrap();
+        let view = array.view_mut();
         assert_eq!(view.ptr(), empty_const_ptr());
         assert_eq!(view.as_mut_ptr(), empty_mut_ptr());
     }

--- a/strided-view/src/view.rs
+++ b/strided-view/src/view.rs
@@ -14,6 +14,21 @@ use std::sync::Arc;
 use crate::element_op::{ComposableElementOp, ElementOp, ElementOpApply, Identity};
 use crate::{Result, StridedError};
 
+#[inline]
+fn empty_layout(dims: &[usize]) -> bool {
+    dims.iter().any(|&dim| dim == 0)
+}
+
+#[inline]
+fn empty_const_ptr<T>() -> *const T {
+    core::ptr::NonNull::<T>::dangling().as_ptr()
+}
+
+#[inline]
+fn empty_mut_ptr<T>() -> *mut T {
+    core::ptr::NonNull::<T>::dangling().as_ptr()
+}
+
 // ============================================================================
 // Validation helpers
 // ============================================================================
@@ -140,7 +155,11 @@ impl<'a, T, Op> StridedView<'a, T, Op> {
     /// Create a new immutable strided view from a borrowed slice.
     pub fn new(data: &'a [T], dims: &[usize], strides: &[isize], offset: isize) -> Result<Self> {
         validate_bounds(data.len(), dims, strides, offset)?;
-        let ptr = unsafe { data.as_ptr().offset(offset) };
+        let ptr = if empty_layout(dims) {
+            empty_const_ptr()
+        } else {
+            unsafe { data.as_ptr().offset(offset) }
+        };
         Ok(Self {
             ptr,
             data,
@@ -161,7 +180,11 @@ impl<'a, T, Op> StridedView<'a, T, Op> {
         strides: &[isize],
         offset: isize,
     ) -> Self {
-        let ptr = data.as_ptr().offset(offset);
+        let ptr = if empty_layout(dims) {
+            empty_const_ptr()
+        } else {
+            data.as_ptr().offset(offset)
+        };
         Self {
             ptr,
             data,
@@ -454,7 +477,11 @@ impl<'a, T> StridedViewMut<'a, T> {
         offset: isize,
     ) -> Result<Self> {
         validate_bounds(data.len(), dims, strides, offset)?;
-        let ptr = unsafe { data.as_mut_ptr().offset(offset) };
+        let ptr = if empty_layout(dims) {
+            empty_mut_ptr()
+        } else {
+            unsafe { data.as_mut_ptr().offset(offset) }
+        };
         Ok(Self {
             ptr,
             data,
@@ -474,7 +501,11 @@ impl<'a, T> StridedViewMut<'a, T> {
         strides: &[isize],
         offset: isize,
     ) -> Self {
-        let ptr = data.as_mut_ptr().offset(offset);
+        let ptr = if empty_layout(dims) {
+            empty_mut_ptr()
+        } else {
+            data.as_mut_ptr().offset(offset)
+        };
         Self {
             ptr,
             data,
@@ -972,6 +1003,20 @@ impl<T: Copy> IndexMut<&[usize]> for StridedArray<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_views_use_dangling_base_pointers_for_extreme_offsets() {
+        let dims = [0usize];
+        let strides = [1isize];
+        let data: [f64; 0] = [];
+        let view = StridedView::<f64>::new(&data, &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(view.ptr(), empty_const_ptr());
+
+        let mut data: [f64; 0] = [];
+        let view = StridedViewMut::new(&mut data, &dims, &strides, isize::MAX).unwrap();
+        assert_eq!(view.ptr(), empty_const_ptr());
+        assert_eq!(view.as_mut_ptr(), empty_mut_ptr());
+    }
     use num_complex::Complex64;
 
     #[test]


### PR DESCRIPTION
## Summary

- add compile-free dtype-erased one-shot `erased_map_into` and `erased_zip_into` APIs with explicit `ExecContext`
- cover add, subtract, multiply, divide, remainder, negate, conjugate, abs, sign, maximum, and minimum
- preserve operation-specific dtype contracts, including complex-to-real absolute value and wrapping integer divide/remainder with a pre-write zero check
- validate dtype, shape, destination injectivity, unsupported dtype/op pairs, and destination/input overlap before writes
- use a pointer-backed input descriptor so overlap is rejected before Rust input references are formed
- preserve downstream scalar edge semantics: canonical complex zero sign, NaN propagation, and left-operand signed-zero ties

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test -p strided-kernel --all-features`
- `cargo doc --workspace --no-deps`
- allocation regression: contiguous one-shot map/zip adds no allocation beyond typed kernels
- differential coverage against `ErasedFusedPlan` for every `KernelDType`
- explicit `ExecContext::max_threads` versus serial differential coverage
- edge coverage for overlap errors, complex abs/sign, integer overflow and zero divisors, signed zero, and bounded exact injectivity

This upstream-only PR does not change a tenferro public API benchmark row by itself. The exact `cpu/output_reuse` t1/t4 before/after gate belongs to the dependent tenferro-rs#1504 adoption PR; the tenferro pin will be updated only after this PR merges.

Closes #166