### PR TITLE
Fix overflowing logical dimension validation

### DIFF
--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -675,6 +675,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn rejects_usize_max_dimension_before_isize_truncation() {
+        let data = [0u8; 1];
+        let dims = [usize::MAX];
+        let strides = [-1isize];
+        assert!(matches!(
+            RawStridedRef::new(&data, &dims, &strides, 0),
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+        let mut data = [0u8; 1];
+        assert!(matches!(
+            RawStridedMut::new(&mut data, &dims, &strides, 0),
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+        assert!(matches!(
+            ErasedRawStridedRef::new(KernelDType::Bool, &data, &dims, &strides, 0),
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+        let mut data = [0u8; 1];
+        assert!(matches!(
+            ErasedRawStridedMut::new(KernelDType::Bool, &mut data, &dims, &strides, 0),
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+        let ptr = NonNull::new(data.as_mut_ptr()).unwrap();
+        assert!(matches!(
+            unsafe {
+                ErasedRawStridedPtr::new(KernelDType::Bool, ptr, data.len(), &dims, &strides, 0)
+            },
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+        let mut data = vec![MaybeUninit::<u8>::uninit(); 1];
+        assert!(matches!(
+            ErasedRawStridedUninitMut::new(KernelDType::Bool, &mut data, &dims, &strides, 0),
+            Err(crate::StridedError::OffsetOverflow)
+        ));
+    }
+
+    #[test]
     fn empty_raw_views_use_dangling_base_pointers_for_extreme_offsets() {
         let dims = [0usize];
         let strides = [1isize];

--- a/strided-view/src/view.rs
+++ b/strided-view/src/view.rs
@@ -52,8 +52,12 @@ pub(crate) fn validate_bounds(
     let mut max_offset = offset;
     for (&dim, &stride) in dims.iter().zip(strides.iter()) {
         if dim > 1 {
+            let last = dim
+                .checked_sub(1)
+                .and_then(|value| isize::try_from(value).ok())
+                .ok_or(StridedError::OffsetOverflow)?;
             let end = stride
-                .checked_mul(dim as isize - 1)
+                .checked_mul(last)
                 .ok_or(StridedError::OffsetOverflow)?;
             if end >= 0 {
                 max_offset = max_offset


### PR DESCRIPTION
## Summary

- convert `dim - 1` to `isize` with checked arithmetic before stride multiplication
- return `OffsetOverflow` instead of truncating oversized logical dimensions
- cover typed and erased ref/mut/pointer/uninitialized descriptor variants

## Verification

- `cargo test --workspace`
- `MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' cargo +nightly miri test -p strided-view rejects_usize_max_dimension_before_isize_truncation`
- `cargo fmt --all -- --check`
- `git diff --check`
- Sol low review: no findings
- Sol high unsafe review: no findings

The allocation-alignment half originally described in the issue is intentionally moved to #190 after strict-provenance Miri showed that `align_offset` cannot prove allocation alignment from a byte slice.

Closes #189
