### PR TITLE
chore: ignore CodeGraph index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ plan
 
 # Git worktrees
 .worktrees/
+
+# CodeGraph index
+/.codegraph/


### PR DESCRIPTION
Ignore the repository-root /.codegraph/ index directory. Validation: cargo fmt --all -- --check; cargo check --workspace --all-targets; cargo doc --workspace --no-deps; git diff --check.