### PR TITLE
Optimize contiguous dynamic indexed replay

### DIFF
--- a/strided-kernel/src/gather_plan.rs
+++ b/strided-kernel/src/gather_plan.rs
@@ -590,6 +590,9 @@ impl DynamicSlicePlan {
         if self.total == 0 {
             return Ok(());
         }
+        if self.uses_rank_one_contiguous_path() {
+            return self.execute_rank_one_contiguous(dest, operand, starts);
+        }
         #[cfg(feature = "parallel")]
         {
             let nthreads = crate::threading::parallel_threads_for_len(self.total);
@@ -631,6 +634,51 @@ impl DynamicSlicePlan {
             }
             advance_col_major_index(dest_idx, &self.dest_dims);
         }
+        Ok(())
+    }
+
+    #[inline]
+    fn uses_rank_one_contiguous_path(&self) -> bool {
+        self.operand_dims.len() == 1 && self.operand_strides[0] == 1 && self.dest_strides[0] == 1
+    }
+
+    fn execute_rank_one_contiguous<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        operand: &RawStridedRef<'_, T>,
+        starts: &RawStridedRef<'_, I>,
+    ) -> Result<()>
+    where
+        T: Copy,
+        I: GatherIndex,
+    {
+        let mut clamped_starts = [0usize; 1];
+        read_clamped_starts(
+            starts,
+            &self.operand_dims,
+            &self.slice_sizes,
+            &mut clamped_starts,
+        )?;
+        let source_start = checked_offset_add(operand.offset(), 1, clamped_starts[0])?;
+        let source_start =
+            usize::try_from(source_start).map_err(|_| StridedError::OffsetOverflow)?;
+        let dest_start =
+            usize::try_from(dest.offset()).map_err(|_| StridedError::OffsetOverflow)?;
+        let source_end = source_start
+            .checked_add(self.total)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest_end = dest_start
+            .checked_add(self.total)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let source = operand
+            .data()
+            .get(source_start..source_end)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest = dest
+            .data_mut()
+            .get_mut(dest_start..dest_end)
+            .ok_or(StridedError::OffsetOverflow)?;
+        dest.copy_from_slice(source);
         Ok(())
     }
 
@@ -791,6 +839,9 @@ impl DynamicUpdateSlicePlan {
         if self.total == 0 {
             return Ok(());
         }
+        if self.uses_rank_one_contiguous_path() {
+            return self.execute_rank_one_contiguous(dest, update, starts);
+        }
         #[cfg(feature = "parallel")]
         {
             let nthreads = crate::threading::parallel_threads_for_len(self.total);
@@ -832,6 +883,53 @@ impl DynamicUpdateSlicePlan {
             }
             advance_col_major_index(update_idx, &self.update_dims);
         }
+        Ok(())
+    }
+
+    #[inline]
+    fn uses_rank_one_contiguous_path(&self) -> bool {
+        self.operand_dims.len() == 1
+            && self.operand_strides[0] == 1
+            && self.update_strides[0] == 1
+            && self.dest_strides[0] == 1
+    }
+
+    fn execute_rank_one_contiguous<T, I>(
+        &self,
+        dest: &mut RawStridedMut<'_, T>,
+        update: &RawStridedRef<'_, T>,
+        starts: &RawStridedRef<'_, I>,
+    ) -> Result<()>
+    where
+        T: Copy,
+        I: GatherIndex,
+    {
+        let mut clamped_starts = [0usize; 1];
+        read_clamped_starts(
+            starts,
+            &self.operand_dims,
+            &self.update_dims,
+            &mut clamped_starts,
+        )?;
+        let update_start =
+            usize::try_from(update.offset()).map_err(|_| StridedError::OffsetOverflow)?;
+        let dest_start = checked_offset_add(dest.offset(), 1, clamped_starts[0])?;
+        let dest_start = usize::try_from(dest_start).map_err(|_| StridedError::OffsetOverflow)?;
+        let update_end = update_start
+            .checked_add(self.total)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest_end = dest_start
+            .checked_add(self.total)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let update = update
+            .data()
+            .get(update_start..update_end)
+            .ok_or(StridedError::OffsetOverflow)?;
+        let dest = dest
+            .data_mut()
+            .get_mut(dest_start..dest_end)
+            .ok_or(StridedError::OffsetOverflow)?;
+        dest.copy_from_slice(update);
         Ok(())
     }
 
@@ -1370,5 +1468,51 @@ impl CoordScratch {
             Some(heap) => heap,
             None => &mut self.inline[..self.len],
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DynamicSlicePlan, DynamicUpdateSlicePlan};
+
+    #[test]
+    fn dynamic_slice_fast_path_is_limited_to_rank_one_contiguous_layouts() {
+        let contiguous =
+            DynamicSlicePlan::compile(&[16], &[1], &[1], &[1], &[8], &[1], &[8]).unwrap();
+        assert!(contiguous.uses_rank_one_contiguous_path());
+
+        let higher_rank =
+            DynamicSlicePlan::compile(&[4, 4], &[1, 4], &[2], &[1], &[2, 2], &[1, 2], &[2, 2])
+                .unwrap();
+        assert!(!higher_rank.uses_rank_one_contiguous_path());
+
+        let strided = DynamicSlicePlan::compile(&[16], &[2], &[1], &[1], &[8], &[2], &[8]).unwrap();
+        assert!(!strided.uses_rank_one_contiguous_path());
+    }
+
+    #[test]
+    fn dynamic_update_fast_path_is_limited_to_rank_one_contiguous_layouts() {
+        let contiguous =
+            DynamicUpdateSlicePlan::compile(&[16], &[1], &[1], &[1], &[8], &[1], &[16], &[1])
+                .unwrap();
+        assert!(contiguous.uses_rank_one_contiguous_path());
+
+        let higher_rank = DynamicUpdateSlicePlan::compile(
+            &[4, 4],
+            &[1, 4],
+            &[2],
+            &[1],
+            &[2, 2],
+            &[1, 2],
+            &[4, 4],
+            &[1, 4],
+        )
+        .unwrap();
+        assert!(!higher_rank.uses_rank_one_contiguous_path());
+
+        let strided =
+            DynamicUpdateSlicePlan::compile(&[16], &[2], &[1], &[1], &[8], &[2], &[16], &[2])
+                .unwrap();
+        assert!(!strided.uses_rank_one_contiguous_path());
     }
 }

--- a/strided-kernel/tests/erased_indexed_write_plan.rs
+++ b/strided-kernel/tests/erased_indexed_write_plan.rs
@@ -1,3 +1,4 @@
+use num_complex::{Complex32, Complex64};
 use strided_kernel::{
     ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedRawStridedMut, ErasedRawStridedRef,
     ErasedScatterPlan, ExecContext, KernelDType, ScatterSpec, StridedError,
@@ -297,4 +298,323 @@ fn erased_indexed_write_plans_reject_invalid_contracts() {
         scatter_bool_err,
         StridedError::UnsupportedDType { dtype: "bool" }
     ));
+}
+
+fn strided_storage<T: Copy + Default>(values: &[T]) -> Vec<T> {
+    let mut storage = vec![T::default(); values.len().saturating_mul(2).saturating_sub(1)];
+    for (slot, &value) in storage.iter_mut().step_by(2).zip(values) {
+        *slot = value;
+    }
+    storage
+}
+
+fn assert_dynamic_fast_paths_match_generic<T>(dtype: KernelDType, values: &[T], updates: &[T])
+where
+    T: Copy + core::fmt::Debug + Default + PartialEq,
+{
+    let starts_dims = [1usize];
+    let starts_strides = [1isize];
+    let starts = [99i64];
+    let starts_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        as_bytes(&starts),
+        &starts_dims,
+        &starts_strides,
+        0,
+    )
+    .unwrap();
+
+    let slice_dims = [4usize];
+    let contiguous_strides = [1isize];
+    let strided_strides = [2isize];
+    let operand_dims = [values.len()];
+    let contiguous_operand = values.to_vec();
+    let strided_operand = strided_storage(values);
+    let mut contiguous_slice = vec![T::default(); slice_dims[0]];
+    let mut strided_slice = strided_storage(&contiguous_slice);
+    let contiguous_slice_plan = ErasedDynamicSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        &operand_dims,
+        &contiguous_strides,
+        &starts_dims,
+        &starts_strides,
+        &slice_dims,
+        &contiguous_strides,
+        &slice_dims,
+    )
+    .unwrap();
+    let strided_slice_plan = ErasedDynamicSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        &operand_dims,
+        &strided_strides,
+        &starts_dims,
+        &starts_strides,
+        &slice_dims,
+        &strided_strides,
+        &slice_dims,
+    )
+    .unwrap();
+    let contiguous_operand_ref = ErasedRawStridedRef::new(
+        dtype,
+        as_bytes(&contiguous_operand),
+        &operand_dims,
+        &contiguous_strides,
+        0,
+    )
+    .unwrap();
+    let strided_operand_ref = ErasedRawStridedRef::new(
+        dtype,
+        as_bytes(&strided_operand),
+        &operand_dims,
+        &strided_strides,
+        0,
+    )
+    .unwrap();
+    let mut contiguous_slice_ref = ErasedRawStridedMut::new(
+        dtype,
+        as_bytes_mut(&mut contiguous_slice),
+        &slice_dims,
+        &contiguous_strides,
+        0,
+    )
+    .unwrap();
+    let mut strided_slice_ref = ErasedRawStridedMut::new(
+        dtype,
+        as_bytes_mut(&mut strided_slice),
+        &slice_dims,
+        &strided_strides,
+        0,
+    )
+    .unwrap();
+    contiguous_slice_plan
+        .execute(
+            &ExecContext::max_threads(4).unwrap(),
+            &mut contiguous_slice_ref,
+            &contiguous_operand_ref,
+            &starts_ref,
+        )
+        .unwrap();
+    strided_slice_plan
+        .execute(
+            &ExecContext::max_threads(4).unwrap(),
+            &mut strided_slice_ref,
+            &strided_operand_ref,
+            &starts_ref,
+        )
+        .unwrap();
+    let strided_slice_values = strided_slice.iter().step_by(2).copied().collect::<Vec<_>>();
+    assert_eq!(contiguous_slice, strided_slice_values);
+
+    let update_dims = [updates.len()];
+    let contiguous_update = updates.to_vec();
+    let strided_update = strided_storage(updates);
+    let mut contiguous_dest = vec![T::default(); values.len()];
+    let mut strided_dest = strided_storage(&contiguous_dest);
+    let contiguous_update_plan = ErasedDynamicUpdateSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        &operand_dims,
+        &contiguous_strides,
+        &starts_dims,
+        &starts_strides,
+        &update_dims,
+        &contiguous_strides,
+        &operand_dims,
+        &contiguous_strides,
+    )
+    .unwrap();
+    let strided_update_plan = ErasedDynamicUpdateSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        &operand_dims,
+        &strided_strides,
+        &starts_dims,
+        &starts_strides,
+        &update_dims,
+        &strided_strides,
+        &operand_dims,
+        &strided_strides,
+    )
+    .unwrap();
+    let contiguous_update_ref = ErasedRawStridedRef::new(
+        dtype,
+        as_bytes(&contiguous_update),
+        &update_dims,
+        &contiguous_strides,
+        0,
+    )
+    .unwrap();
+    let strided_update_ref = ErasedRawStridedRef::new(
+        dtype,
+        as_bytes(&strided_update),
+        &update_dims,
+        &strided_strides,
+        0,
+    )
+    .unwrap();
+    let mut contiguous_dest_ref = ErasedRawStridedMut::new(
+        dtype,
+        as_bytes_mut(&mut contiguous_dest),
+        &operand_dims,
+        &contiguous_strides,
+        0,
+    )
+    .unwrap();
+    let mut strided_dest_ref = ErasedRawStridedMut::new(
+        dtype,
+        as_bytes_mut(&mut strided_dest),
+        &operand_dims,
+        &strided_strides,
+        0,
+    )
+    .unwrap();
+    contiguous_update_plan
+        .execute(
+            &ExecContext::max_threads(4).unwrap(),
+            &mut contiguous_dest_ref,
+            &contiguous_operand_ref,
+            &contiguous_update_ref,
+            &starts_ref,
+        )
+        .unwrap();
+    strided_update_plan
+        .execute(
+            &ExecContext::max_threads(4).unwrap(),
+            &mut strided_dest_ref,
+            &strided_operand_ref,
+            &strided_update_ref,
+            &starts_ref,
+        )
+        .unwrap();
+    let strided_dest_values = strided_dest.iter().step_by(2).copied().collect::<Vec<_>>();
+    assert_eq!(contiguous_dest, strided_dest_values);
+}
+
+#[test]
+fn erased_dynamic_fast_paths_match_generic_replay_for_every_value_dtype() {
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::F32,
+        &[0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        &[10.0f32, 11.0, 12.0],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::F64,
+        &[0.0f64, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        &[10.0f64, 11.0, 12.0],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::I32,
+        &[0i32, 1, 2, 3, 4, 5, 6, 7],
+        &[10i32, 11, 12],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::I64,
+        &[0i64, 1, 2, 3, 4, 5, 6, 7],
+        &[10i64, 11, 12],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::Bool,
+        &[false, true, false, true, true, false, true, false],
+        &[true, true, false],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::C32,
+        &[
+            Complex32::new(0.0, 0.0),
+            Complex32::new(1.0, -1.0),
+            Complex32::new(2.0, -2.0),
+            Complex32::new(3.0, -3.0),
+            Complex32::new(4.0, -4.0),
+            Complex32::new(5.0, -5.0),
+            Complex32::new(6.0, -6.0),
+            Complex32::new(7.0, -7.0),
+        ],
+        &[
+            Complex32::new(10.0, 1.0),
+            Complex32::new(11.0, 2.0),
+            Complex32::new(12.0, 3.0),
+        ],
+    );
+    assert_dynamic_fast_paths_match_generic(
+        KernelDType::C64,
+        &[
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, -1.0),
+            Complex64::new(2.0, -2.0),
+            Complex64::new(3.0, -3.0),
+            Complex64::new(4.0, -4.0),
+            Complex64::new(5.0, -5.0),
+            Complex64::new(6.0, -6.0),
+            Complex64::new(7.0, -7.0),
+        ],
+        &[
+            Complex64::new(10.0, 1.0),
+            Complex64::new(11.0, 2.0),
+            Complex64::new(12.0, 3.0),
+        ],
+    );
+}
+
+#[test]
+fn erased_dynamic_slice_preserves_empty_and_negative_stride_generic_cases() {
+    let empty_plan = ErasedDynamicSlicePlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &[4],
+        &[1],
+        &[1],
+        &[1],
+        &[0],
+        &[1],
+        &[0],
+    )
+    .unwrap();
+    let operand = [0.0f64, 1.0, 2.0, 3.0];
+    let starts = [0i64];
+    let mut empty = Vec::<f64>::new();
+    let operand_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &[4], &[1], 0).unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&starts), &[1], &[1], 0).unwrap();
+    let mut empty_ref =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut empty), &[0], &[1], 0)
+            .unwrap();
+    empty_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut empty_ref,
+            &operand_ref,
+            &starts_ref,
+        )
+        .unwrap();
+
+    let reverse_plan = ErasedDynamicSlicePlan::compile(
+        KernelDType::F64,
+        KernelDType::I64,
+        &[4],
+        &[-1],
+        &[1],
+        &[1],
+        &[4],
+        &[1],
+        &[4],
+    )
+    .unwrap();
+    let reverse_operand =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &[4], &[-1], 3).unwrap();
+    let mut reversed = [0.0f64; 4];
+    let mut reversed_ref =
+        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut reversed), &[4], &[1], 0)
+            .unwrap();
+    reverse_plan
+        .execute(
+            &ExecContext::serial(),
+            &mut reversed_ref,
+            &reverse_operand,
+            &starts_ref,
+        )
+        .unwrap();
+    assert_eq!(reversed, [3.0, 2.0, 1.0, 0.0]);
 }


### PR DESCRIPTION
## Summary

- route rank-one unit-stride dynamic slice replay through one checked slice copy
- route the overwrite phase of rank-one unit-stride dynamic-update-slice through the same allocation-free shape
- preserve the existing generic and bounded-parallel replay for higher-rank, non-unit-stride, and negative-stride layouts
- add erased differential coverage for every `KernelDType`, clamped starts, empty output, negative strides, and explicit `MaxThreads(4)`

Closes #169.

## Performance

Release-mode Criterion, measured sequentially after build. t1 was bound to CPU 60; t4 to CPUs 60-63. Twenty samples, 500 ms warmup, 2 s target measurement.

| erased public-size row | before t1 | after t1 | 95% change | before t4 | after t4 | 95% change |
|---|---:|---:|---:|---:|---:|---:|
| dynamic_slice, 2,097,152 f64 | 18.73 ms | 0.642 ms | [-96.66%, -96.54%] | 2.694 ms | 0.638 ms | [-76.27%, -75.37%] |
| dynamic_update_slice, 1,048,576 f64 | 9.889 ms | 0.542 ms | [-94.63%, -94.47%] | 1.710 ms | 0.538 ms | [-69.04%, -68.40%] |

Predeclared controls covered rank-one contiguous, rank-two contiguous, and rank-two genuinely-strided layouts for gather, additive scatter, dynamic slice, and dynamic update at t1/t4. The largest candidate-relative 95% upper bound was +5.66%, below the +20% gate. Additive scatter remains serial.

Full protocol and row attribution are recorded in #169.

## Safety and semantics

- bounds and layout contracts remain validated before replay
- fast replay uses checked ranges and safe `copy_from_slice`; no unchecked aliasing is introduced
- dynamic-update-slice still performs the required operand copy before overwriting the clamped window
- `ExecContext` remains explicit; the copy uses no more threads than the supplied context permits

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- focused Criterion t1/t4 comparison with all generic-layout controls below the repository gate
