### PR TITLE
feat(kernel): add fused sum-of-squares reduction

### DIFF
--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -41,8 +41,9 @@ let total = reduce(&a.view(), |x| x, |a, b| a + b, 0.0).unwrap();
 
 ### Built-in Erased Reduction Order
 
-The built-in erased `Sum` and `Product` reductions have a narrower, explicit
-determinism contract than the generic closure-based `reduce` API:
+The built-in erased `Sum`, `Product`, and `SumSquares` reductions have a
+narrower, explicit determinism contract than the generic closure-based
+`reduce` API:
 
 - Compact full reductions traverse consecutive physical storage from the
   logical origin. Other full reductions use the stable fused/block traversal.
@@ -52,6 +53,11 @@ determinism contract than the generic closure-based `reduce` API:
   the `simd` feature is enabled. Other dtype/feature combinations use a fixed
   eight-lane scalar accumulator. Accumulator lanes are merged in stable order.
   Generic closure reductions retain their existing association.
+- `SumSquares` accepts `f32` and `f64`. Each value is multiplied by itself and
+  rounded in that dtype before the result enters the `Sum` accumulator. The
+  multiply and add are not contracted into FMA, so overflow and underflow are
+  classified before accumulation. The kernel does not materialize a squared
+  tensor.
 - `i32` and `i64` use wrapping sum/product. Floating and complex reductions use
   same-dtype arithmetic without widening, compensation, conjugation, or
   fast-math. Reassociation can change roundoff, signed zero, NaN details, and
@@ -63,8 +69,9 @@ determinism contract than the generic closure-based `reduce` API:
   merge order for a fixed executable, target, input, and layout; worker
   completion order does not affect the result. Different budgets may produce
   different floating or complex roundoff.
-- Empty sum and product return zero and one respectively. No tolerance or
-  correctness gate is relaxed for the optimized association.
+- Empty sum, product, and sum-of-squares return zero, one, and zero
+  respectively. No tolerance or correctness gate is relaxed for the optimized
+  association.
 
 ## High-Level Operations
 

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -682,6 +682,11 @@ pub struct ErasedFusedPlan {
 pub enum ReduceOp {
     Sum,
     Product,
+    /// Sum of same-dtype rounded squares.
+    ///
+    /// Each input is first multiplied by itself without FMA contraction, then
+    /// accumulated under the same association policy as [`Self::Sum`].
+    SumSquares,
 }
 
 /// Dtype-erased reduction wrapper.
@@ -862,7 +867,7 @@ impl ErasedReducePlan {
         dims: &[usize],
         src_strides: &[isize],
     ) -> Result<Self> {
-        check_reduce_dtype(dtype)?;
+        check_reduce_op_dtype(dtype, op)?;
         if dims.len() != src_strides.len() {
             return Err(StridedError::StrideLengthMismatch);
         }
@@ -892,7 +897,7 @@ impl ErasedReducePlan {
         dest_strides: &[isize],
         axes: &[usize],
     ) -> Result<Self> {
-        check_reduce_dtype(dtype)?;
+        check_reduce_op_dtype(dtype, op)?;
         if src_dims.len() != src_strides.len() || dest_dims.len() != dest_strides.len() {
             return Err(StridedError::StrideLengthMismatch);
         }
@@ -1989,6 +1994,15 @@ fn check_reduce_dtype(dtype: KernelDType) -> Result<()> {
     }
 }
 
+fn check_reduce_op_dtype(dtype: KernelDType, op: ReduceOp) -> Result<()> {
+    if op == ReduceOp::SumSquares && !matches!(dtype, KernelDType::F32 | KernelDType::F64) {
+        return Err(StridedError::UnsupportedDType {
+            dtype: dtype.label(),
+        });
+    }
+    check_reduce_dtype(dtype)
+}
+
 fn check_index_dtype(dtype: KernelDType) -> Result<()> {
     match dtype {
         KernelDType::I32 | KernelDType::I64 => Ok(()),
@@ -2331,7 +2345,6 @@ fn execute_reduce<T>(
 where
     T: ErasedReduceScalar,
 {
-    let source = erased_view::<T>(src);
     let use_serial = ctx.is_serial()
         || ctx
             .max_threads_limit()
@@ -2340,18 +2353,20 @@ where
         if let Some(value) = reduce_contiguous_serial(op, src) {
             value
         } else {
+            let source = erased_view::<T>(src);
             crate::reduce_view::reduce_serial(
                 &source,
-                |value| value,
+                |value| reduce_map_value(op, value),
                 |a, b| reduce_values(op, a, b),
                 reduce_identity(op),
             )?
         }
     } else {
+        let source = erased_view::<T>(src);
         ctx.run(|| {
             crate::reduce(
                 &source,
-                |value| value,
+                |value| reduce_map_value(op, value),
                 |a, b| reduce_values(op, a, b),
                 reduce_identity(op),
             )
@@ -2385,6 +2400,14 @@ where
             .unwrap_or_else(|| reduce_contiguous_lanes(values, T::zero(), T::reduce_sum)),
         ReduceOp::Product => T::try_simd_product(values)
             .unwrap_or_else(|| reduce_contiguous_lanes(values, T::one(), T::reduce_product)),
+        ReduceOp::SumSquares => T::try_simd_sum_squares(values).unwrap_or_else(|| {
+            reduce_contiguous_mapped_lanes(
+                values,
+                T::zero(),
+                |value| T::reduce_product(value, value),
+                T::reduce_sum,
+            )
+        }),
     })
 }
 
@@ -2393,15 +2416,28 @@ fn reduce_contiguous_lanes<T>(values: &[T], identity: T, combine: impl Fn(T, T) 
 where
     T: Copy,
 {
+    reduce_contiguous_mapped_lanes(values, identity, |value| value, combine)
+}
+
+#[inline]
+fn reduce_contiguous_mapped_lanes<T>(
+    values: &[T],
+    identity: T,
+    map: impl Fn(T) -> T,
+    combine: impl Fn(T, T) -> T,
+) -> T
+where
+    T: Copy,
+{
     let mut lanes = [identity; SERIAL_REDUCE_LANES];
     let mut chunks = values.chunks_exact(SERIAL_REDUCE_LANES);
     for chunk in chunks.by_ref() {
         for lane in 0..SERIAL_REDUCE_LANES {
-            lanes[lane] = combine(lanes[lane], chunk[lane]);
+            lanes[lane] = combine(lanes[lane], map(chunk[lane]));
         }
     }
     for (lane, &value) in chunks.remainder().iter().enumerate() {
-        lanes[lane] = combine(lanes[lane], value);
+        lanes[lane] = combine(lanes[lane], map(value));
     }
     lanes.into_iter().fold(identity, combine)
 }
@@ -2569,7 +2605,7 @@ where
             let source_offset =
                 checked_strided_offset(source_offset_base, layout.src_strides, src_idx)?;
             let value = unsafe { *source_data.as_ptr().offset(source_offset) };
-            acc = reduce_values(op, acc, value);
+            acc = reduce_values(op, acc, reduce_map_value(op, value));
             advance_col_major_index(reduce_idx, layout.reduce_dims);
         }
 
@@ -2626,7 +2662,7 @@ where
                     let source_offset =
                         checked_strided_offset(source_offset_base, layout.src_strides, src_idx)?;
                     let value = unsafe { *source_ptr.offset(source_offset) };
-                    acc = reduce_values(op, acc, value);
+                    acc = reduce_values(op, acc, reduce_map_value(op, value));
                     advance_col_major_index(reduce_idx, layout.reduce_dims);
                 }
 
@@ -2654,6 +2690,7 @@ where
     match op {
         ReduceOp::Sum => T::zero(),
         ReduceOp::Product => T::one(),
+        ReduceOp::SumSquares => T::zero(),
     }
 }
 
@@ -2665,11 +2702,29 @@ where
     match op {
         ReduceOp::Sum => T::reduce_sum(a, b),
         ReduceOp::Product => T::reduce_product(a, b),
+        ReduceOp::SumSquares => T::reduce_sum(a, b),
+    }
+}
+
+#[inline]
+fn reduce_map_value<T>(op: ReduceOp, value: T) -> T
+where
+    T: ErasedReduceScalar,
+{
+    match op {
+        ReduceOp::Sum | ReduceOp::Product => value,
+        ReduceOp::SumSquares => T::reduce_product(value, value),
     }
 }
 
 trait ErasedReduceScalar:
-    Copy + One + Zero + crate::MaybeSendSync + crate::simd::MaybeSimdOps + crate::simd::MaybeSimdProduct
+    Copy
+    + One
+    + Zero
+    + crate::MaybeSendSync
+    + crate::simd::MaybeSimdOps
+    + crate::simd::MaybeSimdProduct
+    + crate::simd::MaybeSimdSumSquares
 {
     fn reduce_sum(lhs: Self, rhs: Self) -> Self;
     fn reduce_product(lhs: Self, rhs: Self) -> Self;

--- a/strided-kernel/src/simd.rs
+++ b/strided-kernel/src/simd.rs
@@ -518,12 +518,19 @@ pub(crate) trait MaybeSimdProduct: Copy + Sized {
     }
 }
 
+pub(crate) trait MaybeSimdSumSquares: Copy + Sized {
+    fn try_simd_sum_squares(_src: &[Self]) -> Option<Self> {
+        None
+    }
+}
+
 // Default (no-op) impls for integer types and Complex
 macro_rules! impl_no_simd {
     ($($t:ty),*) => {
         $(
             impl MaybeSimdOps for $t {}
             impl MaybeSimdProduct for $t {}
+            impl MaybeSimdSumSquares for $t {}
         )*
     };
 }
@@ -538,21 +545,29 @@ impl<T: num_traits::Num + Copy + Clone + std::ops::Neg<Output = T>> MaybeSimdPro
     for num_complex::Complex<T>
 {
 }
+impl<T: num_traits::Num + Copy + Clone + std::ops::Neg<Output = T>> MaybeSimdSumSquares
+    for num_complex::Complex<T>
+{
+}
 
 // f32/f64: SIMD-accelerated when feature enabled, no-op otherwise
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdOps for f32 {}
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdProduct for f32 {}
+#[cfg(not(feature = "simd"))]
+impl MaybeSimdSumSquares for f32 {}
 
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdOps for f64 {}
 #[cfg(not(feature = "simd"))]
 impl MaybeSimdProduct for f64 {}
+#[cfg(not(feature = "simd"))]
+impl MaybeSimdSumSquares for f64 {}
 
 #[cfg(feature = "simd")]
 mod simd_impls {
-    use super::{MaybeSimdOps, MaybeSimdProduct};
+    use super::{MaybeSimdOps, MaybeSimdProduct, MaybeSimdSumSquares};
     use pulp::{Simd, WithSimd};
 
     impl MaybeSimdOps for f32 {
@@ -636,6 +651,51 @@ mod simd_impls {
             }
 
             Some(pulp::Arch::new().dispatch(Product(src)))
+        }
+    }
+
+    impl MaybeSimdSumSquares for f32 {
+        fn try_simd_sum_squares(src: &[f32]) -> Option<f32> {
+            struct SumSquares<'a>(&'a [f32]);
+            impl<'a> WithSimd for SumSquares<'a> {
+                type Output = f32;
+
+                #[inline(always)]
+                fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
+                    let (head, tail) = S::as_simd_f32s(self.0);
+                    let mut acc0 = simd.splat_f32s(0.0);
+                    let mut acc1 = simd.splat_f32s(0.0);
+                    let mut acc2 = simd.splat_f32s(0.0);
+                    let mut acc3 = simd.splat_f32s(0.0);
+
+                    let mut i = 0usize;
+                    while i + 4 <= head.len() {
+                        let square0 = simd.mul_f32s(head[i], head[i]);
+                        let square1 = simd.mul_f32s(head[i + 1], head[i + 1]);
+                        let square2 = simd.mul_f32s(head[i + 2], head[i + 2]);
+                        let square3 = simd.mul_f32s(head[i + 3], head[i + 3]);
+                        acc0 = simd.add_f32s(acc0, square0);
+                        acc1 = simd.add_f32s(acc1, square1);
+                        acc2 = simd.add_f32s(acc2, square2);
+                        acc3 = simd.add_f32s(acc3, square3);
+                        i += 4;
+                    }
+                    for &value in &head[i..] {
+                        let square = simd.mul_f32s(value, value);
+                        acc0 = simd.add_f32s(acc0, square);
+                    }
+
+                    let acc = simd.add_f32s(simd.add_f32s(acc0, acc1), simd.add_f32s(acc2, acc3));
+                    let mut sum = simd.reduce_sum_f32s(acc);
+                    for &value in tail {
+                        let square = value * value;
+                        sum += square;
+                    }
+                    sum
+                }
+            }
+
+            Some(pulp::Arch::new().dispatch(SumSquares(src)))
         }
     }
 
@@ -765,6 +825,51 @@ mod simd_impls {
             }
 
             Some(pulp::Arch::new().dispatch(Product(src)))
+        }
+    }
+
+    impl MaybeSimdSumSquares for f64 {
+        fn try_simd_sum_squares(src: &[f64]) -> Option<f64> {
+            struct SumSquares<'a>(&'a [f64]);
+            impl<'a> WithSimd for SumSquares<'a> {
+                type Output = f64;
+
+                #[inline(always)]
+                fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
+                    let (head, tail) = S::as_simd_f64s(self.0);
+                    let mut acc0 = simd.splat_f64s(0.0);
+                    let mut acc1 = simd.splat_f64s(0.0);
+                    let mut acc2 = simd.splat_f64s(0.0);
+                    let mut acc3 = simd.splat_f64s(0.0);
+
+                    let mut i = 0usize;
+                    while i + 4 <= head.len() {
+                        let square0 = simd.mul_f64s(head[i], head[i]);
+                        let square1 = simd.mul_f64s(head[i + 1], head[i + 1]);
+                        let square2 = simd.mul_f64s(head[i + 2], head[i + 2]);
+                        let square3 = simd.mul_f64s(head[i + 3], head[i + 3]);
+                        acc0 = simd.add_f64s(acc0, square0);
+                        acc1 = simd.add_f64s(acc1, square1);
+                        acc2 = simd.add_f64s(acc2, square2);
+                        acc3 = simd.add_f64s(acc3, square3);
+                        i += 4;
+                    }
+                    for &value in &head[i..] {
+                        let square = simd.mul_f64s(value, value);
+                        acc0 = simd.add_f64s(acc0, square);
+                    }
+
+                    let acc = simd.add_f64s(simd.add_f64s(acc0, acc1), simd.add_f64s(acc2, acc3));
+                    let mut sum = simd.reduce_sum_f64s(acc);
+                    for &value in tail {
+                        let square = value * value;
+                        sum += square;
+                    }
+                    sum
+                }
+            }
+
+            Some(pulp::Arch::new().dispatch(SumSquares(src)))
         }
     }
 

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -266,6 +266,78 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         "erased reduce-axis execute must not allocate"
     );
 
+    let sum_squares_axis_plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::SumSquares,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &axes,
+    )
+    .unwrap();
+    sum_squares_axis_plan
+        .execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    let allocations = count_allocations(|| {
+        sum_squares_axis_plan
+            .execute(&ExecContext::serial(), &mut dest, &source)
+            .unwrap();
+    });
+    assert_eq!(
+        allocations, 0,
+        "erased sum-squares axis execute must not allocate"
+    );
+
+    let sum_squares_dims = [4096usize];
+    let sum_squares_strides = [1isize];
+    let sum_squares_src = vec![1.25f64; sum_squares_dims[0]];
+    let mut sum_squares_dst = [0.0f64];
+    let sum_squares_plan = ErasedReducePlan::compile(
+        KernelDType::F64,
+        ReduceOp::SumSquares,
+        &sum_squares_dims,
+        &sum_squares_strides,
+    )
+    .unwrap();
+    let sum_squares_source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&sum_squares_src),
+        &sum_squares_dims,
+        &sum_squares_strides,
+        0,
+    )
+    .unwrap();
+    let mut sum_squares_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut sum_squares_dst),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    sum_squares_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut sum_squares_dest,
+            &sum_squares_source,
+        )
+        .unwrap();
+    let allocations = count_allocations(|| {
+        sum_squares_plan
+            .execute(
+                &ExecContext::serial(),
+                &mut sum_squares_dest,
+                &sum_squares_source,
+            )
+            .unwrap();
+    });
+    assert_eq!(
+        allocations, 0,
+        "compact sum-squares replay must not allocate"
+    );
+
     let src_dims = [2usize; 8];
     let src_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
     let start_dims = [8usize];

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -203,6 +203,37 @@ fn erased_reduce_plan_fixed_bounded_context_is_bitwise_repeatable() {
     }
 }
 
+#[cfg(feature = "parallel")]
+#[test]
+fn erased_sum_squares_fixed_bounded_context_is_bitwise_repeatable() {
+    let dims = [131_073usize];
+    let strides = [1isize];
+    let input = (0..dims[0])
+        .map(|index| match index % 4 {
+            0 => 1.0e6,
+            1 => 1.0,
+            2 => -1.0e6,
+            _ => -0.5,
+        })
+        .collect::<Vec<f64>>();
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let ctx = ExecContext::max_threads(4).unwrap();
+    let mut expected = None;
+
+    for _ in 0..8 {
+        let mut output = [0.0f64];
+        let mut dest =
+            ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0)
+                .unwrap();
+        plan.execute(&ctx, &mut dest, &source).unwrap();
+        let bits = output[0].to_bits();
+        assert_eq!(*expected.get_or_insert(bits), bits);
+    }
+}
+
 #[test]
 fn erased_reduce_plan_preserves_noncompact_and_nonfinite_semantics() {
     let dims = [2usize, 2];
@@ -802,4 +833,341 @@ fn erased_reduce_plan_rejects_invalid_compile_layout() {
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &[2, 3], &[1]).unwrap_err();
 
     assert!(matches!(err, StridedError::StrideLengthMismatch));
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_matches_materialized_full_reduction() {
+    let dims = [5usize];
+    let strides = [-1isize];
+    let input = [1.5f64, -2.0, 3.25, -4.5, 0.125, 99.0];
+    let expected = input[..5].iter().map(|&value| value * value).sum::<f64>();
+    let mut serial_output = [0.0f64];
+    let mut max_one_output = [0.0f64];
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 4).unwrap();
+
+    let mut serial_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut serial_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    plan.execute(&ExecContext::serial(), &mut serial_dest, &source)
+        .unwrap();
+
+    let mut max_one_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut max_one_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    plan.execute(
+        &ExecContext::max_threads(1).unwrap(),
+        &mut max_one_dest,
+        &source,
+    )
+    .unwrap();
+
+    assert_eq!(serial_output, [expected]);
+    assert_eq!(max_one_output[0].to_bits(), serial_output[0].to_bits());
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_is_bitwise_materialized_sum() {
+    let dims = [257usize];
+    let strides = [1isize];
+    let input = (0..dims[0])
+        .map(|index| match index % 5 {
+            0 => 1.0e100,
+            1 => -1.0e-100,
+            2 => index as f64 * 0.25,
+            3 => -3.5,
+            _ => 0.0,
+        })
+        .collect::<Vec<_>>();
+    let squared = input
+        .iter()
+        .copied()
+        .map(|value| value * value)
+        .collect::<Vec<_>>();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let squared_source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&squared), &dims, &strides, 0).unwrap();
+    let sum_squares_plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
+    let sum_plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
+    let mut fused_output = [0.0f64];
+    let mut materialized_output = [0.0f64];
+    let mut fused_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut fused_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    let mut materialized_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut materialized_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+
+    sum_squares_plan
+        .execute(&ExecContext::serial(), &mut fused_dest, &source)
+        .unwrap();
+    sum_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut materialized_dest,
+            &squared_source,
+        )
+        .unwrap();
+
+    assert_eq!(fused_output[0].to_bits(), materialized_output[0].to_bits());
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_matches_materialized_axis_reduction() {
+    let src_dims = [2usize, 3, 2];
+    let src_strides = [1isize, 2, 6];
+    let input = [
+        1.0f32, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0, 11.0, -12.0,
+    ];
+    let dest_dims = [3usize];
+    let dest_strides = [2isize];
+    let mut output = [-1.0f32; 5];
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F32,
+        ReduceOp::SumSquares,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0, 2],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F32,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        0,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F32,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::max_threads(2).unwrap(), &mut dest, &source)
+        .unwrap();
+
+    let expected = [
+        1.0f32.powi(2) + (-2.0f32).powi(2) + 7.0f32.powi(2) + (-8.0f32).powi(2),
+        3.0f32.powi(2) + (-4.0f32).powi(2) + 9.0f32.powi(2) + (-10.0f32).powi(2),
+        5.0f32.powi(2) + (-6.0f32).powi(2) + 11.0f32.powi(2) + (-12.0f32).powi(2),
+    ];
+    assert_eq!(output, [expected[0], -1.0, expected[1], -1.0, expected[2]]);
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_axis_handles_negative_stride_offset_and_zero_extent() {
+    let src_dims = [2usize, 3];
+    let src_strides = [-1isize, 2];
+    let input = [1.0f64, -2.0, 3.0, -4.0, 5.0, -6.0];
+    let dest_dims = [3usize];
+    let dest_strides = [2isize];
+    let mut output = [-1.0f64; 6];
+    let plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::SumSquares,
+        &src_dims,
+        &src_strides,
+        &dest_dims,
+        &dest_strides,
+        &[0],
+    )
+    .unwrap();
+    let source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes(&input),
+        &src_dims,
+        &src_strides,
+        1,
+    )
+    .unwrap();
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut output),
+        &dest_dims,
+        &dest_strides,
+        1,
+    )
+    .unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+    assert_eq!(output, [-1.0, 5.0, -1.0, 25.0, -1.0, 61.0]);
+
+    let empty_src_dims = [2usize, 0];
+    let empty_src_strides = [-1isize, 2];
+    let empty_dest_dims = [2usize];
+    let empty_dest_strides = [1isize];
+    let empty_plan = ErasedReducePlan::compile_axes(
+        KernelDType::F64,
+        ReduceOp::SumSquares,
+        &empty_src_dims,
+        &empty_src_strides,
+        &empty_dest_dims,
+        &empty_dest_strides,
+        &[1],
+    )
+    .unwrap();
+    let empty_source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes::<f64>(&[]),
+        &empty_src_dims,
+        &empty_src_strides,
+        isize::MAX,
+    )
+    .unwrap();
+    let mut empty_output = [9.0f64, 10.0];
+    let mut empty_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut empty_output),
+        &empty_dest_dims,
+        &empty_dest_strides,
+        0,
+    )
+    .unwrap();
+
+    empty_plan
+        .execute(&ExecContext::serial(), &mut empty_dest, &empty_source)
+        .unwrap();
+    assert_eq!(empty_output, [0.0, 0.0]);
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_handles_empty_rank_zero_and_nonfinite_values() {
+    let empty_dims = [0usize];
+    let strides = [1isize];
+    let empty_plan = ErasedReducePlan::compile(
+        KernelDType::F64,
+        ReduceOp::SumSquares,
+        &empty_dims,
+        &strides,
+    )
+    .unwrap();
+    let empty_source = ErasedRawStridedRef::new(
+        KernelDType::F64,
+        as_bytes::<f64>(&[]),
+        &empty_dims,
+        &strides,
+        isize::MAX,
+    )
+    .unwrap();
+    let mut empty_output = [9.0f64];
+    let mut empty_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut empty_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    empty_plan
+        .execute(&ExecContext::serial(), &mut empty_dest, &empty_source)
+        .unwrap();
+    assert_eq!(empty_output, [0.0]);
+
+    let scalar = [-0.0f64];
+    let scalar_plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &[], &[]).unwrap();
+    let scalar_source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&scalar), &[], &[], 0).unwrap();
+    let mut scalar_output = [1.0f64];
+    let mut scalar_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut scalar_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    scalar_plan
+        .execute(&ExecContext::serial(), &mut scalar_dest, &scalar_source)
+        .unwrap();
+    assert_eq!(scalar_output[0].to_bits(), 0.0f64.to_bits());
+
+    let nonfinite = [f64::INFINITY, f64::NAN];
+    let nonfinite_plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &[2], &[1]).unwrap();
+    let nonfinite_source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&nonfinite), &[2], &[1], 0).unwrap();
+    let mut nonfinite_output = [0.0f64];
+    let mut nonfinite_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut nonfinite_output),
+        &[],
+        &[],
+        0,
+    )
+    .unwrap();
+    nonfinite_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut nonfinite_dest,
+            &nonfinite_source,
+        )
+        .unwrap();
+    assert!(nonfinite_output[0].is_nan());
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_rounds_multiplication_before_accumulation() {
+    let dims = [2usize];
+    let strides = [1isize];
+    let input = [f64::MAX, f64::MIN_POSITIVE / 2.0];
+    let plan =
+        ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
+    let source =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let mut output = [0.0f64];
+    let mut dest =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .unwrap();
+
+    assert!(output[0].is_infinite());
+    assert_eq!((input[1] * input[1]).to_bits(), 0.0f64.to_bits());
+}
+
+#[test]
+fn erased_reduce_plan_sum_squares_rejects_non_float_dtypes() {
+    for dtype in [
+        KernelDType::I32,
+        KernelDType::I64,
+        KernelDType::C32,
+        KernelDType::C64,
+        KernelDType::Bool,
+    ] {
+        let err = ErasedReducePlan::compile(dtype, ReduceOp::SumSquares, &[1], &[1]).unwrap_err();
+        assert!(matches!(err, StridedError::UnsupportedDType { .. }));
+    }
 }


### PR DESCRIPTION
## Summary

- add `ReduceOp::SumSquares` for erased f32/f64 full and axis reductions
- preserve the reviewed W5 accumulation order while rounding `x * x` before accumulation and forbidding FMA contraction
- keep compact serial replay allocation-free and cover arbitrary strided/offset/empty layouts
- document the numerical and determinism contract

Policy was posted before implementation: https://github.com/tensor4all/strided-rs/issues/149#issuecomment-5121145409

## Verification

- `cargo test --workspace`
- SIMD focused suite: 30/30 plus allocation contract 1/1
- no-SIMD focused suite: 8/8
- release/native assembly audit: no fused multiply-add in SumSquares
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review: approved after fixing compact-path allocation and adding bitwise materialized-sum and negative-stride axis coverage

## Performance evidence

This upstream PR adds a previously unused operation, so existing tenferro public API rows cannot change at this commit. The dependent tenferro adoption PR will carry the required exact `norm_fro` t1/t4 before/after gate. The W5-main baseline already recorded on the same pinned cores is: f64 eager 23.849/10.293 ms (t1/t4), trace 6.236/2.451 ms; c64 eager 31.053/8.460 ms, trace 23.848/6.900 ms. PyTorch f64 is 1.205/1.226 ms and c64 is 23.856/6.327 ms.

Part of tensor4all/tenferro-rs#1505 and the reduction follow-up under #149.