### PR TITLE
Support uninitialized output for full-overwrite static plans

### DIFF
--- a/docs/plans/2026-07-29-uninitialized-static-output.md
+++ b/docs/plans/2026-07-29-uninitialized-static-output.md
@@ -1,0 +1,40 @@
+# Uninitialized static-output implementation record
+
+Issue: #174
+
+## Cause
+
+Downstream buffer pools need to hand static indexing plans fresh storage
+without first constructing valid typed values. The existing erased destination
+descriptor requires valid bytes at construction, including the `bool` validity
+invariant, so downstream code could only satisfy it by zero-initializing a
+buffer that the plan immediately overwrote.
+
+## Contract
+
+- `ErasedRawStridedUninitMut` borrows `MaybeUninit<u8>` storage and validates
+  dtype alignment, byte length, shape, strides, offset, and reachable bounds
+  without reading value bytes.
+- Only slice, reverse, pad, and concatenate expose `execute_uninit`; each plan
+  fully initializes every reachable logical destination element on success.
+  Unreachable backing-layout holes may remain uninitialized.
+- Input dtype, layout, validity, arity, and input/output non-overlap are checked
+  before the first destination write. Violations return `StridedError`.
+- Replay keeps the caller-provided `ExecContext` and does not allocate for
+  ranks up to `RAW_FUSED_RANK_LIMIT`.
+
+## Implementation
+
+`CopyPlan` writes through `RawStridedMut<MaybeUninit<T>>` for slice, reverse,
+and concatenate. Pad writes the fill scalar to the complete logical
+destination first, then copies input values through the existing contiguous
+axis-0 or general traversal. No typed mutable reference to uninitialized `T`
+storage is formed.
+
+## Verification
+
+Focused differential tests cover all `KernelDType` values, `bool`, complex
+values, empty layouts, non-contiguous pad output, multi-input concatenate,
+rank above the inline traversal limit, and overlap rejection before mutation.
+The allocation-counting test covers all four erased full-overwrite entry
+points.

--- a/docs/plans/2026-07-29-uninitialized-static-output.md
+++ b/docs/plans/2026-07-29-uninitialized-static-output.md
@@ -34,7 +34,8 @@ storage is formed.
 ## Verification
 
 Focused differential tests cover all `KernelDType` values, `bool`, complex
-values, empty layouts, non-contiguous pad output, multi-input concatenate,
-rank above the inline traversal limit, and overlap rejection before mutation.
-The allocation-counting test covers all four erased full-overwrite entry
-points.
+values, alignment-1 empty storage, non-contiguous pad output, multi-input
+concatenate, rank above the inline traversal limit, and overlap rejection
+before mutation. Concatenate validates every segment offset before writing, so
+a later overflow cannot leave a partially initialized destination. The
+allocation-counting test covers all four erased full-overwrite entry points.

--- a/strided-kernel/src/copy_plan.rs
+++ b/strided-kernel/src/copy_plan.rs
@@ -9,11 +9,15 @@
 //! replay it with no planning and no heap allocation for ranks at most
 //! [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).
 
+use core::mem::MaybeUninit;
 use core::ops::Mul;
 
+use crate::map_view::map_raw_into;
 use crate::ops_view::{copy_conj, copy_into, copy_scale};
 use crate::raw_ops::{apply_fused_pair, fuse_pair_layout, FusedPairLayout};
-use crate::{ElementOpApply, MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError};
+use crate::{
+    ElementOpApply, Identity, MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError,
+};
 
 // Same pattern as map_view.rs / outer_product.rs: stack storage when the
 // parallel feature pulls in smallvec, plain Vec otherwise. Only `compile`
@@ -104,7 +108,11 @@ impl CopyPlan {
     /// by [`RawStridedRef::new`]/[`RawStridedMut::new`] (or asserted by the
     /// caller of the `new_unchecked` constructors), so layout equality is the
     /// complete precondition for the unsafe-free fused replay below.
-    fn check_call<T>(&self, dest: &RawStridedMut<'_, T>, src: &RawStridedRef<'_, T>) -> Result<()> {
+    fn check_call<D, S>(
+        &self,
+        dest: &RawStridedMut<'_, D>,
+        src: &RawStridedRef<'_, S>,
+    ) -> Result<()> {
         if dest.dims() != &self.dims[..]
             || src.dims() != &self.dims[..]
             || dest.strides() != &self.dst_strides[..]
@@ -113,6 +121,36 @@ impl CopyPlan {
             return Err(StridedError::PlanLayoutMismatch);
         }
         Ok(())
+    }
+
+    /// `dest = src` into a potentially uninitialized destination.
+    ///
+    /// On success every reachable logical destination element is initialized.
+    /// Non-reachable holes in the backing allocation are not written.
+    pub fn execute_uninit<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        src: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, src)?;
+        match &self.fused {
+            Some(layout) => {
+                apply_fused_pair(
+                    dest,
+                    src,
+                    layout,
+                    |dst, value| {
+                        dst.write(value);
+                    },
+                    |value| value,
+                );
+                Ok(())
+            }
+            None => map_raw_into::<MaybeUninit<T>, T, Identity>(dest, src, MaybeUninit::new),
+        }
     }
 
     /// `dest = src`. Allocation-free for ranks at most [`RAW_FUSED_RANK_LIMIT`](crate::RAW_FUSED_RANK_LIMIT).

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -2273,6 +2273,13 @@ where
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
         plan.check_input_layout(position, &input_ref)?;
+        plan.segment_offset(position, dest_offset)?;
+    }
+    for (position, input) in inputs.iter().enumerate() {
+        let input_data = typed_slice::<T>(input.data());
+        let input_ref = unsafe {
+            RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
+        };
         plan.execute_segment(position, &mut dest_ref, &input_ref)?;
     }
     Ok(())
@@ -2301,6 +2308,7 @@ where
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
         plan.check_input_layout(position, &input_ref)?;
+        plan.segment_offset(position, dest_offset)?;
     }
     for (position, input) in inputs.iter().enumerate() {
         let input = validated_input_ref(input)?;
@@ -3079,6 +3087,14 @@ fn typed_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
 }
 
 fn typed_uninit_slice_mut<T>(bytes: &mut [MaybeUninit<u8>]) -> &mut [MaybeUninit<T>] {
+    if bytes.is_empty() {
+        return unsafe {
+            core::slice::from_raw_parts_mut(
+                core::ptr::NonNull::<MaybeUninit<T>>::dangling().as_ptr(),
+                0,
+            )
+        };
+    }
     let len = bytes.len() / core::mem::size_of::<T>();
     unsafe { core::slice::from_raw_parts_mut(bytes.as_mut_ptr().cast::<MaybeUninit<T>>(), len) }
 }

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -13,17 +13,17 @@
 //! Mutable erased descriptors only re-scan value-constrained dtypes, currently
 //! `bool`, after their raw bytes have escaped through `data_mut`.
 
-use core::ops::Add;
+use core::{mem::MaybeUninit, ops::Add};
 
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use crate::{
     fused_elementwise_into, ConcatenatePlan, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
-    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ExecContext, FusedPlan,
-    FusedScalar, GatherIndex, GatherPlan, GatherSpec, Identity, KernelDType, PadPlan,
-    RawStridedMut, RawStridedRef, Result, ReversePlan, ScatterPlan, ScatterSpec, SlicePlan,
-    StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
+    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedRawStridedUninitMut,
+    ExecContext, FusedPlan, FusedScalar, GatherIndex, GatherPlan, GatherSpec, Identity,
+    KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result, ReversePlan, ScatterPlan,
+    ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -345,6 +345,32 @@ impl ErasedSlicePlan {
         }
         result
     }
+
+    /// Execute a static slice as a full overwrite of uninitialized output storage.
+    pub fn execute_uninit(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedUninitMut<'_>,
+        operand: &ErasedRawStridedPtr<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        validate_uninit_no_overlap(dest, operand, 0)?;
+        let operand = validated_input_ref(operand)?;
+
+        ctx.run(|| match self.dtype {
+            KernelDType::F32 => execute_slice_uninit::<f32>(&self.plan, dest, &operand),
+            KernelDType::F64 => execute_slice_uninit::<f64>(&self.plan, dest, &operand),
+            KernelDType::I32 => execute_slice_uninit::<i32>(&self.plan, dest, &operand),
+            KernelDType::I64 => execute_slice_uninit::<i64>(&self.plan, dest, &operand),
+            KernelDType::Bool => execute_slice_uninit::<bool>(&self.plan, dest, &operand),
+            KernelDType::C32 => execute_slice_uninit::<Complex32>(&self.plan, dest, &operand),
+            KernelDType::C64 => execute_slice_uninit::<Complex64>(&self.plan, dest, &operand),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        })
+    }
 }
 
 impl ErasedReversePlan {
@@ -404,6 +430,32 @@ impl ErasedReversePlan {
             }
         }
         result
+    }
+
+    /// Execute reverse as a full overwrite of uninitialized output storage.
+    pub fn execute_uninit(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedUninitMut<'_>,
+        operand: &ErasedRawStridedPtr<'_>,
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        validate_uninit_no_overlap(dest, operand, 0)?;
+        let operand = validated_input_ref(operand)?;
+
+        ctx.run(|| match self.dtype {
+            KernelDType::F32 => execute_reverse_uninit::<f32>(&self.plan, dest, &operand),
+            KernelDType::F64 => execute_reverse_uninit::<f64>(&self.plan, dest, &operand),
+            KernelDType::I32 => execute_reverse_uninit::<i32>(&self.plan, dest, &operand),
+            KernelDType::I64 => execute_reverse_uninit::<i64>(&self.plan, dest, &operand),
+            KernelDType::Bool => execute_reverse_uninit::<bool>(&self.plan, dest, &operand),
+            KernelDType::C32 => execute_reverse_uninit::<Complex32>(&self.plan, dest, &operand),
+            KernelDType::C64 => execute_reverse_uninit::<Complex64>(&self.plan, dest, &operand),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        })
     }
 }
 
@@ -479,6 +531,34 @@ impl ErasedPadPlan {
         }
         result
     }
+
+    /// Execute pad as a full overwrite of uninitialized output storage.
+    pub fn execute_uninit(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedUninitMut<'_>,
+        operand: &ErasedRawStridedPtr<'_>,
+        fill: &[u8],
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        check_dtype(self.dtype, operand.dtype())?;
+        validate_scalar_bytes(self.dtype, fill)?;
+        validate_uninit_no_overlap(dest, operand, 0)?;
+        let operand = validated_input_ref(operand)?;
+
+        ctx.run(|| match self.dtype {
+            KernelDType::F32 => execute_pad_uninit::<f32>(&self.plan, dest, &operand, fill),
+            KernelDType::F64 => execute_pad_uninit::<f64>(&self.plan, dest, &operand, fill),
+            KernelDType::I32 => execute_pad_uninit::<i32>(&self.plan, dest, &operand, fill),
+            KernelDType::I64 => execute_pad_uninit::<i64>(&self.plan, dest, &operand, fill),
+            KernelDType::Bool => execute_pad_uninit::<bool>(&self.plan, dest, &operand, fill),
+            KernelDType::C32 => execute_pad_uninit::<Complex32>(&self.plan, dest, &operand, fill),
+            KernelDType::C64 => execute_pad_uninit::<Complex64>(&self.plan, dest, &operand, fill),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        })
+    }
 }
 
 impl ErasedConcatenatePlan {
@@ -547,6 +627,40 @@ impl ErasedConcatenatePlan {
             }
         }
         result
+    }
+
+    /// Execute concatenate as a full overwrite of uninitialized output storage.
+    pub fn execute_uninit(
+        &self,
+        ctx: &ExecContext,
+        dest: &mut ErasedRawStridedUninitMut<'_>,
+        inputs: &[ErasedRawStridedPtr<'_>],
+    ) -> Result<()> {
+        check_dtype(self.dtype, dest.dtype())?;
+        if inputs.len() != self.plan.input_count() {
+            return Err(StridedError::RankMismatch(
+                inputs.len(),
+                self.plan.input_count(),
+            ));
+        }
+        for (position, input) in inputs.iter().enumerate() {
+            check_dtype(self.dtype, input.dtype())?;
+            validate_uninit_no_overlap(dest, input, position)?;
+            validated_input_ref(input)?;
+        }
+
+        ctx.run(|| match self.dtype {
+            KernelDType::F32 => execute_concatenate_uninit::<f32>(&self.plan, dest, inputs),
+            KernelDType::F64 => execute_concatenate_uninit::<f64>(&self.plan, dest, inputs),
+            KernelDType::I32 => execute_concatenate_uninit::<i32>(&self.plan, dest, inputs),
+            KernelDType::I64 => execute_concatenate_uninit::<i64>(&self.plan, dest, inputs),
+            KernelDType::Bool => execute_concatenate_uninit::<bool>(&self.plan, dest, inputs),
+            KernelDType::C32 => execute_concatenate_uninit::<Complex32>(&self.plan, dest, inputs),
+            KernelDType::C64 => execute_concatenate_uninit::<Complex64>(&self.plan, dest, inputs),
+            _ => Err(StridedError::UnsupportedDType {
+                dtype: self.dtype.label(),
+            }),
+        })
     }
 }
 
@@ -1520,6 +1634,26 @@ fn validate_no_overlap(
     }
 }
 
+fn validate_uninit_no_overlap(
+    dest: &ErasedRawStridedUninitMut<'_>,
+    input: &ErasedRawStridedPtr<'_>,
+    input_index: usize,
+) -> Result<()> {
+    let dest_start = dest.data_ptr() as usize;
+    let input_start = input.data_ptr() as usize;
+    let Some(dest_end) = dest_start.checked_add(dest.byte_len()) else {
+        return Err(StridedError::OffsetOverflow);
+    };
+    let Some(input_end) = input_start.checked_add(input.byte_len()) else {
+        return Err(StridedError::OffsetOverflow);
+    };
+    if dest_start < input_end && input_start < dest_end {
+        Err(StridedError::OverlappingInputOutput { input: input_index })
+    } else {
+        Ok(())
+    }
+}
+
 trait OneShotScalar: Copy + crate::MaybeSendSync + 'static {
     const INTEGER: bool = false;
     fn is_zero(_value: Self) -> bool {
@@ -1980,6 +2114,32 @@ where
     plan.execute(&mut dest_ref, &operand_ref)
 }
 
+fn execute_slice_uninit<T>(
+    plan: &SlicePlan,
+    dest: &mut ErasedRawStridedUninitMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute_uninit(&mut dest_ref, &operand_ref)
+}
+
 fn execute_reverse<T>(
     plan: &ReversePlan,
     dest: &mut ErasedRawStridedMut<'_>,
@@ -2004,6 +2164,32 @@ where
     let mut dest_ref =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.execute(&mut dest_ref, &operand_ref)
+}
+
+fn execute_reverse_uninit<T>(
+    plan: &ReversePlan,
+    dest: &mut ErasedRawStridedUninitMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute_uninit(&mut dest_ref, &operand_ref)
 }
 
 fn execute_pad<T>(
@@ -2034,6 +2220,34 @@ where
     plan.execute(&mut dest_ref, &operand_ref, fill)
 }
 
+fn execute_pad_uninit<T>(
+    plan: &PadPlan,
+    dest: &mut ErasedRawStridedUninitMut<'_>,
+    operand: &ErasedRawStridedRef<'_>,
+    fill: &[u8],
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let fill = read_unaligned_scalar::<T>(fill);
+    let operand_data = typed_slice::<T>(operand.data());
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let operand_ref = unsafe {
+        RawStridedRef::new_unchecked(
+            operand_data,
+            operand.dims(),
+            operand.strides(),
+            operand.offset(),
+        )
+    };
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.execute_uninit(&mut dest_ref, &operand_ref, fill)
+}
+
 fn execute_concatenate<T>(
     plan: &ConcatenatePlan,
     dest: &mut ErasedRawStridedMut<'_>,
@@ -2060,6 +2274,41 @@ where
         };
         plan.check_input_layout(position, &input_ref)?;
         plan.execute_segment(position, &mut dest_ref, &input_ref)?;
+    }
+    Ok(())
+}
+
+fn execute_concatenate_uninit<T>(
+    plan: &ConcatenatePlan,
+    dest: &mut ErasedRawStridedUninitMut<'_>,
+    inputs: &[ErasedRawStridedPtr<'_>],
+) -> Result<()>
+where
+    T: Copy + crate::MaybeSendSync,
+{
+    let dest_dims = dest.dims();
+    let dest_strides = dest.strides();
+    let dest_offset = dest.offset();
+    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let mut dest_ref =
+        unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
+    plan.check_dest_layout(&dest_ref)?;
+
+    for (position, input) in inputs.iter().enumerate() {
+        let input = validated_input_ref(input)?;
+        let input_data = typed_slice::<T>(input.data());
+        let input_ref = unsafe {
+            RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
+        };
+        plan.check_input_layout(position, &input_ref)?;
+    }
+    for (position, input) in inputs.iter().enumerate() {
+        let input = validated_input_ref(input)?;
+        let input_data = typed_slice::<T>(input.data());
+        let input_ref = unsafe {
+            RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
+        };
+        plan.execute_segment_uninit(position, &mut dest_ref, &input_ref)?;
     }
     Ok(())
 }
@@ -2827,6 +3076,11 @@ fn typed_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
             bytes.len() / core::mem::size_of::<T>(),
         )
     }
+}
+
+fn typed_uninit_slice_mut<T>(bytes: &mut [MaybeUninit<u8>]) -> &mut [MaybeUninit<T>] {
+    let len = bytes.len() / core::mem::size_of::<T>();
+    unsafe { core::slice::from_raw_parts_mut(bytes.as_mut_ptr().cast::<MaybeUninit<T>>(), len) }
 }
 
 fn read_unaligned_scalar<T>(bytes: &[u8]) -> T

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -87,9 +87,9 @@ mod reduce_view;
 pub use strided_view::view;
 pub use strided_view::{
     col_major_strides, row_major_strides, Adjoint, ComposableElementOp, Compose, Conj, ElementOp,
-    ElementOpApply, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, Identity,
-    KernelDType, RawStridedMut, RawStridedRef, Result, StridedArray, StridedError, StridedView,
-    StridedViewMut, Transpose,
+    ElementOpApply, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
+    ErasedRawStridedUninitMut, Identity, KernelDType, RawStridedMut, RawStridedRef, Result,
+    StridedArray, StridedError, StridedView, StridedViewMut, Transpose,
 };
 
 // ============================================================================

--- a/strided-kernel/src/static_indexing_plan.rs
+++ b/strided-kernel/src/static_indexing_plan.rs
@@ -5,6 +5,8 @@
 //! of `strided-kernel`; callers provide already-owned output buffers and fixed
 //! raw descriptors.
 
+use core::mem::MaybeUninit;
+
 use crate::{CopyPlan, MaybeSendSync, RawStridedMut, RawStridedRef, Result, StridedError};
 
 #[cfg(feature = "parallel")]
@@ -167,9 +169,34 @@ impl SlicePlan {
         self.copy_plan.execute(dest, &source)
     }
 
-    fn check_call<T>(
+    /// Execute into storage whose reachable destination elements are uninitialized.
+    pub fn execute_uninit<T>(
         &self,
-        dest: &RawStridedMut<'_, T>,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, operand)?;
+        let source_offset = operand
+            .offset()
+            .checked_add(self.source_offset_delta)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let source = unsafe {
+            RawStridedRef::new_unchecked(
+                operand.data(),
+                &self.dest_dims,
+                &self.source_strides,
+                source_offset,
+            )
+        };
+        self.copy_plan.execute_uninit(dest, &source)
+    }
+
+    fn check_call<D, T>(
+        &self,
+        dest: &RawStridedMut<'_, D>,
         operand: &RawStridedRef<'_, T>,
     ) -> Result<()> {
         if operand.dims() != &self.operand_dims[..]
@@ -286,6 +313,28 @@ impl PadPlan {
         self.copy_operand(dest, operand)
     }
 
+    /// Execute pad into storage whose reachable destination elements are uninitialized.
+    pub fn execute_uninit<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+        fill: T,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, operand)?;
+        self.fill_dest(dest, MaybeUninit::new(fill))?;
+
+        if self.operand_total == 0 {
+            return Ok(());
+        }
+        if let Some(run) = self.contiguous_axis0_run {
+            return self.copy_operand_axis0_runs_uninit(dest, operand, run);
+        }
+        self.copy_operand_uninit(dest, operand)
+    }
+
     fn fill_dest<T>(&self, dest: &mut RawStridedMut<'_, T>, fill: T) -> Result<()>
     where
         T: Copy + MaybeSendSync,
@@ -363,6 +412,58 @@ impl PadPlan {
                     core::ptr::copy_nonoverlapping(
                         operand_ptr.offset(operand_offset),
                         dest_ptr.offset(dest_offset),
+                        run.len,
+                    );
+                }
+            }
+            advance_col_major_index(outer_idx, outer_dims);
+        }
+        Ok(())
+    }
+
+    fn copy_operand_axis0_runs_uninit<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+        run: ContiguousPadAxis0Run,
+    ) -> Result<()>
+    where
+        T: Copy,
+    {
+        if run.len == 0 {
+            return Ok(());
+        }
+        let outer_dims = &self.operand_dims[1..];
+        let outer_total = checked_total_len(outer_dims)?;
+        let mut outer_idx_storage = CoordScratch::new(outer_dims.len());
+        let outer_idx = outer_idx_storage.as_mut_slice();
+        let operand_ptr = operand.data().as_ptr();
+        let dest_ptr = dest.data_mut().as_mut_ptr();
+
+        for _ in 0..outer_total {
+            let mut operand_offset =
+                checked_offset_add(operand.offset(), self.operand_strides[0], run.operand_start)?;
+            let mut dest_offset =
+                checked_offset_add(dest.offset(), self.dest_strides[0], run.dest_start)?;
+            let mut in_bounds = true;
+            for (outer_axis, &coord) in outer_idx.iter().enumerate() {
+                let axis = outer_axis + 1;
+                let out_pos = i128::from(self.edge_padding_low[axis])
+                    + coord as i128 * i128::from(self.interior_step[axis]);
+                if out_pos < 0 || out_pos >= self.dest_dims[axis] as i128 {
+                    in_bounds = false;
+                    break;
+                }
+                operand_offset =
+                    checked_offset_add(operand_offset, self.operand_strides[axis], coord)?;
+                dest_offset =
+                    checked_offset_add(dest_offset, self.dest_strides[axis], out_pos as usize)?;
+            }
+            if in_bounds {
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        operand_ptr.offset(operand_offset),
+                        dest_ptr.offset(dest_offset).cast::<T>(),
                         run.len,
                     );
                 }
@@ -455,6 +556,126 @@ impl PadPlan {
             }
         }
         self.copy_operand_serial(dest, operand)
+    }
+
+    fn copy_operand_uninit<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        #[cfg(feature = "parallel")]
+        {
+            let nthreads = crate::threading::parallel_threads_for_len(self.operand_total);
+            if nthreads > 1 {
+                return self.copy_operand_uninit_parallel(dest, operand, nthreads);
+            }
+        }
+        self.copy_operand_uninit_serial(dest, operand)
+    }
+
+    fn copy_operand_uninit_serial<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy,
+    {
+        let operand_offset_base = operand.offset();
+        let operand_strides = operand.strides();
+        let operand_data = operand.data();
+        let dest_offset_base = dest.offset();
+        let dest_strides = dest.strides();
+        let dest_data = dest.data_mut();
+        let mut input_idx_storage = CoordScratch::new(self.operand_dims.len());
+        let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+        let input_idx = input_idx_storage.as_mut_slice();
+        let out_idx = out_idx_storage.as_mut_slice();
+
+        for _ in 0..self.operand_total {
+            let mut in_bounds = true;
+            for axis in 0..self.operand_dims.len() {
+                let out_pos = i128::from(self.edge_padding_low[axis])
+                    + input_idx[axis] as i128 * i128::from(self.interior_step[axis]);
+                if out_pos < 0 || out_pos >= self.dest_dims[axis] as i128 {
+                    in_bounds = false;
+                    break;
+                }
+                out_idx[axis] = out_pos as usize;
+            }
+            if in_bounds {
+                let operand_offset =
+                    checked_strided_offset(operand_offset_base, operand_strides, input_idx)?;
+                let dest_offset = checked_strided_offset(dest_offset_base, dest_strides, out_idx)?;
+                unsafe {
+                    (*dest_data.as_mut_ptr().offset(dest_offset))
+                        .write(*operand_data.as_ptr().offset(operand_offset));
+                }
+            }
+            advance_col_major_index(input_idx, &self.operand_dims);
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "parallel")]
+    fn copy_operand_uninit_parallel<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+        nthreads: usize,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        let operand_offset_base = operand.offset();
+        let operand_ptr = crate::threading::SendPtr(operand.data().as_ptr() as *mut T);
+        let dest_offset_base = dest.offset();
+        let dest_ptr = crate::threading::SendPtr(dest.data_mut().as_mut_ptr());
+        crate::threading::parallel_map_reduce(
+            0..self.operand_total,
+            nthreads,
+            &|range| {
+                let mut input_idx_storage = CoordScratch::new(self.operand_dims.len());
+                let mut out_idx_storage = CoordScratch::new(self.dest_dims.len());
+                let input_idx = input_idx_storage.as_mut_slice();
+                let out_idx = out_idx_storage.as_mut_slice();
+                fill_col_major_index(range.start, &self.operand_dims, input_idx);
+                let operand_ptr = operand_ptr.as_const();
+                let dest_ptr = dest_ptr.as_ptr();
+
+                for _ in range {
+                    let mut in_bounds = true;
+                    for axis in 0..self.operand_dims.len() {
+                        let out_pos = i128::from(self.edge_padding_low[axis])
+                            + input_idx[axis] as i128 * i128::from(self.interior_step[axis]);
+                        if out_pos < 0 || out_pos >= self.dest_dims[axis] as i128 {
+                            in_bounds = false;
+                            break;
+                        }
+                        out_idx[axis] = out_pos as usize;
+                    }
+                    if in_bounds {
+                        let operand_offset = checked_strided_offset(
+                            operand_offset_base,
+                            &self.operand_strides,
+                            input_idx,
+                        )?;
+                        let dest_offset =
+                            checked_strided_offset(dest_offset_base, &self.dest_strides, out_idx)?;
+                        unsafe {
+                            (*dest_ptr.offset(dest_offset))
+                                .write(*operand_ptr.offset(operand_offset));
+                        }
+                    }
+                    advance_col_major_index(input_idx, &self.operand_dims);
+                }
+                Ok(())
+            },
+            &|left, right| left.and(right),
+        )
     }
 
     fn copy_operand_serial<T>(
@@ -562,9 +783,9 @@ impl PadPlan {
         )
     }
 
-    fn check_call<T>(
+    fn check_call<D, T>(
         &self,
-        dest: &RawStridedMut<'_, T>,
+        dest: &RawStridedMut<'_, D>,
         operand: &RawStridedRef<'_, T>,
     ) -> Result<()> {
         if operand.dims() != &self.operand_dims[..]
@@ -689,6 +910,31 @@ impl ConcatenatePlan {
         Ok(())
     }
 
+    /// Execute concatenate into storage whose reachable destination elements are uninitialized.
+    pub fn execute_uninit<T>(
+        &self,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        inputs: &[RawStridedRef<'_, T>],
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_dest_layout(dest)?;
+        if inputs.len() != self.input_dims.len() {
+            return Err(StridedError::RankMismatch(
+                inputs.len(),
+                self.input_dims.len(),
+            ));
+        }
+        for (position, input) in inputs.iter().enumerate() {
+            self.check_input_layout(position, input)?;
+        }
+        for (position, input) in inputs.iter().enumerate() {
+            self.execute_segment_uninit(position, dest, input)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn check_dest_layout<T>(&self, dest: &RawStridedMut<'_, T>) -> Result<()> {
         if dest.dims() != &self.dest_dims[..] || dest.strides() != &self.dest_strides[..] {
             return Err(StridedError::PlanLayoutMismatch);
@@ -737,6 +983,31 @@ impl ConcatenatePlan {
             )
         };
         self.copy_plans[position].execute(&mut segment, input)
+    }
+
+    pub(crate) fn execute_segment_uninit<T>(
+        &self,
+        position: usize,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        input: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        let segment_offset = dest
+            .offset()
+            .checked_add(self.dest_offset_deltas[position])
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest_data = dest.data_mut();
+        let mut segment = unsafe {
+            RawStridedMut::new_unchecked(
+                dest_data,
+                &self.input_dims[position],
+                &self.dest_strides,
+                segment_offset,
+            )
+        };
+        self.copy_plans[position].execute_uninit(&mut segment, input)
     }
 }
 
@@ -819,9 +1090,34 @@ impl ReversePlan {
         self.copy_plan.execute(dest, &source)
     }
 
-    fn check_call<T>(
+    /// Execute reverse into storage whose reachable destination elements are uninitialized.
+    pub fn execute_uninit<T>(
         &self,
-        dest: &RawStridedMut<'_, T>,
+        dest: &mut RawStridedMut<'_, MaybeUninit<T>>,
+        operand: &RawStridedRef<'_, T>,
+    ) -> Result<()>
+    where
+        T: Copy + MaybeSendSync,
+    {
+        self.check_call(dest, operand)?;
+        let source_offset = operand
+            .offset()
+            .checked_add(self.source_offset_delta)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let source = unsafe {
+            RawStridedRef::new_unchecked(
+                operand.data(),
+                &self.operand_dims,
+                &self.source_strides,
+                source_offset,
+            )
+        };
+        self.copy_plan.execute_uninit(dest, &source)
+    }
+
+    fn check_call<D, T>(
+        &self,
+        dest: &RawStridedMut<'_, D>,
         operand: &RawStridedRef<'_, T>,
     ) -> Result<()> {
         if operand.dims() != &self.operand_dims[..]

--- a/strided-kernel/src/static_indexing_plan.rs
+++ b/strided-kernel/src/static_indexing_plan.rs
@@ -905,6 +905,9 @@ impl ConcatenatePlan {
         }
         for (position, input) in inputs.iter().enumerate() {
             self.check_input_layout(position, input)?;
+            self.segment_offset(position, dest.offset())?;
+        }
+        for (position, input) in inputs.iter().enumerate() {
             self.execute_segment(position, dest, input)?;
         }
         Ok(())
@@ -928,6 +931,7 @@ impl ConcatenatePlan {
         }
         for (position, input) in inputs.iter().enumerate() {
             self.check_input_layout(position, input)?;
+            self.segment_offset(position, dest.offset())?;
         }
         for (position, input) in inputs.iter().enumerate() {
             self.execute_segment_uninit(position, dest, input)?;
@@ -960,6 +964,12 @@ impl ConcatenatePlan {
         self.input_dims.len()
     }
 
+    pub(crate) fn segment_offset(&self, position: usize, dest_offset: isize) -> Result<isize> {
+        dest_offset
+            .checked_add(self.dest_offset_deltas[position])
+            .ok_or(StridedError::OffsetOverflow)
+    }
+
     pub(crate) fn execute_segment<T>(
         &self,
         position: usize,
@@ -969,10 +979,7 @@ impl ConcatenatePlan {
     where
         T: Copy + MaybeSendSync,
     {
-        let segment_offset = dest
-            .offset()
-            .checked_add(self.dest_offset_deltas[position])
-            .ok_or(StridedError::OffsetOverflow)?;
+        let segment_offset = self.segment_offset(position, dest.offset())?;
         let dest_data = dest.data_mut();
         let mut segment = unsafe {
             RawStridedMut::new_unchecked(
@@ -994,10 +1001,7 @@ impl ConcatenatePlan {
     where
         T: Copy + MaybeSendSync,
     {
-        let segment_offset = dest
-            .offset()
-            .checked_add(self.dest_offset_deltas[position])
-            .ok_or(StridedError::OffsetOverflow)?;
+        let segment_offset = self.segment_offset(position, dest.offset())?;
         let dest_data = dest.data_mut();
         let mut segment = unsafe {
             RawStridedMut::new_unchecked(

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -6,15 +6,17 @@
 //! unrelated tests.
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use num_complex::Complex64;
 use strided_kernel::{
     erased_map_into, erased_zip_into, map_into, zip_map2_into, CopyPlan, ErasedConcatenatePlan,
     ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedMapOp,
-    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedReducePlan,
-    ErasedReversePlan, ErasedScatterPlan, ErasedSlicePlan, ErasedZipOp, ExecContext, Identity,
-    KernelDType, RawStridedMut, RawStridedRef, ReduceOp, ScatterSpec, StridedView, StridedViewMut,
+    ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
+    ErasedRawStridedUninitMut, ErasedReducePlan, ErasedReversePlan, ErasedScatterPlan,
+    ErasedSlicePlan, ErasedZipOp, ExecContext, Identity, KernelDType, RawStridedMut, RawStridedRef,
+    ReduceOp, ScatterSpec, StridedView, StridedViewMut,
 };
 
 struct CountingAllocator;
@@ -60,6 +62,15 @@ fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
         core::slice::from_raw_parts_mut(
             data.as_mut_ptr().cast::<u8>(),
             data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
+fn as_uninit_bytes_mut<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
+            core::mem::size_of_val(data),
         )
     }
 }
@@ -485,6 +496,26 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased slice execute must not allocate");
+    let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
+    let mut uninit_dest = ErasedRawStridedUninitMut::new(
+        KernelDType::F64,
+        as_uninit_bytes_mut(&mut uninit_dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let source_ptr = ErasedRawStridedPtr::from_ref(&source);
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute_uninit(&ExecContext::serial(), &mut uninit_dest, &source_ptr)
+                .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased uninitialized slice execute must not allocate"
+    );
 
     let axes: Vec<usize> = (0..8).collect();
     let mut dst = vec![0.0f64; 256];
@@ -514,6 +545,25 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased reverse execute must not allocate");
+    let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
+    let mut uninit_dest = ErasedRawStridedUninitMut::new(
+        KernelDType::F64,
+        as_uninit_bytes_mut(&mut uninit_dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute_uninit(&ExecContext::serial(), &mut uninit_dest, &source_ptr)
+                .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased uninitialized reverse execute must not allocate"
+    );
 
     let edge = [0i64; 8];
     let interior = [0i64; 8];
@@ -548,6 +598,30 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         }
     });
     assert_eq!(allocations, 0, "erased pad execute must not allocate");
+    let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
+    let mut uninit_dest = ErasedRawStridedUninitMut::new(
+        KernelDType::F64,
+        as_uninit_bytes_mut(&mut uninit_dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute_uninit(
+                &ExecContext::serial(),
+                &mut uninit_dest,
+                &source_ptr,
+                as_bytes(&fill),
+            )
+            .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased uninitialized pad execute must not allocate"
+    );
 
     let mut left_dims = [2usize; 8];
     left_dims[0] = 1;
@@ -605,6 +679,29 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     assert_eq!(
         allocations, 0,
         "erased concatenate execute must not allocate"
+    );
+    let input_ptrs = [
+        ErasedRawStridedPtr::from_ref(&inputs[0]),
+        ErasedRawStridedPtr::from_ref(&inputs[1]),
+    ];
+    let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
+    let mut uninit_dest = ErasedRawStridedUninitMut::new(
+        KernelDType::F64,
+        as_uninit_bytes_mut(&mut uninit_dst),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let allocations = count_allocations(|| {
+        for _ in 0..16 {
+            plan.execute_uninit(&ExecContext::serial(), &mut uninit_dest, &input_ptrs)
+                .unwrap();
+        }
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased uninitialized concatenate execute must not allocate"
     );
 }
 

--- a/strided-kernel/tests/erased_static_indexing_plan.rs
+++ b/strided-kernel/tests/erased_static_indexing_plan.rs
@@ -79,6 +79,38 @@ where
     assert_eq!(assume_init_vec(dest), expected);
 }
 
+fn assert_empty_uninit_slice<T>(dtype: KernelDType)
+where
+    T: Copy,
+{
+    let dims = [0usize];
+    let strides = [1isize];
+    let starts = [0usize];
+    let limits = [0usize];
+    let slice_strides = [1usize];
+    let plan = ErasedSlicePlan::compile(
+        dtype,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let operand: [T; 0] = [];
+    let operand_ref =
+        ErasedRawStridedRef::new(dtype, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
+    let mut empty_bytes: [MaybeUninit<u8>; 0] = [];
+    let mut dest_ref =
+        ErasedRawStridedUninitMut::new(dtype, &mut empty_bytes, &dims, &strides, 0).unwrap();
+
+    plan.execute_uninit(&ExecContext::serial(), &mut dest_ref, &operand_ptr)
+        .unwrap();
+}
+
 #[test]
 fn erased_slice_uninit_executes_every_kernel_dtype() {
     assert_uninit_slice(KernelDType::F32, vec![1.0f32, -2.0], vec![1.0, -2.0]);
@@ -96,6 +128,17 @@ fn erased_slice_uninit_executes_every_kernel_dtype() {
         vec![Complex64::new(1.0, 2.0), Complex64::new(-2.0, 3.0)],
         vec![Complex64::new(1.0, 2.0), Complex64::new(-2.0, 3.0)],
     );
+}
+
+#[test]
+fn erased_slice_uninit_accepts_unaligned_empty_storage_for_every_kernel_dtype() {
+    assert_empty_uninit_slice::<f32>(KernelDType::F32);
+    assert_empty_uninit_slice::<f64>(KernelDType::F64);
+    assert_empty_uninit_slice::<i32>(KernelDType::I32);
+    assert_empty_uninit_slice::<i64>(KernelDType::I64);
+    assert_empty_uninit_slice::<bool>(KernelDType::Bool);
+    assert_empty_uninit_slice::<Complex32>(KernelDType::C32);
+    assert_empty_uninit_slice::<Complex64>(KernelDType::C64);
 }
 
 #[test]
@@ -282,6 +325,68 @@ fn erased_uninit_static_replay_rejects_input_output_overlap_before_writing() {
             .map(|value| unsafe { value.assume_init() })
             .collect::<Vec<_>>(),
         [7, 9]
+    );
+}
+
+#[test]
+fn erased_concatenate_validates_all_segment_offsets_before_writing() {
+    let first_dims = [1usize];
+    let empty_dims = [0usize];
+    let input_strides = [1isize];
+    let dest_dims = [1usize];
+    let dest_strides = [isize::MAX];
+    let input_dims: [&[usize]; 2] = [&first_dims, &empty_dims];
+    let input_stride_sets: [&[isize]; 2] = [&input_strides, &input_strides];
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::I32,
+        &input_dims,
+        &input_stride_sets,
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+    let first = [11i32];
+    let empty: [i32; 0] = [];
+    let first_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&first),
+        &first_dims,
+        &input_strides,
+        0,
+    )
+    .unwrap();
+    let empty_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&empty),
+        &empty_dims,
+        &input_strides,
+        0,
+    )
+    .unwrap();
+    let inputs = [
+        ErasedRawStridedPtr::from_ref(&first_ref),
+        ErasedRawStridedPtr::from_ref(&empty_ref),
+    ];
+    let mut dest = [MaybeUninit::new(3i32), MaybeUninit::new(7i32)];
+    let mut dest_ref = ErasedRawStridedUninitMut::new(
+        KernelDType::I32,
+        as_uninit_bytes_mut(&mut dest),
+        &dest_dims,
+        &dest_strides,
+        1,
+    )
+    .unwrap();
+
+    let error = plan
+        .execute_uninit(&ExecContext::serial(), &mut dest_ref, &inputs)
+        .unwrap_err();
+
+    assert!(matches!(error, StridedError::OffsetOverflow));
+    assert_eq!(
+        dest.map(|value| unsafe { value.assume_init() }),
+        [3, 7],
+        "validation failure must precede every segment write"
     );
 }
 

--- a/strided-kernel/tests/erased_static_indexing_plan.rs
+++ b/strided-kernel/tests/erased_static_indexing_plan.rs
@@ -1,7 +1,9 @@
+use core::mem::MaybeUninit;
 use num_complex::{Complex32, Complex64};
 use strided_kernel::{
-    ErasedConcatenatePlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedRef,
-    ErasedReversePlan, ErasedSlicePlan, ExecContext, KernelDType, StridedError,
+    ErasedConcatenatePlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr,
+    ErasedRawStridedRef, ErasedRawStridedUninitMut, ErasedReversePlan, ErasedSlicePlan,
+    ExecContext, KernelDType, StridedError,
 };
 
 fn as_bytes<T>(data: &[T]) -> &[u8] {
@@ -20,6 +22,267 @@ fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
             data.len() * core::mem::size_of::<T>(),
         )
     }
+}
+
+fn as_uninit_bytes_mut<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
+    unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
+            core::mem::size_of_val(data),
+        )
+    }
+}
+
+fn assume_init_vec<T>(data: Vec<MaybeUninit<T>>) -> Vec<T> {
+    let mut data = core::mem::ManuallyDrop::new(data);
+    unsafe { Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity()) }
+}
+
+fn assert_uninit_slice<T>(dtype: KernelDType, operand: Vec<T>, expected: Vec<T>)
+where
+    T: Copy + core::fmt::Debug + PartialEq,
+{
+    let dims = [operand.len()];
+    let strides = [1isize];
+    let starts = [0usize];
+    let limits = [operand.len()];
+    let slice_strides = [1usize];
+    let plan = ErasedSlicePlan::compile(
+        dtype,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::new(dtype, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
+    let mut dest = Vec::<MaybeUninit<T>>::with_capacity(operand.len());
+    unsafe {
+        dest.set_len(operand.len());
+    }
+    let mut dest_ref =
+        ErasedRawStridedUninitMut::new(dtype, as_uninit_bytes_mut(&mut dest), &dims, &strides, 0)
+            .unwrap();
+
+    plan.execute_uninit(
+        &ExecContext::max_threads(2).unwrap(),
+        &mut dest_ref,
+        &operand_ptr,
+    )
+    .unwrap();
+
+    assert_eq!(assume_init_vec(dest), expected);
+}
+
+#[test]
+fn erased_slice_uninit_executes_every_kernel_dtype() {
+    assert_uninit_slice(KernelDType::F32, vec![1.0f32, -2.0], vec![1.0, -2.0]);
+    assert_uninit_slice(KernelDType::F64, vec![1.0f64, -2.0], vec![1.0, -2.0]);
+    assert_uninit_slice(KernelDType::I32, vec![1i32, -2], vec![1, -2]);
+    assert_uninit_slice(KernelDType::I64, vec![1i64, -2], vec![1, -2]);
+    assert_uninit_slice(KernelDType::Bool, vec![true, false], vec![true, false]);
+    assert_uninit_slice(
+        KernelDType::C32,
+        vec![Complex32::new(1.0, 2.0), Complex32::new(-2.0, 3.0)],
+        vec![Complex32::new(1.0, 2.0), Complex32::new(-2.0, 3.0)],
+    );
+    assert_uninit_slice(
+        KernelDType::C64,
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-2.0, 3.0)],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(-2.0, 3.0)],
+    );
+}
+
+#[test]
+fn erased_reverse_uninit_handles_rank_above_inline_limit() {
+    let dims = [2usize; 9];
+    let strides = [1isize, 2, 4, 8, 16, 32, 64, 128, 256];
+    let axes = [0usize, 8];
+    let operand: Vec<i32> = (0..512).collect();
+    let plan =
+        ErasedReversePlan::compile(KernelDType::I32, &dims, &strides, &strides, &axes).unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
+    let mut dest = vec![MaybeUninit::<i32>::uninit(); operand.len()];
+    let mut dest_ref = ErasedRawStridedUninitMut::new(
+        KernelDType::I32,
+        as_uninit_bytes_mut(&mut dest),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute_uninit(&ExecContext::serial(), &mut dest_ref, &operand_ptr)
+        .unwrap();
+
+    let dest = assume_init_vec(dest);
+    assert_eq!(dest[0], operand[257]);
+    assert_eq!(dest[511], operand[254]);
+}
+
+#[test]
+fn erased_pad_and_concatenate_uninit_cover_noncontiguous_and_multi_input_outputs() {
+    let operand_dims = [2usize];
+    let operand_strides = [1isize];
+    let padded_dims = [4usize];
+    let padded_strides = [2isize];
+    let edge_low = [1i64];
+    let edge_high = [1i64];
+    let interior = [0i64];
+    let operand = [10i32, 20];
+    let fill = [-1i32];
+    let pad = ErasedPadPlan::compile(
+        KernelDType::I32,
+        &operand_dims,
+        &operand_strides,
+        &padded_dims,
+        &padded_strides,
+        &edge_low,
+        &edge_high,
+        &interior,
+    )
+    .unwrap();
+    let operand_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&operand),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
+    let mut padded = vec![MaybeUninit::<i32>::uninit(); 7];
+    let mut padded_ref = ErasedRawStridedUninitMut::new(
+        KernelDType::I32,
+        as_uninit_bytes_mut(&mut padded),
+        &padded_dims,
+        &padded_strides,
+        0,
+    )
+    .unwrap();
+    pad.execute_uninit(
+        &ExecContext::serial(),
+        &mut padded_ref,
+        &operand_ptr,
+        as_bytes(&fill),
+    )
+    .unwrap();
+    assert_eq!(
+        [0usize, 2, 4, 6].map(|index| unsafe { padded[index].assume_init() }),
+        [-1, 10, 20, -1]
+    );
+
+    let lhs = [1i32, 2];
+    let rhs = [3i32, 4];
+    let input_dims: [&[usize]; 2] = [&operand_dims, &operand_dims];
+    let input_strides: [&[isize]; 2] = [&operand_strides, &operand_strides];
+    let concat_dims = [4usize];
+    let concat_strides = [1isize];
+    let concat = ErasedConcatenatePlan::compile(
+        KernelDType::I32,
+        &input_dims,
+        &input_strides,
+        &concat_dims,
+        &concat_strides,
+        0,
+    )
+    .unwrap();
+    let lhs_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&lhs),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let rhs_ref = ErasedRawStridedRef::new(
+        KernelDType::I32,
+        as_bytes(&rhs),
+        &operand_dims,
+        &operand_strides,
+        0,
+    )
+    .unwrap();
+    let inputs = [
+        ErasedRawStridedPtr::from_ref(&lhs_ref),
+        ErasedRawStridedPtr::from_ref(&rhs_ref),
+    ];
+    let mut joined = vec![MaybeUninit::<i32>::uninit(); 4];
+    let mut joined_ref = ErasedRawStridedUninitMut::new(
+        KernelDType::I32,
+        as_uninit_bytes_mut(&mut joined),
+        &concat_dims,
+        &concat_strides,
+        0,
+    )
+    .unwrap();
+    concat
+        .execute_uninit(&ExecContext::serial(), &mut joined_ref, &inputs)
+        .unwrap();
+    assert_eq!(assume_init_vec(joined), [1, 2, 3, 4]);
+}
+
+#[test]
+fn erased_uninit_static_replay_rejects_input_output_overlap_before_writing() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let starts = [0usize];
+    let limits = [2usize];
+    let slice_strides = [1usize];
+    let plan = ErasedSlicePlan::compile(
+        KernelDType::I32,
+        &dims,
+        &strides,
+        &dims,
+        &strides,
+        &starts,
+        &limits,
+        &slice_strides,
+    )
+    .unwrap();
+    let mut storage = vec![MaybeUninit::new(7i32), MaybeUninit::new(9i32)];
+    let input_ptr = unsafe {
+        ErasedRawStridedPtr::new(
+            KernelDType::I32,
+            core::ptr::NonNull::new(storage.as_mut_ptr().cast::<u8>()).unwrap(),
+            core::mem::size_of_val(storage.as_slice()),
+            &dims,
+            &strides,
+            0,
+        )
+        .unwrap()
+    };
+    let mut dest = ErasedRawStridedUninitMut::new(
+        KernelDType::I32,
+        as_uninit_bytes_mut(&mut storage),
+        &dims,
+        &strides,
+        0,
+    )
+    .unwrap();
+
+    let error = plan
+        .execute_uninit(&ExecContext::serial(), &mut dest, &input_ptr)
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        StridedError::OverlappingInputOutput { input: 0 }
+    ));
+    assert_eq!(
+        storage
+            .into_iter()
+            .map(|value| unsafe { value.assume_init() })
+            .collect::<Vec<_>>(),
+        [7, 9]
+    );
 }
 
 #[test]

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -34,8 +34,8 @@ pub use element_op::{
 // View-based types
 // ============================================================================
 pub use raw::{
-    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, KernelDType, RawStridedMut,
-    RawStridedRef,
+    ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedRawStridedUninitMut,
+    KernelDType, RawStridedMut, RawStridedRef,
 };
 pub use view::{col_major_strides, row_major_strides, StridedArray, StridedView, StridedViewMut};
 

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -8,6 +8,7 @@
 use crate::element_op::Identity;
 use crate::view::validate_bounds;
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use num_complex::{Complex32, Complex64};
 
@@ -394,6 +395,80 @@ impl<'a> ErasedRawStridedMut<'a> {
     /// be exactly `0` or `1` before a typed `bool` slice is formed.
     pub unsafe fn assume_data_valid(&mut self) {
         self.needs_data_revalidation = false;
+    }
+}
+
+/// Borrowed dtype-erased raw strided output whose reachable elements may be
+/// uninitialized.
+///
+/// This descriptor is only accepted by operations that prove and perform a
+/// full overwrite of every reachable logical destination element. The backing
+/// allocation may contain non-reachable holes, which remain uninitialized.
+#[derive(Debug)]
+pub struct ErasedRawStridedUninitMut<'a> {
+    dtype: KernelDType,
+    data: &'a mut [MaybeUninit<u8>],
+    dims: &'a [usize],
+    strides: &'a [isize],
+    offset: isize,
+}
+
+impl<'a> ErasedRawStridedUninitMut<'a> {
+    /// Create an uninitialized erased output descriptor after validating byte
+    /// length, alignment, rank/stride agreement, and reachable bounds.
+    pub fn new(
+        dtype: KernelDType,
+        data: &'a mut [MaybeUninit<u8>],
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let data_ptr =
+            NonNull::new(data.as_mut_ptr().cast::<u8>()).unwrap_or_else(NonNull::dangling);
+        let element_count = validate_erased_buffer_layout(dtype, data_ptr, data.len())?;
+        validate_bounds(element_count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    #[inline]
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
+    }
+
+    #[inline]
+    pub fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr().cast::<u8>()
+    }
+
+    #[inline]
+    pub fn byte_len(&self) -> usize {
+        self.data.len()
+    }
+
+    #[inline]
+    pub fn data_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.data
+    }
+
+    #[inline]
+    pub fn dims(&self) -> &'a [usize] {
+        self.dims
+    }
+
+    #[inline]
+    pub fn strides(&self) -> &'a [isize] {
+        self.strides
+    }
+
+    #[inline]
+    pub fn offset(&self) -> isize {
+        self.offset
     }
 }
 


### PR DESCRIPTION
Closes #174.

## Summary
- add a validated `ErasedRawStridedUninitMut` descriptor over `MaybeUninit` storage
- add full-overwrite replay for slice, reverse, pad, and concatenate without constructing initialized typed output
- reject overlap and validate all concatenate segments before the first write
- preserve explicit `ExecContext` and allocation-free replay through the inline-rank limit

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test -p strided-kernel --test erased_static_indexing_plan --all-features` (15 passed)
- `cargo test -p strided-kernel --test copy_plan_alloc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p strided-kernel -p strided-view --no-deps --features parallel,simd`

`cargo clippy ... -D warnings` is currently blocked by pre-existing Rust 1.97 lints in `strided-view` (`manual_is_multiple_of`, `manual_contains`, and the existing `uninit_vec` path); none are introduced by this diff.

Downstream adoption and exact t1/t4 public API measurements remain in tensor4all/tenferro-rs#1517.