### PR TITLE
perf(kernel): accelerate compact full reductions

### DIFF
--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -39,6 +39,33 @@ zip_map2_into(&mut out.view_mut(), &a.view(), &b.view(), |x, y| x + y).unwrap();
 let total = reduce(&a.view(), |x| x, |a, b| a + b, 0.0).unwrap();
 ```
 
+### Built-in Erased Reduction Order
+
+The built-in erased `Sum` and `Product` reductions have a narrower, explicit
+determinism contract than the generic closure-based `reduce` API:
+
+- Compact full reductions traverse consecutive physical storage from the
+  logical origin. Other full reductions use the stable fused/block traversal.
+  Axis reductions enumerate reduced coordinates in declared axis order, with
+  the first reduced axis varying fastest.
+- Serial compact `f32`/`f64` full reductions use four SIMD accumulators when
+  the `simd` feature is enabled. Other dtype/feature combinations use a fixed
+  eight-lane scalar accumulator. Accumulator lanes are merged in stable order.
+  Generic closure reductions retain their existing association.
+- `i32` and `i64` use wrapping sum/product. Floating and complex reductions use
+  same-dtype arithmetic without widening, compensation, conjugation, or
+  fast-math. Reassociation can change roundoff, signed zero, NaN details, and
+  the point at which an intermediate overflows or underflows. Consequently,
+  floating product may differ in finite/zero/infinite/NaN classification from
+  a strict left fold.
+- `ExecContext::serial()` and `ExecContext::max_threads(1)` use the same serial
+  algorithm. A fixed nonzero thread budget has deterministic partition and
+  merge order for a fixed executable, target, input, and layout; worker
+  completion order does not affect the result. Different budgets may produce
+  different floating or complex roundoff.
+- Empty sum and product return zero and one respectively. No tolerance or
+  correctness gate is relaxed for the optimized association.
+
 ## High-Level Operations
 
 ```rust

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
+const SERIAL_REDUCE_LANES: usize = 8;
 
 /// Runtime unary operation for [`erased_map_into`].
 #[non_exhaustive]
@@ -2331,13 +2332,21 @@ where
     T: ErasedReduceScalar,
 {
     let source = erased_view::<T>(src);
-    let value = if ctx.is_serial() {
-        crate::reduce_view::reduce_serial(
-            &source,
-            |value| value,
-            |a, b| reduce_values(op, a, b),
-            reduce_identity(op),
-        )?
+    let use_serial = ctx.is_serial()
+        || ctx
+            .max_threads_limit()
+            .is_some_and(|max_threads| max_threads.get() == 1);
+    let value = if use_serial {
+        if let Some(value) = reduce_contiguous_serial(op, src) {
+            value
+        } else {
+            crate::reduce_view::reduce_serial(
+                &source,
+                |value| value,
+                |a, b| reduce_values(op, a, b),
+                reduce_identity(op),
+            )?
+        }
     } else {
         ctx.run(|| {
             crate::reduce(
@@ -2355,6 +2364,46 @@ where
         *dest_data.as_mut_ptr().offset(dest_offset) = value;
     }
     Ok(())
+}
+
+fn reduce_contiguous_serial<T>(op: ReduceOp, src: &ErasedRawStridedRef<'_>) -> Option<T>
+where
+    T: ErasedReduceScalar,
+{
+    crate::kernel::same_contiguous_layout(src.dims(), &[src.strides()])?;
+    let len = checked_total_len(src.dims()).ok()?;
+    if len == 0 {
+        return Some(reduce_identity(op));
+    }
+
+    let source_data = typed_slice::<T>(src.data());
+    let start = usize::try_from(src.offset()).ok()?;
+    let end = start.checked_add(len)?;
+    let values = source_data.get(start..end)?;
+    Some(match op {
+        ReduceOp::Sum => T::try_simd_sum(values)
+            .unwrap_or_else(|| reduce_contiguous_lanes(values, T::zero(), T::reduce_sum)),
+        ReduceOp::Product => T::try_simd_product(values)
+            .unwrap_or_else(|| reduce_contiguous_lanes(values, T::one(), T::reduce_product)),
+    })
+}
+
+#[inline]
+fn reduce_contiguous_lanes<T>(values: &[T], identity: T, combine: impl Fn(T, T) -> T) -> T
+where
+    T: Copy,
+{
+    let mut lanes = [identity; SERIAL_REDUCE_LANES];
+    let mut chunks = values.chunks_exact(SERIAL_REDUCE_LANES);
+    for chunk in chunks.by_ref() {
+        for lane in 0..SERIAL_REDUCE_LANES {
+            lanes[lane] = combine(lanes[lane], chunk[lane]);
+        }
+    }
+    for (lane, &value) in chunks.remainder().iter().enumerate() {
+        lanes[lane] = combine(lanes[lane], value);
+    }
+    lanes.into_iter().fold(identity, combine)
 }
 
 fn dispatch_reduce<T>(
@@ -2619,7 +2668,9 @@ where
     }
 }
 
-trait ErasedReduceScalar: Copy + One + Zero + crate::MaybeSendSync {
+trait ErasedReduceScalar:
+    Copy + One + Zero + crate::MaybeSendSync + crate::simd::MaybeSimdOps + crate::simd::MaybeSimdProduct
+{
     fn reduce_sum(lhs: Self, rhs: Self) -> Self;
     fn reduce_product(lhs: Self, rhs: Self) -> Self;
 }

--- a/strided-kernel/src/simd.rs
+++ b/strided-kernel/src/simd.rs
@@ -512,10 +512,19 @@ pub trait MaybeSimdOps: Copy + Sized {
     }
 }
 
+pub(crate) trait MaybeSimdProduct: Copy + Sized {
+    fn try_simd_product(_src: &[Self]) -> Option<Self> {
+        None
+    }
+}
+
 // Default (no-op) impls for integer types and Complex
 macro_rules! impl_no_simd {
     ($($t:ty),*) => {
-        $(impl MaybeSimdOps for $t {})*
+        $(
+            impl MaybeSimdOps for $t {}
+            impl MaybeSimdProduct for $t {}
+        )*
     };
 }
 
@@ -525,17 +534,25 @@ impl<T: num_traits::Num + Copy + Clone + std::ops::Neg<Output = T>> MaybeSimdOps
     for num_complex::Complex<T>
 {
 }
+impl<T: num_traits::Num + Copy + Clone + std::ops::Neg<Output = T>> MaybeSimdProduct
+    for num_complex::Complex<T>
+{
+}
 
 // f32/f64: SIMD-accelerated when feature enabled, no-op otherwise
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdOps for f32 {}
+#[cfg(not(feature = "simd"))]
+impl MaybeSimdProduct for f32 {}
 
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdOps for f64 {}
+#[cfg(not(feature = "simd"))]
+impl MaybeSimdProduct for f64 {}
 
 #[cfg(feature = "simd")]
 mod simd_impls {
-    use super::MaybeSimdOps;
+    use super::{MaybeSimdOps, MaybeSimdProduct};
     use pulp::{Simd, WithSimd};
 
     impl MaybeSimdOps for f32 {
@@ -578,49 +595,93 @@ mod simd_impls {
         }
 
         fn try_simd_dot(a: &[f32], b: &[f32]) -> Option<f32> {
-            struct Dot<'a> {
-                a: &'a [f32],
-                b: &'a [f32],
-            }
-            impl<'a> WithSimd for Dot<'a> {
+            try_simd_dot_f32(a, b)
+        }
+    }
+
+    impl MaybeSimdProduct for f32 {
+        fn try_simd_product(src: &[f32]) -> Option<f32> {
+            struct Product<'a>(&'a [f32]);
+            impl<'a> WithSimd for Product<'a> {
                 type Output = f32;
 
                 #[inline(always)]
                 fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
-                    debug_assert_eq!(self.a.len(), self.b.len());
-                    let (a_head, a_tail) = S::as_simd_f32s(self.a);
-                    let (b_head, b_tail) = S::as_simd_f32s(self.b);
-                    debug_assert_eq!(a_head.len(), b_head.len());
-                    debug_assert_eq!(a_tail.len(), b_tail.len());
+                    let (head, tail) = S::as_simd_f32s(self.0);
 
-                    let mut acc0 = simd.splat_f32s(0.0);
-                    let mut acc1 = simd.splat_f32s(0.0);
-                    let mut acc2 = simd.splat_f32s(0.0);
-                    let mut acc3 = simd.splat_f32s(0.0);
+                    let mut acc0 = simd.splat_f32s(1.0);
+                    let mut acc1 = simd.splat_f32s(1.0);
+                    let mut acc2 = simd.splat_f32s(1.0);
+                    let mut acc3 = simd.splat_f32s(1.0);
 
                     let mut i = 0usize;
-                    while i + 4 <= a_head.len() {
-                        acc0 = simd.mul_add_f32s(a_head[i], b_head[i], acc0);
-                        acc1 = simd.mul_add_f32s(a_head[i + 1], b_head[i + 1], acc1);
-                        acc2 = simd.mul_add_f32s(a_head[i + 2], b_head[i + 2], acc2);
-                        acc3 = simd.mul_add_f32s(a_head[i + 3], b_head[i + 3], acc3);
+                    while i + 4 <= head.len() {
+                        acc0 = simd.mul_f32s(acc0, head[i]);
+                        acc1 = simd.mul_f32s(acc1, head[i + 1]);
+                        acc2 = simd.mul_f32s(acc2, head[i + 2]);
+                        acc3 = simd.mul_f32s(acc3, head[i + 3]);
                         i += 4;
                     }
-                    for j in i..a_head.len() {
-                        acc0 = simd.mul_add_f32s(a_head[j], b_head[j], acc0);
+                    for &value in &head[i..] {
+                        acc0 = simd.mul_f32s(acc0, value);
                     }
 
-                    let acc = simd.add_f32s(simd.add_f32s(acc0, acc1), simd.add_f32s(acc2, acc3));
-                    let mut sum = simd.reduce_sum_f32s(acc);
-                    for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
-                        sum += x * y;
+                    let acc = simd.mul_f32s(simd.mul_f32s(acc0, acc1), simd.mul_f32s(acc2, acc3));
+                    let mut product = simd.reduce_product_f32s(acc);
+                    for &value in tail {
+                        product *= value;
                     }
-                    sum
+                    product
                 }
             }
 
-            Some(pulp::Arch::new().dispatch(Dot { a, b }))
+            Some(pulp::Arch::new().dispatch(Product(src)))
         }
+    }
+
+    fn try_simd_dot_f32(a: &[f32], b: &[f32]) -> Option<f32> {
+        struct Dot<'a> {
+            a: &'a [f32],
+            b: &'a [f32],
+        }
+        impl<'a> WithSimd for Dot<'a> {
+            type Output = f32;
+
+            #[inline(always)]
+            fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
+                debug_assert_eq!(self.a.len(), self.b.len());
+                let (a_head, a_tail) = S::as_simd_f32s(self.a);
+                let (b_head, b_tail) = S::as_simd_f32s(self.b);
+                debug_assert_eq!(a_head.len(), b_head.len());
+                debug_assert_eq!(a_tail.len(), b_tail.len());
+
+                let mut acc0 = simd.splat_f32s(0.0);
+                let mut acc1 = simd.splat_f32s(0.0);
+                let mut acc2 = simd.splat_f32s(0.0);
+                let mut acc3 = simd.splat_f32s(0.0);
+
+                let mut i = 0usize;
+                while i + 4 <= a_head.len() {
+                    acc0 = simd.mul_add_f32s(a_head[i], b_head[i], acc0);
+                    acc1 = simd.mul_add_f32s(a_head[i + 1], b_head[i + 1], acc1);
+                    acc2 = simd.mul_add_f32s(a_head[i + 2], b_head[i + 2], acc2);
+                    acc3 = simd.mul_add_f32s(a_head[i + 3], b_head[i + 3], acc3);
+                    i += 4;
+                }
+                for j in i..a_head.len() {
+                    acc0 = simd.mul_add_f32s(a_head[j], b_head[j], acc0);
+                }
+
+                let acc = simd.add_f32s(simd.add_f32s(acc0, acc1), simd.add_f32s(acc2, acc3));
+                let mut sum = simd.reduce_sum_f32s(acc);
+                for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
+                    sum += x * y;
+                }
+                sum
+            }
+        }
+
+        Some(pulp::Arch::new().dispatch(Dot { a, b }))
     }
 
     impl MaybeSimdOps for f64 {
@@ -663,49 +724,93 @@ mod simd_impls {
         }
 
         fn try_simd_dot(a: &[f64], b: &[f64]) -> Option<f64> {
-            struct Dot<'a> {
-                a: &'a [f64],
-                b: &'a [f64],
-            }
-            impl<'a> WithSimd for Dot<'a> {
+            try_simd_dot_f64(a, b)
+        }
+    }
+
+    impl MaybeSimdProduct for f64 {
+        fn try_simd_product(src: &[f64]) -> Option<f64> {
+            struct Product<'a>(&'a [f64]);
+            impl<'a> WithSimd for Product<'a> {
                 type Output = f64;
 
                 #[inline(always)]
                 fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
-                    debug_assert_eq!(self.a.len(), self.b.len());
-                    let (a_head, a_tail) = S::as_simd_f64s(self.a);
-                    let (b_head, b_tail) = S::as_simd_f64s(self.b);
-                    debug_assert_eq!(a_head.len(), b_head.len());
-                    debug_assert_eq!(a_tail.len(), b_tail.len());
+                    let (head, tail) = S::as_simd_f64s(self.0);
 
-                    let mut acc0 = simd.splat_f64s(0.0);
-                    let mut acc1 = simd.splat_f64s(0.0);
-                    let mut acc2 = simd.splat_f64s(0.0);
-                    let mut acc3 = simd.splat_f64s(0.0);
+                    let mut acc0 = simd.splat_f64s(1.0);
+                    let mut acc1 = simd.splat_f64s(1.0);
+                    let mut acc2 = simd.splat_f64s(1.0);
+                    let mut acc3 = simd.splat_f64s(1.0);
 
                     let mut i = 0usize;
-                    while i + 4 <= a_head.len() {
-                        acc0 = simd.mul_add_f64s(a_head[i], b_head[i], acc0);
-                        acc1 = simd.mul_add_f64s(a_head[i + 1], b_head[i + 1], acc1);
-                        acc2 = simd.mul_add_f64s(a_head[i + 2], b_head[i + 2], acc2);
-                        acc3 = simd.mul_add_f64s(a_head[i + 3], b_head[i + 3], acc3);
+                    while i + 4 <= head.len() {
+                        acc0 = simd.mul_f64s(acc0, head[i]);
+                        acc1 = simd.mul_f64s(acc1, head[i + 1]);
+                        acc2 = simd.mul_f64s(acc2, head[i + 2]);
+                        acc3 = simd.mul_f64s(acc3, head[i + 3]);
                         i += 4;
                     }
-                    for j in i..a_head.len() {
-                        acc0 = simd.mul_add_f64s(a_head[j], b_head[j], acc0);
+                    for &value in &head[i..] {
+                        acc0 = simd.mul_f64s(acc0, value);
                     }
 
-                    let acc = simd.add_f64s(simd.add_f64s(acc0, acc1), simd.add_f64s(acc2, acc3));
-                    let mut sum = simd.reduce_sum_f64s(acc);
-                    for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
-                        sum += x * y;
+                    let acc = simd.mul_f64s(simd.mul_f64s(acc0, acc1), simd.mul_f64s(acc2, acc3));
+                    let mut product = simd.reduce_product_f64s(acc);
+                    for &value in tail {
+                        product *= value;
                     }
-                    sum
+                    product
                 }
             }
 
-            Some(pulp::Arch::new().dispatch(Dot { a, b }))
+            Some(pulp::Arch::new().dispatch(Product(src)))
         }
+    }
+
+    fn try_simd_dot_f64(a: &[f64], b: &[f64]) -> Option<f64> {
+        struct Dot<'a> {
+            a: &'a [f64],
+            b: &'a [f64],
+        }
+        impl<'a> WithSimd for Dot<'a> {
+            type Output = f64;
+
+            #[inline(always)]
+            fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
+                debug_assert_eq!(self.a.len(), self.b.len());
+                let (a_head, a_tail) = S::as_simd_f64s(self.a);
+                let (b_head, b_tail) = S::as_simd_f64s(self.b);
+                debug_assert_eq!(a_head.len(), b_head.len());
+                debug_assert_eq!(a_tail.len(), b_tail.len());
+
+                let mut acc0 = simd.splat_f64s(0.0);
+                let mut acc1 = simd.splat_f64s(0.0);
+                let mut acc2 = simd.splat_f64s(0.0);
+                let mut acc3 = simd.splat_f64s(0.0);
+
+                let mut i = 0usize;
+                while i + 4 <= a_head.len() {
+                    acc0 = simd.mul_add_f64s(a_head[i], b_head[i], acc0);
+                    acc1 = simd.mul_add_f64s(a_head[i + 1], b_head[i + 1], acc1);
+                    acc2 = simd.mul_add_f64s(a_head[i + 2], b_head[i + 2], acc2);
+                    acc3 = simd.mul_add_f64s(a_head[i + 3], b_head[i + 3], acc3);
+                    i += 4;
+                }
+                for j in i..a_head.len() {
+                    acc0 = simd.mul_add_f64s(a_head[j], b_head[j], acc0);
+                }
+
+                let acc = simd.add_f64s(simd.add_f64s(acc0, acc1), simd.add_f64s(acc2, acc3));
+                let mut sum = simd.reduce_sum_f64s(acc);
+                for (&x, &y) in a_tail.iter().zip(b_tail.iter()) {
+                    sum += x * y;
+                }
+                sum
+            }
+        }
+
+        Some(pulp::Arch::new().dispatch(Dot { a, b }))
     }
 }
 

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -1,7 +1,7 @@
 use num_complex::{Complex32, Complex64};
 use strided_kernel::{
-    ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ExecContext, KernelDType, ReduceOp,
-    StridedError,
+    ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan, ExecContext, KernelDType,
+    MaybeSimdOps, ReduceOp, StridedError,
 };
 
 fn as_bytes<T>(data: &[T]) -> &[u8] {
@@ -129,6 +129,233 @@ fn erased_reduce_plan_integer_full_reductions_use_wrapping_arithmetic() {
         .unwrap();
 
     assert_eq!(product_output, [i64::MAX.wrapping_mul(2)]);
+}
+
+#[test]
+fn erased_reduce_plan_serial_full_sum_uses_fixed_multi_accumulator_order() {
+    let dims = [9usize];
+    let strides = [1isize];
+    let input = [1.0e16f64, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0e16];
+    let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+
+    let mut serial_output = [0.0f64];
+    let mut serial_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut serial_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    plan.execute(&ExecContext::serial(), &mut serial_dest, &source)
+        .unwrap();
+
+    let mut one_thread_output = [0.0f64];
+    let mut one_thread_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut one_thread_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    plan.execute(
+        &ExecContext::max_threads(1).unwrap(),
+        &mut one_thread_dest,
+        &source,
+    )
+    .unwrap();
+
+    let expected = <f64 as MaybeSimdOps>::try_simd_sum(&input).unwrap_or(7.0);
+    assert_eq!(serial_output[0].to_bits(), expected.to_bits());
+    assert_eq!(one_thread_output[0].to_bits(), serial_output[0].to_bits());
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn erased_reduce_plan_fixed_bounded_context_is_bitwise_repeatable() {
+    let dims = [131_073usize];
+    let strides = [1isize];
+    let input = (0..dims[0])
+        .map(|index| match index % 4 {
+            0 => 1.0e12,
+            1 => 1.0,
+            2 => -1.0e12,
+            _ => -0.5,
+        })
+        .collect::<Vec<f64>>();
+    let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let ctx = ExecContext::max_threads(4).unwrap();
+    let mut expected = None;
+
+    for _ in 0..8 {
+        let mut output = [0.0f64];
+        let mut dest =
+            ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0)
+                .unwrap();
+        plan.execute(&ctx, &mut dest, &source).unwrap();
+        let bits = output[0].to_bits();
+        assert_eq!(*expected.get_or_insert(bits), bits);
+    }
+}
+
+#[test]
+fn erased_reduce_plan_preserves_noncompact_and_nonfinite_semantics() {
+    let dims = [2usize, 2];
+    let strides = [1isize, 3];
+    let input = [
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, -1.0),
+        Complex64::new(99.0, 99.0),
+        Complex64::new(-2.0, 0.5),
+        Complex64::new(4.0, 1.5),
+    ];
+    let plan = ErasedReducePlan::compile(KernelDType::C64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut output = [Complex64::new(0.0, 0.0)];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [input[0] + input[1] + input[3] + input[4]]);
+
+    let nonfinite_input = [f64::INFINITY, 2.0, f64::NEG_INFINITY];
+    let nonfinite_dims = [nonfinite_input.len()];
+    let nonfinite_strides = [1isize];
+    let nonfinite_plan = ErasedReducePlan::compile(
+        KernelDType::F64,
+        ReduceOp::Sum,
+        &nonfinite_dims,
+        &nonfinite_strides,
+    )
+    .unwrap();
+    let nonfinite_source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&nonfinite_input),
+        &nonfinite_dims,
+        &nonfinite_strides,
+        0,
+    )
+    .unwrap();
+    let mut nonfinite_output = [0.0f64];
+    let mut nonfinite_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut nonfinite_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    nonfinite_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut nonfinite_dest,
+            &nonfinite_source,
+        )
+        .unwrap();
+
+    assert!(nonfinite_output[0].is_nan());
+}
+
+#[test]
+fn erased_reduce_plan_contiguous_product_covers_vector_body_and_tail() {
+    let dims = [65usize];
+    let strides = [1isize];
+    let input = (0..dims[0])
+        .map(|index| if index % 2 == 0 { 2.0f64 } else { 0.5 })
+        .collect::<Vec<_>>();
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut output = [0.0f64];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [2.0]);
+}
+
+#[test]
+fn erased_reduce_plan_contiguous_fast_path_honors_offset_and_empty_layout() {
+    let storage = [99.0f64, 88.0, 1.0, 2.0, 3.0, 77.0];
+    let dims = [3usize];
+    let strides = [1isize];
+    let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&storage), &dims, &strides, 2).unwrap();
+    let mut output = [0.0f64];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(output, [6.0]);
+
+    let empty_dims = [0usize];
+    let empty_plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &empty_dims, &strides)
+            .unwrap();
+    let empty_source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes::<f64>(&[]),
+        &empty_dims,
+        &strides,
+        isize::MAX,
+    )
+    .unwrap();
+    let mut empty_output = [0.0f64];
+    let mut empty_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut empty_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    empty_plan
+        .execute(&ExecContext::serial(), &mut empty_dest, &empty_source)
+        .unwrap();
+
+    assert_eq!(empty_output, [1.0]);
+}
+
+#[test]
+fn erased_reduce_plan_product_documents_reassociated_overflow_classification() {
+    let dims = [65usize];
+    let strides = [1isize];
+    let mut input = [1.0f64; 65];
+    input[0] = f64::MAX;
+    input[1] = f64::MIN_POSITIVE;
+    input[2] = f64::MIN_POSITIVE;
+    input[3] = f64::MIN_POSITIVE;
+    input[32] = f64::MAX;
+    let left_fold = input.iter().copied().fold(1.0, |acc, value| acc * value);
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut output = [0.0f64];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert_eq!(left_fold, 0.0);
+    assert!(!output[0].is_finite());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- document the built-in erased reduction association and fixed-context determinism contract
- accelerate compact full sum/product with fixed multi-accumulator SIMD/scalar paths
- preserve generic traversal for noncompact layouts and make `serial()` / `max_threads(1)` identical
- cover reassociated overflow classification, nonzero/empty offsets, and actual bounded-parallel determinism

Closes #167.

## Policy
The policy was posted before implementation at #149 comment 5120321777. The floating-product overflow/underflow clarification is #149 comment 5120696554. No oracle tolerance or benchmark threshold changes.

## Public API benchmark
`PUBLICATION_GATE_PROFILE=full`, 15 runs / 3 warmups, `8192x4096` f64. CPU 60 for t1; CPUs 56-59 for t4. Baseline tenferro `117395df` + strided `ed3053a`.

| row | baseline t1 ms | candidate t1 ms | delta | baseline t4 ms | candidate t4 ms | delta |
|---|---:|---:|---:|---:|---:|---:|
| sum eager | 28.207 | 10.163 | -64.0% | 8.040 | 7.583 | -5.7% |
| sum trace | 28.332 | 10.210 | -64.0% | 7.652 | 7.398 | -3.3% |
| product eager | 28.308 | 10.162 | -64.1% | 8.443 | 7.459 | -11.7% |
| product trace | 28.315 | 10.236 | -63.9% | 8.098 | 8.314 | +2.7% |

Same-machine PyTorch: t1 10.130/10.133 ms and t4 5.894/5.856 ms for sum/product. Candidate is within 2x and no row breaches +20%.

## Verification
- `cargo test --workspace`
- `cargo test -p strided-kernel --test erased_reduce_plan --features parallel`
- `cargo test -p strided-kernel --test erased_reduce_plan --no-default-features --features parallel`
- `cargo doc --workspace --no-deps`
- `cargo fmt --all -- --check`
- coverage policy: 53/53 files pass
- independent review: approved
