### PR TITLE
perf(kernel): hoist runtime comparison dispatch

### DIFF
--- a/docs/superpowers/plans/2026-07-30-bool-compare-loop-hoist.md
+++ b/docs/superpowers/plans/2026-07-30-bool-compare-loop-hoist.md
@@ -1,0 +1,63 @@
+# Boolean comparison loop-hoist plan
+
+Issue: #179
+
+## Problem
+
+Downstream comparison closures match a runtime operation for every tensor
+element. On the 33,554,432-element f64 public workload, this prevents the
+single-threaded loop from reaching the throughput of a fixed comparison.
+
+## Design
+
+Add `CompareOp` and `compare_into` to the typed kernel surface.
+`compare_into` selects one fixed comparison closure before entering the
+existing `zip_map2_into` traversal. Shape validation, strided fallback,
+threading policy, and thresholds remain owned by that traversal.
+The new boundary rejects non-injective mutable layouts before traversal, using
+the allocation-free injectivity validator, so bounded parallel execution
+cannot assign overlapping writes to workers.
+
+The initial API supports ordered scalar types through `PartialOrd`. Complex
+equality remains on the downstream generic path. A SIMD mask-to-byte-store
+kernel is explicitly deferred because loop hoisting is sufficient and does not
+add unsafe code or an architecture-specific contract.
+
+## Evidence
+
+An uncommitted same-process probe compared the old runtime-match closure with
+`compare_into` on 33,554,432 f64 elements, using 3 warmups and 15 samples:
+
+| Threads | Runtime match | Loop hoisted | Change |
+|---:|---:|---:|---:|
+| 1 | 42.064 ms | 19.551 ms | -53.5% |
+| 4 | 13.276 ms | 13.066 ms | -1.6% |
+
+CPUs 60-63 were idle before the run. The four-thread result is already
+bandwidth-limited, so no SIMD implementation is justified by this evidence.
+
+The exact downstream tenferro public API row was then measured with the local
+candidate wired into both owned-tensor and borrowed-view comparison paths.
+The run used the same CPUs, 3 warmups, and 15 samples:
+
+| Threads | Current tenferro | Local adoption | Change |
+|---:|---:|---:|---:|
+| 1 | 60.752 ms | 40.337 ms | -33.6% |
+| 4 | 20.440 ms | 17.833 ms | -12.8% |
+
+A repeated candidate run measured 41.607 ms at one thread and 17.908 ms at
+four threads. The upstream PR adds only the fixed-operation entry point; the
+temporary downstream wiring is not part of this repository and will land in a
+separate tenferro adoption PR after the upstream commit is merged.
+
+## Verification
+
+- Differential tests for `Eq`, `Lt`, `Le`, `Gt`, and `Ge` across f32, f64,
+  i32, i64, and bool.
+- NaN unordered behavior.
+- Noncontiguous reverse-stride traversal.
+- Typed rejection of a large stride-zero destination before mutation under a
+  bounded Rayon policy.
+- Full workspace format and tests.
+- Exact downstream `compare_lt` public API row measured at one and four
+  threads before updating the git pin.

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -96,7 +96,8 @@ pub use strided_view::{
 // Map operations
 // ============================================================================
 pub use map_view::{
-    broadcast_mul_into, map_into, mul_into, zip_map2_into, zip_map3_into, zip_map4_into,
+    broadcast_mul_into, compare_into, map_into, mul_into, zip_map2_into, zip_map3_into,
+    zip_map4_into, CompareOp,
 };
 
 // ============================================================================

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -1011,6 +1011,50 @@ pub fn zip_map2_into<
     )
 }
 
+/// Runtime comparison selected once before entering the element loop.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompareOp {
+    Eq,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+}
+
+/// Compare two ordered views elementwise into a Boolean destination.
+///
+/// Unlike embedding a runtime operation match inside a [`zip_map2_into`]
+/// closure, this entry point selects a fixed comparison before traversal.
+///
+/// # Errors
+///
+/// Returns [`StridedError::DimensionMismatch`] when the source and destination
+/// shapes differ, or [`StridedError::NonInjectiveOutputLayout`] when distinct
+/// logical destination elements may overlap.
+pub fn compare_into<T, OpA, OpB>(
+    dest: &mut StridedViewMut<bool>,
+    a: &StridedView<T, OpA>,
+    b: &StridedView<T, OpB>,
+    op: CompareOp,
+) -> Result<()>
+where
+    T: Copy + MaybeSendSync + PartialOrd,
+    OpA: ElementOp<T>,
+    OpB: ElementOp<T>,
+{
+    if !crate::fused::is_injective_layout_without_alloc(dest.dims(), dest.strides()) {
+        return Err(StridedError::NonInjectiveOutputLayout);
+    }
+    match op {
+        CompareOp::Eq => zip_map2_into(dest, a, b, |lhs, rhs| lhs == rhs),
+        CompareOp::Lt => zip_map2_into(dest, a, b, |lhs, rhs| lhs < rhs),
+        CompareOp::Le => zip_map2_into(dest, a, b, |lhs, rhs| lhs <= rhs),
+        CompareOp::Gt => zip_map2_into(dest, a, b, |lhs, rhs| lhs > rhs),
+        CompareOp::Ge => zip_map2_into(dest, a, b, |lhs, rhs| lhs >= rhs),
+    }
+}
+
 pub(crate) fn zip_map2_raw_into<
     D: Copy + MaybeSendSync,
     A: Copy + MaybeSendSync,

--- a/strided-kernel/tests/compare_view.rs
+++ b/strided-kernel/tests/compare_view.rs
@@ -1,0 +1,121 @@
+#[cfg(feature = "parallel")]
+use std::num::NonZeroUsize;
+
+use strided_kernel::{
+    compare_into, CompareOp, Identity, StridedArray, StridedError, StridedView, StridedViewMut,
+};
+#[cfg(feature = "parallel")]
+use strided_kernel::{with_execution_policy, ExecutionPolicy};
+
+macro_rules! assert_all_compare_ops {
+    ($ty:ty, $lhs:expr, $rhs:expr) => {{
+        let lhs = StridedArray::from_parts($lhs, &[4], &[1], 0).unwrap();
+        let rhs = StridedArray::from_parts($rhs, &[4], &[1], 0).unwrap();
+        let cases = [
+            (CompareOp::Eq, [false, true, false, true]),
+            (CompareOp::Lt, [true, false, false, false]),
+            (CompareOp::Le, [true, true, false, true]),
+            (CompareOp::Gt, [false, false, true, false]),
+            (CompareOp::Ge, [false, true, true, true]),
+        ];
+
+        for (op, expected) in cases {
+            let mut out = StridedArray::<bool>::col_major(&[4]);
+            compare_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), op).unwrap();
+            assert_eq!(out.data(), &expected, "operation {op:?}");
+        }
+    }};
+}
+
+#[test]
+fn compare_into_covers_ordered_kernel_dtypes_and_operations() {
+    assert_all_compare_ops!(f32, vec![1.0, 2.0, 3.0, 2.0], vec![2.0, 2.0, 2.0, 2.0]);
+    assert_all_compare_ops!(f64, vec![1.0, 2.0, 3.0, 2.0], vec![2.0, 2.0, 2.0, 2.0]);
+    assert_all_compare_ops!(i32, vec![1, 2, 3, 2], vec![2, 2, 2, 2]);
+    assert_all_compare_ops!(i64, vec![1, 2, 3, 2], vec![2, 2, 2, 2]);
+
+    let lhs = StridedArray::from_parts(vec![false, false, true, true], &[4], &[1], 0).unwrap();
+    let rhs = StridedArray::from_parts(vec![false, true, false, true], &[4], &[1], 0).unwrap();
+    let cases = [
+        (CompareOp::Eq, [true, false, false, true]),
+        (CompareOp::Lt, [false, true, false, false]),
+        (CompareOp::Le, [true, true, false, true]),
+        (CompareOp::Gt, [false, false, true, false]),
+        (CompareOp::Ge, [true, false, true, true]),
+    ];
+    for (op, expected) in cases {
+        let mut out = StridedArray::<bool>::col_major(&[4]);
+        compare_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), op).unwrap();
+        assert_eq!(out.data(), &expected, "operation {op:?}");
+    }
+}
+
+#[test]
+fn compare_into_preserves_nan_unordered_semantics() {
+    let lhs = StridedArray::from_parts(vec![f32::NAN], &[1], &[1], 0).unwrap();
+    let rhs = StridedArray::from_parts(vec![1.0_f32], &[1], &[1], 0).unwrap();
+
+    for op in [
+        CompareOp::Eq,
+        CompareOp::Lt,
+        CompareOp::Le,
+        CompareOp::Gt,
+        CompareOp::Ge,
+    ] {
+        let mut out = StridedArray::<bool>::col_major(&[1]);
+        compare_into(&mut out.view_mut(), &lhs.view(), &rhs.view(), op).unwrap();
+        assert_eq!(out.data(), &[false], "operation {op:?}");
+    }
+}
+
+#[test]
+fn compare_into_preserves_noncontiguous_view_semantics() {
+    let dims = [5];
+    let lhs_data = [1_i64, 2, 3, 4, 5];
+    let rhs = StridedArray::from_parts(vec![0_i64, 3, 3, 3, 6], &dims, &[1], 0).unwrap();
+    let lhs = StridedView::<i64, Identity>::new(&lhs_data, &dims, &[-1], 4).unwrap();
+    let mut out = StridedArray::<bool>::col_major(&dims);
+
+    compare_into(&mut out.view_mut(), &lhs, &rhs.view(), CompareOp::Gt).unwrap();
+
+    assert_eq!(out.data(), &[true, true, false, false, false]);
+}
+
+#[test]
+fn compare_into_rejects_noninjective_destination_before_mutation() {
+    let lhs = StridedArray::from_parts(vec![1_i64; 4], &[4], &[1], 0).unwrap();
+    let rhs = StridedArray::from_parts(vec![2_i64; 4], &[4], &[1], 0).unwrap();
+    let mut output = [true];
+    let mut dest = StridedViewMut::new(&mut output, &[4], &[0], 0).unwrap();
+
+    let error = compare_into(&mut dest, &lhs.view(), &rhs.view(), CompareOp::Lt);
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [true]);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn compare_into_rejects_large_noninjective_destination_before_parallel_mutation() {
+    const LEN: usize = 100_000;
+    let lhs = StridedArray::from_parts(vec![1_i64; LEN], &[LEN], &[1], 0).unwrap();
+    let rhs = StridedArray::from_parts(vec![2_i64; LEN], &[LEN], &[1], 0).unwrap();
+    let mut output = [true];
+    let mut dest = StridedViewMut::new(&mut output, &[LEN], &[0], 0).unwrap();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(2)
+        .build()
+        .unwrap();
+
+    let error = pool.install(|| {
+        with_execution_policy(
+            ExecutionPolicy::Rayon {
+                max_threads: NonZeroUsize::new(2).unwrap(),
+            },
+            || compare_into(&mut dest, &lhs.view(), &rhs.view(), CompareOp::Lt),
+        )
+    });
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [true]);
+}


### PR DESCRIPTION
Closes #179.

Adds typed `CompareOp` / `compare_into`, selecting the comparison once before the existing zip traversal. The new boundary rejects non-injective destinations before mutation and preserves the current strided fallback, execution policy, and threading threshold without adding unsafe or SIMD code.

Kernel-only probe on 33,554,432 f64 elements (AMD EPYC 7713P, 3 warmups / 15 samples):

| threads | runtime match | loop hoisted | change |
|---:|---:|---:|---:|
| 1 | 42.064 ms | 19.551 ms | -53.5% |
| 4 | 13.276 ms | 13.066 ms | -1.6% |

Exact downstream tenferro `compare_lt` public API row, with local adoption in both owned-tensor and borrowed-view paths:

| threads | current tenferro | local adoption | change | repeat candidate |
|---:|---:|---:|---:|---:|
| 1 | 60.752 ms | 40.337 ms | -33.6% | 41.607 ms |
| 4 | 20.440 ms | 17.833 ms | -12.8% | 17.908 ms |

CPUs 60-63 were idle before measurement. The temporary downstream pin and wiring were removed; the permanent adoption remains a separate tenferro PR after this upstream commit merges.

Tests cover all five operations for f32/f64/i32/i64/bool, NaN unordered semantics, reverse strides, and pre-mutation rejection for serial-size and bounded-parallel non-injective destinations. Default tests, parallel+SIMD tests, doc tests, and formatting pass.
