### PR TITLE
fix: reject non-injective map destinations

### DIFF
--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -1530,7 +1530,8 @@ fn execute_one_shot_map<T: OneShotScalar>(
             dtype: T::one_shot_dtype_label(),
         });
     }
-    validate_one_shot_destination(dest)?;
+    let validated =
+        crate::map_view::validate_destination_layout_without_alloc(dest.dims(), dest.strides())?;
     crate::kernel::ensure_same_shape(dest.dims(), input.dims())?;
     if dest.dims().contains(&0) {
         return Ok(());
@@ -1544,7 +1545,12 @@ fn execute_one_shot_map<T: OneShotScalar>(
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     let input = erased_raw_ref::<T>(input);
 
-    crate::map_view::map_raw_into::<T, T, Identity>(&mut dest, &input, |value| T::map(op, value))
+    crate::map_view::map_raw_into_validated::<T, T, Identity>(
+        &mut dest,
+        &input,
+        |value| T::map(op, value),
+        validated,
+    )
 }
 
 fn execute_one_shot_map_with<D, A>(
@@ -1556,7 +1562,8 @@ where
     D: Copy + crate::MaybeSendSync,
     A: Copy + crate::MaybeSendSync,
 {
-    validate_one_shot_destination(dest)?;
+    let validated =
+        crate::map_view::validate_destination_layout_without_alloc(dest.dims(), dest.strides())?;
     crate::kernel::ensure_same_shape(dest.dims(), input.dims())?;
     if dest.dims().contains(&0) {
         return Ok(());
@@ -1568,7 +1575,7 @@ where
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     let input = erased_raw_ref::<A>(input);
-    crate::map_view::map_raw_into::<D, A, Identity>(&mut dest, &input, map)
+    crate::map_view::map_raw_into_validated::<D, A, Identity>(&mut dest, &input, map, validated)
 }
 
 fn execute_one_shot_zip<T: OneShotScalar>(
@@ -1583,7 +1590,8 @@ fn execute_one_shot_zip<T: OneShotScalar>(
             dtype: T::one_shot_dtype_label(),
         });
     }
-    validate_one_shot_destination(dest)?;
+    let validated =
+        crate::map_view::validate_destination_layout_without_alloc(dest.dims(), dest.strides())?;
     crate::kernel::ensure_same_shape(dest.dims(), lhs.dims())?;
     crate::kernel::ensure_same_shape(dest.dims(), rhs.dims())?;
     if dest.dims().contains(&0) {
@@ -1604,20 +1612,13 @@ fn execute_one_shot_zip<T: OneShotScalar>(
     let dest_data = typed_slice_mut::<T>(dest.data_mut());
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
-    crate::map_view::zip_map2_raw_into::<T, T, T, Identity, Identity>(
+    crate::map_view::zip_map2_raw_into_validated::<T, T, T, Identity, Identity>(
         &mut dest,
         &lhs,
         &rhs,
         |lhs, rhs| T::zip(op, lhs, rhs),
+        validated,
     )
-}
-
-fn validate_one_shot_destination(dest: &ErasedRawStridedMut<'_>) -> Result<()> {
-    if crate::fused::is_injective_layout_without_alloc(dest.dims(), dest.strides()) {
-        Ok(())
-    } else {
-        Err(StridedError::NonInjectiveOutputLayout)
-    }
 }
 
 fn validate_no_overlap(

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -27,6 +27,15 @@ type AxisVec<T> = Vec<T>;
 
 const CONTIGUOUS_RANGE_MIN_LEN: usize = 1 << 15;
 
+#[inline]
+fn validate_destination_layout(dims: &[usize], strides: &[isize]) -> Result<()> {
+    if crate::fused::is_injective_layout(dims, strides) {
+        Ok(())
+    } else {
+        Err(StridedError::NonInjectiveOutputLayout)
+    }
+}
+
 // ============================================================================
 // Stride-specialized inner loop helpers
 //
@@ -902,6 +911,7 @@ fn map_parts_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementO
     f: impl Fn(A) -> D + MaybeSync,
 ) -> Result<()> {
     ensure_same_shape(dst_dims, src_dims)?;
+    validate_destination_layout(dst_dims, dst_strides)?;
 
     if sequential_contiguous_layout(dst_dims, &[dst_strides, src_strides]).is_some() {
         let len = total_len(dst_dims);
@@ -1043,9 +1053,6 @@ where
     OpA: ElementOp<T>,
     OpB: ElementOp<T>,
 {
-    if !crate::fused::is_injective_layout_without_alloc(dest.dims(), dest.strides()) {
-        return Err(StridedError::NonInjectiveOutputLayout);
-    }
     match op {
         CompareOp::Eq => zip_map2_into(dest, a, b, |lhs, rhs| lhs == rhs),
         CompareOp::Lt => zip_map2_into(dest, a, b, |lhs, rhs| lhs < rhs),
@@ -1102,6 +1109,7 @@ fn zip_map2_parts_into<
 ) -> Result<()> {
     ensure_same_shape(dst_dims, a_dims)?;
     ensure_same_shape(dst_dims, b_dims)?;
+    validate_destination_layout(dst_dims, dst_strides)?;
 
     if sequential_contiguous_layout(dst_dims, &[dst_strides, a_strides, b_strides]).is_some() {
         let len = total_len(dst_dims);
@@ -1450,6 +1458,7 @@ pub fn zip_map3_into<
     ensure_same_shape(dest.dims(), a.dims())?;
     ensure_same_shape(dest.dims(), b.dims())?;
     ensure_same_shape(dest.dims(), c.dims())?;
+    validate_destination_layout(dest.dims(), dest.strides())?;
 
     let dst_ptr = dest.as_mut_ptr();
     let a_ptr = a.ptr();
@@ -1583,6 +1592,7 @@ pub fn zip_map4_into<
     ensure_same_shape(dest.dims(), b.dims())?;
     ensure_same_shape(dest.dims(), c.dims())?;
     ensure_same_shape(dest.dims(), e.dims())?;
+    validate_destination_layout(dest.dims(), dest.strides())?;
 
     let dst_ptr = dest.as_mut_ptr();
     let a_ptr = a.ptr();

--- a/strided-kernel/src/map_view.rs
+++ b/strided-kernel/src/map_view.rs
@@ -1,6 +1,10 @@
 //! Map operations on dynamic-rank strided views.
 //!
 //! These are the canonical view-based map functions, equivalent to Julia's `Base.map!`.
+//! Mutable destinations must have an injective layout. Validation is
+//! conservative and bounded: layouts that are injective but cannot be proven
+//! by the bounded checker are rejected with
+//! [`StridedError::NonInjectiveOutputLayout`].
 
 use crate::kernel::{
     build_plan_fused, build_plan_fused_small, ensure_same_shape, for_each_inner_block_preordered,
@@ -27,10 +31,27 @@ type AxisVec<T> = Vec<T>;
 
 const CONTIGUOUS_RANGE_MIN_LEN: usize = 1 << 15;
 
+pub(crate) struct ValidatedDestinationLayout(());
+
 #[inline]
-fn validate_destination_layout(dims: &[usize], strides: &[isize]) -> Result<()> {
+fn validate_destination_layout(
+    dims: &[usize],
+    strides: &[isize],
+) -> Result<ValidatedDestinationLayout> {
     if crate::fused::is_injective_layout(dims, strides) {
-        Ok(())
+        Ok(ValidatedDestinationLayout(()))
+    } else {
+        Err(StridedError::NonInjectiveOutputLayout)
+    }
+}
+
+#[inline]
+pub(crate) fn validate_destination_layout_without_alloc(
+    dims: &[usize],
+    strides: &[isize],
+) -> Result<ValidatedDestinationLayout> {
+    if crate::fused::is_injective_layout_without_alloc(dims, strides) {
+        Ok(ValidatedDestinationLayout(()))
     } else {
         Err(StridedError::NonInjectiveOutputLayout)
     }
@@ -900,6 +921,28 @@ pub(crate) fn map_raw_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op:
     )
 }
 
+pub(crate) fn map_raw_into_validated<
+    D: Copy + MaybeSendSync,
+    A: Copy + MaybeSendSync,
+    Op: ElementOp<A>,
+>(
+    dest: &mut crate::RawStridedMut<'_, D>,
+    src: &crate::RawStridedRef<'_, A>,
+    f: impl Fn(A) -> D + MaybeSync,
+    validated: ValidatedDestinationLayout,
+) -> Result<()> {
+    ensure_same_shape(dest.dims(), src.dims())?;
+    map_parts_into_validated::<D, A, Op>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        src.ptr(),
+        src.strides(),
+        f,
+        validated,
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn map_parts_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<A>>(
     dst_ptr: *mut D,
@@ -911,8 +954,28 @@ fn map_parts_into<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementO
     f: impl Fn(A) -> D + MaybeSync,
 ) -> Result<()> {
     ensure_same_shape(dst_dims, src_dims)?;
-    validate_destination_layout(dst_dims, dst_strides)?;
+    let validated = validate_destination_layout(dst_dims, dst_strides)?;
+    map_parts_into_validated::<D, A, Op>(
+        dst_ptr,
+        dst_dims,
+        dst_strides,
+        src_ptr,
+        src_strides,
+        f,
+        validated,
+    )
+}
 
+#[allow(clippy::too_many_arguments)]
+fn map_parts_into_validated<D: Copy + MaybeSendSync, A: Copy + MaybeSendSync, Op: ElementOp<A>>(
+    dst_ptr: *mut D,
+    dst_dims: &[usize],
+    dst_strides: &[isize],
+    src_ptr: *const A,
+    src_strides: &[isize],
+    f: impl Fn(A) -> D + MaybeSync,
+    _validated: ValidatedDestinationLayout,
+) -> Result<()> {
     if sequential_contiguous_layout(dst_dims, &[dst_strides, src_strides]).is_some() {
         let len = total_len(dst_dims);
         let dst = unsafe { std::slice::from_raw_parts_mut(dst_ptr, len) };
@@ -1021,6 +1084,32 @@ pub fn zip_map2_into<
     )
 }
 
+fn zip_map2_into_validated<
+    D: Copy + MaybeSendSync,
+    A: Copy + MaybeSendSync,
+    B: Copy + MaybeSendSync,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dest: &mut StridedViewMut<D>,
+    a: &StridedView<A, OpA>,
+    b: &StridedView<B, OpB>,
+    f: impl Fn(A, B) -> D + MaybeSync,
+    validated: ValidatedDestinationLayout,
+) -> Result<()> {
+    zip_map2_parts_into_validated::<D, A, B, OpA, OpB>(
+        dest.as_mut_ptr(),
+        dest.dims(),
+        dest.strides(),
+        a.ptr(),
+        a.strides(),
+        b.ptr(),
+        b.strides(),
+        f,
+        validated,
+    )
+}
+
 /// Runtime comparison selected once before entering the element loop.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1062,7 +1151,7 @@ where
     }
 }
 
-pub(crate) fn zip_map2_raw_into<
+pub(crate) fn zip_map2_raw_into_validated<
     D: Copy + MaybeSendSync,
     A: Copy + MaybeSendSync,
     B: Copy + MaybeSendSync,
@@ -1073,18 +1162,20 @@ pub(crate) fn zip_map2_raw_into<
     a: &crate::RawStridedRef<'_, A>,
     b: &crate::RawStridedRef<'_, B>,
     f: impl Fn(A, B) -> D + MaybeSync,
+    validated: ValidatedDestinationLayout,
 ) -> Result<()> {
-    zip_map2_parts_into::<D, A, B, OpA, OpB>(
+    ensure_same_shape(dest.dims(), a.dims())?;
+    ensure_same_shape(dest.dims(), b.dims())?;
+    zip_map2_parts_into_validated::<D, A, B, OpA, OpB>(
         dest.as_mut_ptr(),
         dest.dims(),
         dest.strides(),
         a.ptr(),
-        a.dims(),
         a.strides(),
         b.ptr(),
-        b.dims(),
         b.strides(),
         f,
+        validated,
     )
 }
 
@@ -1109,8 +1200,38 @@ fn zip_map2_parts_into<
 ) -> Result<()> {
     ensure_same_shape(dst_dims, a_dims)?;
     ensure_same_shape(dst_dims, b_dims)?;
-    validate_destination_layout(dst_dims, dst_strides)?;
+    let validated = validate_destination_layout(dst_dims, dst_strides)?;
+    zip_map2_parts_into_validated::<D, A, B, OpA, OpB>(
+        dst_ptr,
+        dst_dims,
+        dst_strides,
+        a_ptr,
+        a_strides,
+        b_ptr,
+        b_strides,
+        f,
+        validated,
+    )
+}
 
+#[allow(clippy::too_many_arguments)]
+fn zip_map2_parts_into_validated<
+    D: Copy + MaybeSendSync,
+    A: Copy + MaybeSendSync,
+    B: Copy + MaybeSendSync,
+    OpA: ElementOp<A>,
+    OpB: ElementOp<B>,
+>(
+    dst_ptr: *mut D,
+    dst_dims: &[usize],
+    dst_strides: &[isize],
+    a_ptr: *const A,
+    a_strides: &[isize],
+    b_ptr: *const B,
+    b_strides: &[isize],
+    f: impl Fn(A, B) -> D + MaybeSync,
+    _validated: ValidatedDestinationLayout,
+) -> Result<()> {
     if sequential_contiguous_layout(dst_dims, &[dst_strides, a_strides, b_strides]).is_some() {
         let len = total_len(dst_dims);
         let dst = unsafe { std::slice::from_raw_parts_mut(dst_ptr, len) };
@@ -1318,22 +1439,6 @@ fn mul_identity_into_raw<
     )
 }
 
-fn mul_identity_into<
-    D: Copy + MaybeSendSync + 'static,
-    A: Copy + Mul<B, Output = D> + MaybeSendSync + 'static,
-    B: Copy + MaybeSendSync + 'static,
-    OpA: ElementOp<A>,
-    OpB: ElementOp<B>,
->(
-    dest: &mut StridedViewMut<D>,
-    a: &StridedView<A, OpA>,
-    b: &StridedView<B, OpB>,
-) -> Result<()> {
-    ensure_same_shape(dest.dims(), a.dims())?;
-    ensure_same_shape(dest.dims(), b.dims())?;
-    mul_identity_into_raw(dest, a.ptr(), a.strides(), b.ptr(), b.strides())
-}
-
 /// Element-wise multiplication: `dest[i] = a[i] * b[i]`.
 ///
 /// All views must have the same shape. Broadcast operands should be represented
@@ -1349,11 +1454,15 @@ pub fn mul_into<
     a: &StridedView<A, OpA>,
     b: &StridedView<B, OpB>,
 ) -> Result<()> {
+    ensure_same_shape(dest.dims(), a.dims())?;
+    ensure_same_shape(dest.dims(), b.dims())?;
+    let validated = validate_destination_layout(dest.dims(), dest.strides())?;
+
     if OpA::IS_IDENTITY && OpB::IS_IDENTITY {
-        return mul_identity_into(dest, a, b);
+        return mul_identity_into_raw(dest, a.ptr(), a.strides(), b.ptr(), b.strides());
     }
 
-    zip_map2_into(dest, a, b, |x, y| x * y)
+    zip_map2_into_validated(dest, a, b, |x, y| x * y, validated)
 }
 
 fn broadcast_strides_for_axes(
@@ -1427,6 +1536,7 @@ pub fn broadcast_mul_into<
     b: &StridedView<B, OpB>,
     b_axes: &[usize],
 ) -> Result<()> {
+    let validated = validate_destination_layout(dest.dims(), dest.strides())?;
     let a_strides = broadcast_strides_for_axes(a.dims(), a.strides(), dest.dims(), a_axes)?;
     let b_strides = broadcast_strides_for_axes(b.dims(), b.strides(), dest.dims(), b_axes)?;
 
@@ -1436,7 +1546,7 @@ pub fn broadcast_mul_into<
 
     let a = broadcast_view_with_strides(a, dest.dims(), &a_strides);
     let b = broadcast_view_with_strides(b, dest.dims(), &b_strides);
-    mul_into(dest, &a, &b)
+    zip_map2_into_validated(dest, &a, &b, |x, y| x * y, validated)
 }
 
 /// Ternary element-wise operation: `dest[i] = f(a[i], b[i], c[i])`.
@@ -1730,8 +1840,24 @@ pub fn zip_map4_into<
 #[cfg(test)]
 mod scalar_branch_tests {
     use super::*;
-    use crate::StridedArray;
+    use crate::{RawStridedMut, RawStridedRef, StridedArray};
     use strided_view::Identity;
+
+    #[test]
+    fn raw_map_rejects_noninjective_destination_before_write() {
+        let dims = [4usize];
+        let source_strides = [1isize];
+        let dest_strides = [0isize];
+        let lhs = [1.0f64, 2.0, 3.0, 4.0];
+        let lhs = RawStridedRef::new(&lhs, &dims, &source_strides, 0).unwrap();
+
+        let mut output = [7.0f64];
+        let mut dest = RawStridedMut::new(&mut output, &dims, &dest_strides, 0).unwrap();
+        let error =
+            map_raw_into::<f64, f64, Identity>(&mut dest, &lhs, |value| -value).unwrap_err();
+        assert!(matches!(error, StridedError::NonInjectiveOutputLayout));
+        assert_eq!(output, [7.0]);
+    }
 
     #[test]
     fn test_inner_loop_map2_stride_specializations() {

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -223,6 +223,113 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         "one-shot erased map/zip must not allocate beyond the typed kernels"
     );
 
+    let dims = [3usize, 2];
+    let input_strides = [1isize, 3];
+    let output_strides = [2isize, 3];
+    let lhs = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let rhs = [6.0f64, 5.0, 4.0, 3.0, 2.0, 1.0];
+    let lhs_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &input_strides, 0)
+            .unwrap();
+    let rhs_ref =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &input_strides, 0)
+            .unwrap();
+    let mut dst = [0.0f64; 8];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut dst),
+        &dims,
+        &output_strides,
+        0,
+    )
+    .unwrap();
+    let reference_strides = [2isize, 7];
+    let mut reference_dst = [0.0f64; 12];
+    let mut reference_dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut reference_dst),
+        &dims,
+        &reference_strides,
+        0,
+    )
+    .unwrap();
+    erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut reference_dest,
+        &ErasedRawStridedPtr::from_ref(&lhs_ref),
+    )
+    .unwrap();
+    erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut reference_dest,
+        &ErasedRawStridedPtr::from_ref(&lhs_ref),
+        &ErasedRawStridedPtr::from_ref(&rhs_ref),
+    )
+    .unwrap();
+    erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut dest,
+        &ErasedRawStridedPtr::from_ref(&lhs_ref),
+    )
+    .unwrap();
+    erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &ExecContext::serial(),
+        &mut dest,
+        &ErasedRawStridedPtr::from_ref(&lhs_ref),
+        &ErasedRawStridedPtr::from_ref(&rhs_ref),
+    )
+    .unwrap();
+    let kernel_allocations = count_allocations(|| {
+        erased_map_into(
+            KernelDType::F64,
+            ErasedMapOp::Negate,
+            &ExecContext::serial(),
+            &mut reference_dest,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+        )
+        .unwrap();
+        erased_zip_into(
+            KernelDType::F64,
+            ErasedZipOp::Add,
+            &ExecContext::serial(),
+            &mut reference_dest,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+            &ErasedRawStridedPtr::from_ref(&rhs_ref),
+        )
+        .unwrap();
+    });
+    let allocations = count_allocations(|| {
+        erased_map_into(
+            KernelDType::F64,
+            ErasedMapOp::Negate,
+            &ExecContext::serial(),
+            &mut dest,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+        )
+        .unwrap();
+        erased_zip_into(
+            KernelDType::F64,
+            ErasedZipOp::Add,
+            &ExecContext::serial(),
+            &mut dest,
+            &ErasedRawStridedPtr::from_ref(&lhs_ref),
+            &ErasedRawStridedPtr::from_ref(&rhs_ref),
+        )
+        .unwrap();
+    });
+    assert_eq!(
+        allocations, kernel_allocations,
+        "validated one-shot raw replay must not repeat allocating injectivity checks"
+    );
+
     let src_dims = [2usize; 8];
     let src_strides: Vec<isize> = (0..8).map(|axis| 1isize << axis).collect();
     let dest_dims = [2usize; 4];

--- a/strided-kernel/tests/correctness_view.rs
+++ b/strided-kernel/tests/correctness_view.rs
@@ -28,6 +28,118 @@ fn test_map_into_transposed() {
     }
 }
 
+fn assert_map_arity_rejects_noninjective_destination(len: usize) {
+    let source = StridedArray::<f64>::from_fn_col_major(&[len], |idx| idx[0] as f64);
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[len], &[0], 0).unwrap();
+
+    let error = map_into(&mut dest, &source.view(), |x| x + 1.0);
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
+#[test]
+fn test_map_into_rejects_noninjective_destination_before_serial_write() {
+    assert_map_arity_rejects_noninjective_destination(4);
+}
+
+fn assert_zip_map2_arity_rejects_noninjective_destination(len: usize) {
+    let a = StridedArray::<f64>::from_fn_col_major(&[len], |idx| idx[0] as f64);
+    let b = StridedArray::<f64>::from_fn_col_major(&[len], |idx| (2 * idx[0]) as f64);
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[len], &[0], 0).unwrap();
+
+    let error = zip_map2_into(&mut dest, &a.view(), &b.view(), |x, y| x + y);
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
+#[test]
+fn test_zip_map2_into_rejects_noninjective_destination_before_serial_write() {
+    assert_zip_map2_arity_rejects_noninjective_destination(4);
+}
+
+#[test]
+fn test_zip_map3_into_rejects_noninjective_destination_before_serial_write() {
+    let sources = (0..3)
+        .map(|offset| StridedArray::<f64>::from_fn_col_major(&[4], |idx| (idx[0] + offset) as f64))
+        .collect::<Vec<_>>();
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[4], &[0], 0).unwrap();
+
+    let error = zip_map3_into(
+        &mut dest,
+        &sources[0].view(),
+        &sources[1].view(),
+        &sources[2].view(),
+        |x, y, z| x + y + z,
+    );
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
+#[test]
+fn test_zip_map4_into_rejects_noninjective_destination_before_serial_write() {
+    let sources = (0..4)
+        .map(|offset| StridedArray::<f64>::from_fn_col_major(&[4], |idx| (idx[0] + offset) as f64))
+        .collect::<Vec<_>>();
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[4], &[0], 0).unwrap();
+
+    let error = zip_map4_into(
+        &mut dest,
+        &sources[0].view(),
+        &sources[1].view(),
+        &sources[2].view(),
+        &sources[3].view(),
+        |w, x, y, z| w + x + y + z,
+    );
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn test_map_and_zip_reject_large_noninjective_destinations_before_parallel_write() {
+    const LEN: usize = 100_000;
+    assert_map_arity_rejects_noninjective_destination(LEN);
+    assert_zip_map2_arity_rejects_noninjective_destination(LEN);
+
+    let sources = (0..4)
+        .map(|offset| {
+            StridedArray::<f64>::from_fn_col_major(&[LEN], |idx| (idx[0] + offset) as f64)
+        })
+        .collect::<Vec<_>>();
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[LEN], &[0], 0).unwrap();
+    let error = zip_map3_into(
+        &mut dest,
+        &sources[0].view(),
+        &sources[1].view(),
+        &sources[2].view(),
+        |x, y, z| x + y + z,
+    );
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[LEN], &[0], 0).unwrap();
+    let error = zip_map4_into(
+        &mut dest,
+        &sources[0].view(),
+        &sources[1].view(),
+        &sources[2].view(),
+        &sources[3].view(),
+        |w, x, y, z| w + x + y + z,
+    );
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
 #[test]
 fn test_zip_map2_mixed_strides() {
     let a = make_tensor(6, 4);

--- a/strided-kernel/tests/correctness_view.rs
+++ b/strided-kernel/tests/correctness_view.rs
@@ -1,11 +1,15 @@
 use approx::assert_relative_eq;
 use num_complex::Complex64;
+#[cfg(feature = "parallel")]
+use std::num::NonZeroUsize;
 use strided_kernel::{
     add, axpy, batched_outer_product_into, broadcast_mul_into, copy_conj, copy_into, copy_scale,
     copy_transpose_scale_into, dot, fma, map_into, mul, mul_into, reduce, reduce_axis, sum,
     symmetrize_conj_into, symmetrize_into, zip_map2_into, zip_map3_into, zip_map4_into,
     StridedArray, StridedError,
 };
+#[cfg(feature = "parallel")]
+use strided_kernel::{with_execution_policy, ExecutionPolicy};
 
 fn make_tensor(rows: usize, cols: usize) -> StridedArray<f64> {
     StridedArray::from_fn_row_major(&[rows, cols], |idx| (idx[0] * cols + idx[1]) as f64)
@@ -177,6 +181,45 @@ fn test_mul_into_contiguous() {
             );
         }
     }
+}
+
+fn assert_mul_identity_paths_reject_noninjective_destination(len: usize) {
+    let lhs = StridedArray::<f64>::from_fn_col_major(&[len], |idx| idx[0] as f64 + 1.0);
+    let rhs = StridedArray::<f64>::from_fn_col_major(&[len], |idx| idx[0] as f64 + 2.0);
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[len], &[0], 0).unwrap();
+
+    let error = mul_into(&mut dest, &lhs.view(), &rhs.view());
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+
+    let lhs = StridedArray::<f64>::from_fn_col_major(&[1], |_| 2.0);
+    let rhs = StridedArray::<f64>::from_fn_col_major(&[len], |idx| idx[0] as f64 + 2.0);
+    let mut output = [7.0_f64];
+    let mut dest = strided_kernel::StridedViewMut::new(&mut output, &[len], &[0], 0).unwrap();
+
+    let error = broadcast_mul_into(&mut dest, &lhs.view(), &[0], &rhs.view(), &[0]);
+
+    assert!(matches!(error, Err(StridedError::NonInjectiveOutputLayout)));
+    assert_eq!(output, [7.0]);
+}
+
+#[test]
+fn test_mul_identity_paths_reject_noninjective_destination_before_serial_write() {
+    assert_mul_identity_paths_reject_noninjective_destination(4);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn test_mul_identity_paths_reject_noninjective_destination_before_bounded_parallel_write() {
+    const LEN: usize = 100_000;
+    with_execution_policy(
+        ExecutionPolicy::Rayon {
+            max_threads: NonZeroUsize::new(2).unwrap(),
+        },
+        || assert_mul_identity_paths_reject_noninjective_destination(LEN),
+    );
 }
 
 #[test]

--- a/strided-kernel/tests/erased_one_shot.rs
+++ b/strided-kernel/tests/erased_one_shot.rs
@@ -565,6 +565,38 @@ fn one_shot_accepts_small_injective_layout_without_allocating() {
 }
 
 #[test]
+fn one_shot_rejects_noninjective_destination_before_raw_replay() {
+    let dims = [4usize];
+    let input_strides = [1isize];
+    let output_strides = [0isize];
+    let input = [1.0f64, 2.0, 3.0, 4.0];
+    let input =
+        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &input_strides, 0)
+            .unwrap();
+    let mut actual = [7.0f64];
+    let mut output = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut actual),
+        &dims,
+        &output_strides,
+        0,
+    )
+    .unwrap();
+
+    let error = erased_map_into(
+        KernelDType::F64,
+        ErasedMapOp::Negate,
+        &ExecContext::serial(),
+        &mut output,
+        &ErasedRawStridedPtr::from_ref(&input),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, StridedError::NonInjectiveOutputLayout));
+    assert_eq!(actual, [7.0]);
+}
+
+#[test]
 fn integer_division_preflight_handles_high_rank_iteratively() {
     const RANK: usize = 20_000;
     let dims = vec![1usize; RANK];

--- a/strided-kernel/tests/erased_policy_parallel.rs
+++ b/strided-kernel/tests/erased_policy_parallel.rs
@@ -4,7 +4,7 @@ use strided_kernel::{
     erased_zip_into, ErasedCopyPlan, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan,
     ErasedGatherPlan, ErasedPadPlan, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
     ErasedReducePlan, ErasedScatterPlan, ErasedZipOp, ExecContext, GatherSpec, KernelDType,
-    ReduceOp, ScatterSpec,
+    ReduceOp, ScatterSpec, StridedError,
 };
 
 const LARGE_LEN: usize = (1 << 15) + 65;
@@ -67,6 +67,41 @@ fn large_one_shot_zip_matches_serial() {
     };
 
     assert_eq!(run(bounded_context()), run(ExecContext::serial()));
+}
+
+#[test]
+fn bounded_one_shot_rejects_noninjective_destination_before_raw_replay() {
+    let dims = [LARGE_LEN];
+    let source_strides = [1isize];
+    let dest_strides = [0isize];
+    let lhs = vec![1.0f64; LARGE_LEN];
+    let rhs = vec![2.0f64; LARGE_LEN];
+    let lhs = ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &source_strides, 0)
+        .unwrap();
+    let rhs = ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &source_strides, 0)
+        .unwrap();
+    let mut actual = [7.0f64];
+    let mut dest = ErasedRawStridedMut::new(
+        KernelDType::F64,
+        as_bytes_mut(&mut actual),
+        &dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    let error = erased_zip_into(
+        KernelDType::F64,
+        ErasedZipOp::Add,
+        &bounded_context(),
+        &mut dest,
+        &ErasedRawStridedPtr::from_ref(&lhs),
+        &ErasedRawStridedPtr::from_ref(&rhs),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, StridedError::NonInjectiveOutputLayout));
+    assert_eq!(actual, [7.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Validate mutable destination injectivity before any map/zip write, including `mul_into` and `broadcast_mul_into` identity fast paths.
- Share one pre-mutation validation across `map_into`, `zip_map2_into`, `zip_map3_into`, `zip_map4_into`, erased one-shot, and shared raw/serial/parallel execution.
- Pass a private validation token into raw execution so erased one-shot callers do not repeat validation or allocate for the bounded exact check.
- Conservatively reject layouts that the bounded checker cannot prove injective with `StridedError::NonInjectiveOutputLayout`; no unbounded checker is introduced.

Closes #181

## Review follow-up

- Added serial and bounded two-thread rejection tests for `mul_into` and `broadcast_mul_into`, with unchanged destinations.
- Added erased one-shot/raw rejection tests and a large bounded-parallel rejection test.
- Added allocator instrumentation for a nonstandard injective destination: validated one-shot map+zip matches the equivalent kernel traversal allocation count (30 vs 30), so wrapper validation adds no second allocation pass.
- TDD red phase reproduced both blockers before implementation: both mul identity paths wrote/reached execution instead of returning `NonInjectiveOutputLayout`, and the bounded-exact one-shot case incurred four additional allocations across map+zip.

## Verification

Passed on `e0c4c60`:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p strided-kernel --features parallel`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov -p strided-kernel --features parallel --tests --json --output-path /tmp/strided-181-review-coverage.json` (all coverage-instrumented tests pass)

The coverage threshold script reports the same pre-existing three failures on both candidate and pinned `origin/main`: `gather_plan.rs` 79.6% < 80%, `reduce_view.rs` 65.4% < 80%, and `static_indexing_plan.rs` 76.3% < 80%. Rustdoc likewise succeeds with the same pre-existing `StridedError::DimensionMismatch` link warning on both revisions.

`cargo test --workspace --all-features` is structurally unavailable because it enables mutually exclusive explicit BLAS providers; the build script rejects this with `Select at most one explicit BLAS provider feature.` The required workspace test passes.

## Pinned alternating benchmark

Five alternating baseline/candidate pairs, baseline `4c19952f`, candidate `e0c4c60`; t1 pinned to CPU 60 and t4 to CPUs 60-63. Command: `cargo bench -p strided-kernel --features parallel --bench threaded_compare`.

| Threads | Row | Baseline mean (ms) | Candidate mean (ms) | Delta |
|---:|---|---:|---:|---:|
| 1 | `symmetrize_zip2` | 41.8886 | 40.4300 | -3.48% |
| 1 | `map_transpose` | 0.5530 | 0.5638 | +1.95% |
| 1 | `complex_map` | 17.5470 | 17.5154 | -0.18% |
| 1 | `zip4_permute` | 4.8098 | 4.7788 | -0.64% |
| 4 | `symmetrize_zip2` | 12.3168 | 11.8788 | -3.56% |
| 4 | `map_transpose` | 0.2750 | 0.2652 | -3.56% |
| 4 | `complex_map` | 4.9062 | 4.8894 | -0.34% |
| 4 | `zip4_permute` | 1.3336 | 1.3830 | +3.70% |

Worst point estimate is +3.70%, below the +20% material-regression gate.
