### PR TITLE
perf(kernel): avoid disjoint CopyPlan compile allocation

### DIFF
--- a/docs/plans/2026-07-29-copy-plan-disjoint-compile.md
+++ b/docs/plans/2026-07-29-copy-plan-disjoint-compile.md
@@ -1,0 +1,30 @@
+# CopyPlan disjoint-layout compile allocation
+
+## Context
+
+tenferro-rs #1512 exposed two allocations per `ErasedSlicePlan` compile for a
+2x2 contiguous layout. The allocations came from `CopyPlan` destination
+injectivity validation: the small-layout exact check built a `HashSet` and a
+coordinate vector before consulting the existing disjoint-stride proof.
+
+## Change
+
+`is_injective_layout` now accepts layouts proven injective by
+`has_disjoint_stride_spans` before the bounded exact enumeration, after first
+proving that every positive and negative cumulative offset span is
+representable as `isize`. Non-disjoint layouts at or below the exact-check
+limit still use the same exact algorithm; larger non-disjoint layouts remain
+rejected. The fast path therefore preserves the accepted valid layout set
+while rejecting previously unsafe extreme-stride layouts before fused
+traversal construction. Fusion adjacency also uses checked stride
+multiplication, so representable mixed-sign layouts remain valid without
+overflowing while testing whether adjacent axes can be fused.
+
+The allocation-contract integration test now also requires a 2x2 contiguous
+`CopyPlan::compile` to allocate zero times when the parallel feature provides
+inline rank metadata.
+
+## Provenance
+
+The implementation and tests are original work based on profiling this
+repository and its tenferro-rs consumer. No third-party source was copied.

--- a/strided-kernel/src/copy_plan.rs
+++ b/strided-kernel/src/copy_plan.rs
@@ -378,6 +378,25 @@ mod tests {
     }
 
     #[test]
+    fn compile_rejects_unrepresentable_positive_and_negative_offset_spans() {
+        for strides in [
+            [isize::MAX / 2 + 1, isize::MAX],
+            [isize::MIN / 2 - 1, isize::MIN],
+        ] {
+            let err = CopyPlan::compile(&[2, 2], &strides, &strides).unwrap_err();
+            assert!(matches!(err, StridedError::NonInjectiveOutputLayout));
+        }
+    }
+
+    #[test]
+    fn compile_accepts_representable_mixed_sign_span_without_fusion_overflow() {
+        let positive = isize::MAX / 4;
+        let negative = -(isize::MAX - positive);
+        let strides = [positive, negative];
+        CopyPlan::compile(&[2, 2], &strides, &strides).unwrap();
+    }
+
+    #[test]
     fn compile_rejects_non_injective_destination() {
         // Two logical columns land on the same offsets: forbidden overlap in
         // the mutable destination.

--- a/strided-kernel/src/fused.rs
+++ b/strided-kernel/src/fused.rs
@@ -692,7 +692,7 @@ pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
     let Some(total) = validate_injective_layout_inputs(dims, strides) else {
         return false;
     };
-    if total <= 1 {
+    if total <= 1 || has_disjoint_stride_spans(dims, strides) {
         return true;
     }
 
@@ -701,7 +701,7 @@ pub(crate) fn is_injective_layout(dims: &[usize], strides: &[isize]) -> bool {
         return has_unique_offsets_exact(dims, strides, total);
     }
 
-    has_disjoint_stride_spans(dims, strides)
+    false
 }
 
 pub(crate) fn is_injective_layout_without_alloc(dims: &[usize], strides: &[isize]) -> bool {
@@ -757,6 +757,21 @@ fn validate_injective_layout_inputs(dims: &[usize], strides: &[isize]) -> Option
         .any(|(&dim, &stride)| dim > 1 && stride == 0)
     {
         return None;
+    }
+
+    let mut min_offset = 0isize;
+    let mut max_offset = 0isize;
+    for (&dim, &stride) in dims.iter().zip(strides.iter()) {
+        if dim <= 1 {
+            continue;
+        }
+        let extent = isize::try_from(dim - 1).ok()?;
+        let span = stride.checked_mul(extent)?;
+        if span >= 0 {
+            max_offset = max_offset.checked_add(span)?;
+        } else {
+            min_offset = min_offset.checked_add(span)?;
+        }
     }
     Some(total)
 }
@@ -1519,5 +1534,13 @@ mod tests {
         assert!(!is_injective_layout(&[2, 3], &[1]));
         assert!(!is_injective_layout(&[2, 2], &[0, 1]));
         assert!(is_injective_layout(&[1], &[0]));
+    }
+
+    #[test]
+    fn is_injective_layout_rejects_unrepresentable_offset_spans() {
+        let positive = isize::MAX / 2 + 1;
+        let negative = isize::MIN / 2 - 1;
+        assert!(!is_injective_layout(&[2, 2], &[positive, isize::MAX]));
+        assert!(!is_injective_layout(&[2, 2], &[negative, isize::MIN]));
     }
 }

--- a/strided-kernel/src/raw_ops.rs
+++ b/strided-kernel/src/raw_ops.rs
@@ -73,8 +73,8 @@ pub(crate) fn fuse_pair_layout(
     let mut fused = 0usize;
     for axis in 1..layout.rank {
         let extent = layout.dims[fused] as isize;
-        if layout.dst_strides[fused] * extent == layout.dst_strides[axis]
-            && layout.src_strides[fused] * extent == layout.src_strides[axis]
+        if layout.dst_strides[fused].checked_mul(extent) == Some(layout.dst_strides[axis])
+            && layout.src_strides[fused].checked_mul(extent) == Some(layout.src_strides[axis])
         {
             layout.dims[fused] *= layout.dims[axis];
         } else {

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -68,6 +68,18 @@ fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
 // sibling tests would leak their setup allocations into the counted window.
 #[test]
 fn execute_is_allocation_free_up_to_rank_limit() {
+    #[cfg(feature = "parallel")]
+    {
+        let compile_allocations = count_allocations(|| {
+            let plan = CopyPlan::compile(&[2, 2], &[1, 2], &[1, 2]).unwrap();
+            std::hint::black_box(plan);
+        });
+        assert_eq!(
+            compile_allocations, 0,
+            "provably disjoint small CopyPlan compile must not allocate"
+        );
+    }
+
     // Rank 8 (the RAW_FUSED_RANK_LIMIT boundary), permuted strides so fusion
     // cannot collapse everything into one contiguous run.
     let dims = [2usize; 8];


### PR DESCRIPTION
Closes #172.

## Summary
- prove disjoint stride-span injectivity before bounded exact enumeration
- retain exact validation for non-disjoint small layouts without changing accepted semantics
- require allocation-free 2x2 contiguous `CopyPlan::compile` with `parallel` rank metadata

## Evidence
The tenferro #1512 fixed allocation gate attributed 2 allocations / 104 bytes per compile: an 88-byte exact-check `HashSet` and a 16-byte coordinate vector. After this change the focused compile probe reports 0 allocations.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test -p strided-kernel --features parallel --test copy_plan_alloc`
- `git diff --check`

Implementation and tests are original; no third-party source was copied.