### PR TITLE
Make erased storage descriptors typed

### DIFF
--- a/docs/2026-07-31-issue-190-worklog.md
+++ b/docs/2026-07-31-issue-190-worklog.md
@@ -1,0 +1,94 @@
+# Issue #190 worklog
+
+## Design
+
+Issue #190 replaces safe erased byte storage construction with typed storage
+witnesses. Integer arithmetic and `align_offset` can check offsets and relative
+alignment, but neither can certify that an allocation itself was created with
+the alignment required by `f64` or complex storage. The safe constructors
+therefore accept only sealed, known kernel element types and derive the dtype,
+byte length, alignment, and validity from `&[T]`, `&mut [T]`, or
+`&mut [MaybeUninit<T>]`.
+
+`KernelStorageElement` is public but sealed, `Copy`, `'static`, and limited to
+`f32`, `f64`, `i32`, `i64`, `bool`, `Complex32`, and `Complex64`. Erased raw
+construction remains an explicitly unsafe boundary with documented allocation,
+extent, provenance, lifetime, initialization, alignment, and aliasing
+requirements. It is used only where storage is genuinely erased.
+
+## Bool and lifetime contracts
+
+Raw `Bool` bytes are initialized bytes; only the byte value may be temporarily
+invalid. Pointer consumers first perform dtype checks, then all overlap checks,
+then deferred Bool validation and typed conversion. The concatenate regression
+uses an earlier invalid byte and a later overlapping input, proving that global
+overlap ordering wins over invalid-Bool reporting.
+
+Raw pointer metadata uses `PhantomData<&'a [MaybeUninit<u8>]>`. Conversion after
+the caller has proved no mutable overlap returns a borrow tied to the method
+borrow, and requires the complete byte extent to be initialized and dtype-valid.
+The raw pointer contract permits sequential mutation through the original raw
+pointer before execution, provided no concurrent access occurs; the mutation
+regression verifies invalidation is detected before destination writes.
+
+## Migration scope
+
+Production erased kernel paths now use descriptor-owned typed accessors and
+preserve dtype, overlap, deferred Bool validation, conversion, and write
+ordering. Workspace unit/integration tests, benchmarks, and examples were
+migrated to typed constructors where storage is known. Obsolete safe byte
+constructors, byte exposure, typed-slice helpers, and erased data accessors were
+removed. No benchmark tuning, threshold changes, performance claim, or intended
+semantic behavior change was made.
+
+## Verification
+
+The following checks passed during the implementation and final passes:
+
+```text
+cargo fmt --all
+cargo fmt --all -- --check
+cargo check --workspace --lib
+cargo check --workspace --benches --examples
+cargo check --workspace --all-targets
+cargo test --workspace --no-run
+cargo test --workspace
+cargo test -p strided-kernel --test issue_190_bool_overlap
+cargo doc --workspace --no-deps
+git diff --check
+```
+
+Focused strict-provenance Miri passed:
+
+```text
+MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' \
+  cargo +nightly miri test -p strided-view \
+  raw::tests::typed_erased_storage_covers_all_kernel_dtypes
+MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' \
+  cargo +nightly miri test -p strided-kernel --test issue_190_bool_overlap \
+  concatenate_checks_all_overlaps_before_deferred_bool_validation
+MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' \
+  cargo +nightly miri test -p strided-kernel --test issue_190_bool_overlap \
+  bool_mutation_after_raw_pointer_handoff_is_validated_before_writes
+MIRIFLAGS='-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check' \
+  cargo +nightly miri test -p strided-kernel --test issue_190_bool_overlap \
+  bool_uninitialized_replay_does_not_read_strided_holes
+```
+
+The strided Bool hole regression verifies only reachable offsets are assumed
+initialized after uninitialized replay; the unreachable backing hole remains
+`MaybeUninit` and is never read.
+
+The broad `strided-view raw::tests` Miri filter still fails in the pre-existing
+`raw_mut_can_reborrow_as_view` test with a Stacked Borrows violation in the
+older view reborrow path. This was recorded separately and was not fixed or
+claimed as fixed by issue #190. The source-contract scanner passes normally;
+filesystem traversal is not Miri-isolated and is therefore not included in the
+focused Miri run.
+
+Coverage passed exactly `53/53 files passed` with:
+
+```text
+cargo llvm-cov --workspace --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+```

--- a/strided-kernel/benches/erased_policy_thresholds.rs
+++ b/strided-kernel/benches/erased_policy_thresholds.rs
@@ -86,15 +86,6 @@ fn as_bytes<T>(data: &[T]) -> &[u8] {
     }
 }
 
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 fn patterned_f64(len: usize) -> Vec<f64> {
     (0..len)
         .map(|index| (index % 251) as f64 * 0.25 + 1.0)
@@ -125,26 +116,14 @@ fn bench_axis_reduce(c: &mut Criterion) {
             &[0],
         )
         .unwrap();
-        let source = ErasedRawStridedRef::new(
-            KernelDType::F64,
-            as_bytes(&input),
-            &src_dims,
-            &src_strides,
-            0,
-        )
-        .unwrap();
+        let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0.0f64; columns];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::F64,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &source).unwrap();
                 black_box(&mut dest);
@@ -186,34 +165,17 @@ fn bench_gather_take(c: &mut Criterion) {
             spec,
         )
         .unwrap();
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::F64,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let index_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&indices),
-            &index_dims,
-            &index_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let index_ref =
+            ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0.0f64; case.len];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::F64,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &operand_ref, &index_ref)
                     .unwrap();
@@ -248,34 +210,17 @@ fn bench_dynamic_slice(c: &mut Criterion) {
             &slice_sizes,
         )
         .unwrap();
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::F64,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let starts_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&starts),
-            &starts_dims,
-            &starts_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let starts_ref =
+            ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0.0f64; case.len];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::F64,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &operand_ref, &starts_ref)
                     .unwrap();
@@ -313,42 +258,19 @@ fn bench_dynamic_update_slice(c: &mut Criterion) {
             &dest_strides,
         )
         .unwrap();
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let update_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&update),
-            &update_dims,
-            &update_strides,
-            0,
-        )
-        .unwrap();
-        let starts_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&starts),
-            &starts_dims,
-            &starts_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let update_ref =
+            ErasedRawStridedRef::from_slice(&update, &update_dims, &update_strides, 0).unwrap();
+        let starts_ref =
+            ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0i32; case.len + 128];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::I32,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &operand_ref, &update_ref, &starts_ref)
                     .unwrap();
@@ -384,26 +306,15 @@ fn bench_pad_fill_and_copy(c: &mut Criterion) {
             &interior,
         )
         .unwrap();
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0i32; dest_dims[0]];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::I32,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &operand_ref, as_bytes(&fill))
                     .unwrap();
@@ -421,21 +332,13 @@ fn bench_copy_raw_path(c: &mut Criterion) {
         let strides = [1isize];
         let source_data = patterned_f64(case.len);
         let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
-        let source =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&source_data), &dims, &strides, 0)
-                .unwrap();
+        let source = ErasedRawStridedRef::from_slice(&source_data, &dims, &strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0.0f64; case.len];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::F64,
-                as_bytes_mut(&mut output),
-                &dims,
-                &strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, 0).unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &source).unwrap();
                 black_box(&mut dest);
@@ -481,42 +384,19 @@ fn bench_scatter_additive(c: &mut Criterion) {
             spec,
         )
         .unwrap();
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::F64,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let index_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&indices),
-            &index_dims,
-            &index_strides,
-            0,
-        )
-        .unwrap();
-        let update_ref = ErasedRawStridedRef::new(
-            KernelDType::F64,
-            as_bytes(&updates),
-            &update_dims,
-            &update_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let index_ref =
+            ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+        let update_ref =
+            ErasedRawStridedRef::from_slice(&updates, &update_dims, &update_strides, 0).unwrap();
         let ctx = context(case);
 
         group.bench_function(bench_id(case), |bencher| {
             let mut output = vec![0.0f64; case.len];
-            let mut dest = ErasedRawStridedMut::new(
-                KernelDType::F64,
-                as_bytes_mut(&mut output),
-                &dest_dims,
-                &dest_strides,
-                0,
-            )
-            .unwrap();
+            let mut dest =
+                ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0)
+                    .unwrap();
             bencher.iter(|| {
                 plan.execute(&ctx, &mut dest, &operand_ref, &index_ref, &update_ref)
                     .unwrap();

--- a/strided-kernel/benches/issue_184_uninit_replay.rs
+++ b/strided-kernel/benches/issue_184_uninit_replay.rs
@@ -43,22 +43,6 @@ impl PairOrder {
     }
 }
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe { core::slice::from_raw_parts(data.as_ptr().cast(), core::mem::size_of_val(data)) }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), core::mem::size_of_val(data))
-    }
-}
-
-fn as_uninit_bytes<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
-    unsafe {
-        core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), core::mem::size_of_val(data))
-    }
-}
-
 fn elapsed(operation: &mut impl FnMut()) -> Duration {
     let start = Instant::now();
     operation();
@@ -255,10 +239,8 @@ fn bench_fused(context: ExecContext) {
     let strides = [1];
     let lhs = vector_values(VECTOR_LEN, 1.0);
     let rhs = vector_values(VECTOR_LEN, 2.0);
-    let lhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-    let rhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+    let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
     let refs = [lhs_ref, rhs_ref];
     let ptrs = refs.map(|input| ErasedRawStridedPtr::from_ref(&input));
     let plan = ErasedFusedPlan::compile(
@@ -281,22 +263,11 @@ fn bench_fused(context: ExecContext) {
     .unwrap();
     let mut initialized = vec![0.0; VECTOR_LEN];
     let mut uninitialized = vec![MaybeUninit::<f64>::uninit(); VECTOR_LEN];
-    let mut initialized = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut initialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
-    let mut uninitialized = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes(&mut uninitialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut initialized =
+        ErasedRawStridedMut::from_slice_mut(&mut initialized, &dims, &strides, 0).unwrap();
+    let mut uninitialized =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninitialized, &dims, &strides, 0)
+            .unwrap();
 
     measure_pair(
         "fused_add_mul",

--- a/strided-kernel/src/erased.rs
+++ b/strided-kernel/src/erased.rs
@@ -9,11 +9,7 @@
 //! descriptors used by one replay call, and validate ABI dtype tags before
 //! constructing these Rust descriptors.
 //!
-//! The safe Rust descriptor constructors validate dtype byte layout up front.
-//! Mutable erased descriptors only re-scan value-constrained dtypes, currently
-//! `bool`, after their raw bytes have escaped through `data_mut`.
-
-use core::{mem::MaybeUninit, ops::Add};
+use core::ops::Add;
 
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
@@ -22,8 +18,9 @@ use crate::{
     fused_elementwise_into, ConcatenatePlan, CopyPlan, DynamicSlicePlan, DynamicUpdateSlicePlan,
     ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedRawStridedUninitMut,
     ExecContext, FusedPlan, FusedScalar, GatherIndex, GatherPlan, GatherSpec, Identity,
-    KernelDType, PadPlan, RawStridedMut, RawStridedRef, Result, ReversePlan, ScatterPlan,
-    ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut, RAW_FUSED_RANK_LIMIT,
+    KernelDType, KernelStorageElement, PadPlan, RawStridedMut, RawStridedRef, Result, ReversePlan,
+    ScatterPlan, ScatterSpec, SlicePlan, StridedError, StridedView, StridedViewMut,
+    RAW_FUSED_RANK_LIMIT,
 };
 
 const ERASED_FUSED_INPUT_LIMIT: usize = 4;
@@ -99,7 +96,6 @@ pub fn erased_map_into(
     check_dtype(input_dtype, input.dtype())?;
     check_dtype(map_output_dtype(input_dtype, op)?, dest.dtype())?;
     validate_no_overlap(dest, input, 0)?;
-    dest.validate_data_if_needed()?;
     let input = validated_input_ref(input)?;
 
     let result = ctx.run(|| match (input_dtype, op) {
@@ -120,12 +116,6 @@ pub fn erased_map_into(
             dtype: input_dtype.label(),
         }),
     });
-    if result.is_ok() {
-        // SAFETY: the scalar map writes valid values of the descriptor dtype.
-        unsafe {
-            dest.assume_data_valid();
-        }
-    }
     result
 }
 
@@ -153,7 +143,6 @@ pub fn erased_zip_into(
     check_dtype(dtype, rhs.dtype())?;
     validate_no_overlap(dest, lhs, 0)?;
     validate_no_overlap(dest, rhs, 1)?;
-    dest.validate_data_if_needed()?;
     let lhs = validated_input_ref(lhs)?;
     let rhs = validated_input_ref(rhs)?;
 
@@ -169,12 +158,6 @@ pub fn erased_zip_into(
             dtype: dtype.label(),
         }),
     });
-    if result.is_ok() {
-        // SAFETY: the scalar zip writes valid values of the descriptor dtype.
-        unsafe {
-            dest.assume_data_valid();
-        }
-    }
     result
 }
 
@@ -241,7 +224,6 @@ impl ErasedCopyPlan {
     ) -> Result<()> {
         self.check_dtype(dest.dtype())?;
         self.check_dtype(src.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => execute_copy::<f32>(&self.plan, dest, src),
@@ -255,13 +237,6 @@ impl ErasedCopyPlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: `execute_copy` only writes values produced from the
-            // already-validated source descriptor for the same dtype.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -323,7 +298,6 @@ impl ErasedSlicePlan {
     ) -> Result<()> {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, operand.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => execute_slice::<f32>(&self.plan, dest, operand),
@@ -337,13 +311,6 @@ impl ErasedSlicePlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: static slice writes values read from a descriptor with
-            // the same dtype and already-validated byte representation.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -409,7 +376,6 @@ impl ErasedReversePlan {
     ) -> Result<()> {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, operand.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => execute_reverse::<f32>(&self.plan, dest, operand),
@@ -423,13 +389,6 @@ impl ErasedReversePlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: reverse writes values read from a descriptor with the
-            // same dtype and already-validated byte representation.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -509,7 +468,6 @@ impl ErasedPadPlan {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, operand.dtype())?;
         validate_scalar_bytes(self.dtype, fill)?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => execute_pad::<f32>(&self.plan, dest, operand, fill),
@@ -523,13 +481,6 @@ impl ErasedPadPlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: pad writes either the validated fill scalar or values
-            // read from a descriptor with the same validated dtype.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -606,7 +557,6 @@ impl ErasedConcatenatePlan {
         for input in inputs {
             check_dtype(self.dtype, input.dtype())?;
         }
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => execute_concatenate::<f32>(&self.plan, dest, inputs),
@@ -620,13 +570,6 @@ impl ErasedConcatenatePlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: concatenate writes values read from descriptors with
-            // the same dtype and already-validated byte representation.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -644,9 +587,13 @@ impl ErasedConcatenatePlan {
                 self.plan.input_count(),
             ));
         }
-        for (position, input) in inputs.iter().enumerate() {
+        for input in inputs {
             check_dtype(self.dtype, input.dtype())?;
+        }
+        for (position, input) in inputs.iter().enumerate() {
             validate_uninit_no_overlap(dest, input, position)?;
+        }
+        for input in inputs {
             validated_input_ref(input)?;
         }
 
@@ -834,7 +781,6 @@ impl ErasedFusedPlan {
         for input in inputs {
             check_dtype(self.dtype, input.dtype())?;
         }
-        dest.validate_data_if_needed()?;
 
         let result = match self.dtype {
             KernelDType::F32 => execute_fused::<f32>(&self.plan, ctx, dest, inputs),
@@ -848,13 +794,6 @@ impl ErasedFusedPlan {
                 dtype: self.dtype.label(),
             }),
         };
-        if result.is_ok() {
-            // SAFETY: supported fused elementwise dtypes have no extra byte
-            // validity invariant beyond the typed values written by the kernel.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 
@@ -1088,7 +1027,6 @@ impl ErasedReducePlan {
                 }
             }
         }
-        dest.validate_data_if_needed()?;
 
         let result = match self.dtype {
             KernelDType::F32 => dispatch_reduce::<f32>(self.op, &self.layout, ctx, dest, src),
@@ -1101,13 +1039,6 @@ impl ErasedReducePlan {
                 dtype: self.dtype.label(),
             }),
         };
-        if result.is_ok() {
-            // SAFETY: supported reduction dtypes have no extra byte validity
-            // invariant beyond the typed scalar written by the kernel.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 }
@@ -1169,7 +1100,6 @@ impl ErasedGatherPlan {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, operand.dtype())?;
         check_dtype(self.index_dtype, start_indices.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => dispatch_gather_index::<f32>(
@@ -1225,13 +1155,6 @@ impl ErasedGatherPlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: gather writes values read from a descriptor with the
-            // same dtype and already-validated byte representation.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 }
@@ -1293,7 +1216,6 @@ impl ErasedDynamicSlicePlan {
         check_dtype(self.dtype, dest.dtype())?;
         check_dtype(self.dtype, operand.dtype())?;
         check_dtype(self.index_dtype, starts.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => dispatch_dynamic_slice_index::<f32>(
@@ -1349,13 +1271,6 @@ impl ErasedDynamicSlicePlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: dynamic slice writes values read from a descriptor with
-            // the same dtype and already-validated byte representation.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 }
@@ -1421,7 +1336,6 @@ impl ErasedDynamicUpdateSlicePlan {
         check_dtype(self.dtype, operand.dtype())?;
         check_dtype(self.dtype, update.dtype())?;
         check_dtype(self.index_dtype, starts.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => dispatch_dynamic_update_slice_index::<f32>(
@@ -1484,13 +1398,6 @@ impl ErasedDynamicUpdateSlicePlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: dynamic-update-slice writes either values copied from
-            // `operand` or values read from `update`, both with matching dtype.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 }
@@ -1558,7 +1465,6 @@ impl ErasedScatterPlan {
         check_dtype(self.dtype, operand.dtype())?;
         check_dtype(self.dtype, updates.dtype())?;
         check_dtype(self.index_dtype, scatter_indices.dtype())?;
-        dest.validate_data_if_needed()?;
 
         let result = ctx.run(|| match self.dtype {
             KernelDType::F32 => dispatch_scatter_index::<f32>(
@@ -1613,13 +1519,6 @@ impl ErasedScatterPlan {
                 dtype: self.dtype.label(),
             }),
         });
-        if result.is_ok() {
-            // SAFETY: additive scatter copies or adds values with matching,
-            // already-validated dtypes.
-            unsafe {
-                dest.assume_data_valid();
-            }
-        }
         result
     }
 }
@@ -1645,10 +1544,10 @@ fn execute_one_shot_map<T: OneShotScalar>(
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
-    let input = erased_raw_ref::<T>(input);
+    let input = erased_raw_ref::<T>(input)?;
 
     crate::map_view::map_raw_into_validated::<T, T, Identity>(
         &mut dest,
@@ -1664,8 +1563,8 @@ fn execute_one_shot_map_with<D, A>(
     map: impl Fn(A) -> D + crate::MaybeSync,
 ) -> Result<()>
 where
-    D: Copy + crate::MaybeSendSync,
-    A: Copy + crate::MaybeSendSync,
+    D: Copy + crate::MaybeSendSync + KernelStorageElement,
+    A: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     let validated =
         crate::map_view::validate_destination_layout_without_alloc(dest.dims(), dest.strides())?;
@@ -1676,10 +1575,10 @@ where
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<D>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<D>()?;
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
-    let input = erased_raw_ref::<A>(input);
+    let input = erased_raw_ref::<A>(input)?;
     crate::map_view::map_raw_into_validated::<D, A, Identity>(&mut dest, &input, map, validated)
 }
 
@@ -1703,8 +1602,8 @@ fn execute_one_shot_zip<T: OneShotScalar>(
         return Ok(());
     }
 
-    let lhs = erased_raw_ref::<T>(lhs);
-    let rhs = erased_raw_ref::<T>(rhs);
+    let lhs = erased_raw_ref::<T>(lhs)?;
+    let rhs = erased_raw_ref::<T>(rhs)?;
     if matches!(op, ErasedZipOp::Divide | ErasedZipOp::Remainder)
         && T::INTEGER
         && raw_any(&rhs, T::is_zero)?
@@ -1714,7 +1613,7 @@ fn execute_one_shot_zip<T: OneShotScalar>(
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let mut dest =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     crate::map_view::zip_map2_raw_into_validated::<T, T, T, Identity, Identity>(
@@ -1731,15 +1630,7 @@ fn validate_no_overlap(
     input: &ErasedRawStridedPtr<'_>,
     input_index: usize,
 ) -> Result<()> {
-    let dest_start = dest.data().as_ptr() as usize;
-    let input_start = input.data_ptr() as usize;
-    let Some(dest_end) = dest_start.checked_add(dest.data().len()) else {
-        return Err(StridedError::OffsetOverflow);
-    };
-    let Some(input_end) = input_start.checked_add(input.byte_len()) else {
-        return Err(StridedError::OffsetOverflow);
-    };
-    if dest_start < input_end && input_start < dest_end {
+    if input.overlaps_mut(dest)? {
         Err(StridedError::OverlappingInputOutput { input: input_index })
     } else {
         Ok(())
@@ -1751,22 +1642,14 @@ fn validate_uninit_no_overlap(
     input: &ErasedRawStridedPtr<'_>,
     input_index: usize,
 ) -> Result<()> {
-    let dest_start = dest.data_ptr() as usize;
-    let input_start = input.data_ptr() as usize;
-    let Some(dest_end) = dest_start.checked_add(dest.byte_len()) else {
-        return Err(StridedError::OffsetOverflow);
-    };
-    let Some(input_end) = input_start.checked_add(input.byte_len()) else {
-        return Err(StridedError::OffsetOverflow);
-    };
-    if dest_start < input_end && input_start < dest_end {
+    if input.overlaps_uninit_mut(dest)? {
         Err(StridedError::OverlappingInputOutput { input: input_index })
     } else {
         Ok(())
     }
 }
 
-trait OneShotScalar: Copy + crate::MaybeSendSync + 'static {
+trait OneShotScalar: Copy + crate::MaybeSendSync + KernelStorageElement + 'static {
     const INTEGER: bool = false;
     fn is_zero(_value: Self) -> bool {
         false
@@ -1970,22 +1853,16 @@ impl OneShotScalar for bool {
     }
 }
 
-fn erased_raw_ref<'a, T>(src: &ErasedRawStridedRef<'a>) -> RawStridedRef<'a, T> {
-    let data = typed_slice::<T>(src.data());
-    unsafe { RawStridedRef::new_unchecked(data, src.dims(), src.strides(), src.offset()) }
+fn erased_raw_ref<'a, T: KernelStorageElement>(
+    src: &'a ErasedRawStridedRef<'a>,
+) -> Result<RawStridedRef<'a, T>> {
+    let data = src.data_as::<T>()?;
+    Ok(unsafe { RawStridedRef::new_unchecked(data, src.dims(), src.strides(), src.offset()) })
 }
 
-fn validated_input_ref<'a>(input: &ErasedRawStridedPtr<'a>) -> Result<ErasedRawStridedRef<'a>> {
-    // SAFETY: the pointer descriptor promises readable, dtype-valid storage,
-    // and the caller has already ruled out overlap with the mutable output.
-    let data = unsafe { input.data_unchecked() };
-    ErasedRawStridedRef::new(
-        input.dtype(),
-        data,
-        input.dims(),
-        input.strides(),
-        input.offset(),
-    )
+fn validated_input_ref<'a>(input: &'a ErasedRawStridedPtr<'a>) -> Result<ErasedRawStridedRef<'a>> {
+    // SAFETY: callers reject overlap before this conversion.
+    unsafe { input.try_as_ref_after_no_overlap() }
 }
 
 fn map_output_dtype(dtype: KernelDType, op: ErasedMapOp) -> Result<KernelDType> {
@@ -2194,13 +2071,13 @@ fn execute_copy<T>(
     src: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
-    let source_data = typed_slice::<T>(src.data());
+    let source_data = src.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let source = unsafe {
         RawStridedRef::new_unchecked(source_data, src.dims(), src.strides(), src.offset())
     };
@@ -2215,13 +2092,13 @@ fn execute_slice<T>(
     operand: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2241,13 +2118,13 @@ fn execute_slice_uninit<T>(
     operand: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_uninit_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2267,13 +2144,13 @@ fn execute_reverse<T>(
     operand: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2293,13 +2170,13 @@ fn execute_reverse_uninit<T>(
     operand: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_uninit_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2320,14 +2197,14 @@ fn execute_pad<T>(
     fill: &[u8],
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     let fill = read_unaligned_scalar::<T>(fill);
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2348,14 +2225,14 @@ fn execute_pad_uninit<T>(
     fill: &[u8],
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     let fill = read_unaligned_scalar::<T>(fill);
-    let operand_data = typed_slice::<T>(operand.data());
+    let operand_data = operand.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_uninit_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -2375,7 +2252,7 @@ fn execute_concatenate<T>(
     inputs: &[ErasedRawStridedRef<'_>],
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     if inputs.len() != plan.input_count() {
         return Err(StridedError::RankMismatch(inputs.len(), plan.input_count()));
@@ -2383,13 +2260,13 @@ where
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let mut dest_ref =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.check_dest_layout(&dest_ref)?;
 
     for (position, input) in inputs.iter().enumerate() {
-        let input_data = typed_slice::<T>(input.data());
+        let input_data = input.data_as::<T>()?;
         let input_ref = unsafe {
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
@@ -2397,7 +2274,7 @@ where
         plan.segment_offset(position, dest_offset)?;
     }
     for (position, input) in inputs.iter().enumerate() {
-        let input_data = typed_slice::<T>(input.data());
+        let input_data = input.data_as::<T>()?;
         let input_ref = unsafe {
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
@@ -2412,19 +2289,19 @@ fn execute_concatenate_uninit<T>(
     inputs: &[ErasedRawStridedPtr<'_>],
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_uninit_mut::<T>()?;
     let mut dest_ref =
         unsafe { RawStridedMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
     plan.check_dest_layout(&dest_ref)?;
 
     for (position, input) in inputs.iter().enumerate() {
         let input = validated_input_ref(input)?;
-        let input_data = typed_slice::<T>(input.data());
+        let input_data = input.data_as::<T>()?;
         let input_ref = unsafe {
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
@@ -2433,7 +2310,7 @@ where
     }
     for (position, input) in inputs.iter().enumerate() {
         let input = validated_input_ref(input)?;
-        let input_data = typed_slice::<T>(input.data());
+        let input_data = input.data_as::<T>()?;
         let input_ref = unsafe {
             RawStridedRef::new_unchecked(input_data, input.dims(), input.strides(), input.offset())
         };
@@ -2459,7 +2336,7 @@ where
         if let Some(value) = reduce_contiguous_serial(op, src) {
             value
         } else {
-            let source = erased_view::<T>(src);
+            let source = erased_view::<T>(src)?;
             crate::reduce_view::reduce_serial(
                 &source,
                 |value| reduce_map_value(op, value),
@@ -2468,7 +2345,7 @@ where
             )?
         }
     } else {
-        let source = erased_view::<T>(src);
+        let source = erased_view::<T>(src)?;
         ctx.run(|| {
             crate::reduce(
                 &source,
@@ -2480,7 +2357,7 @@ where
     };
 
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     unsafe {
         *dest_data.as_mut_ptr().offset(dest_offset) = value;
     }
@@ -2497,7 +2374,7 @@ where
         return Some(reduce_identity(op));
     }
 
-    let source_data = typed_slice::<T>(src.data());
+    let source_data = src.data_as::<T>().ok()?;
     let start = usize::try_from(src.offset()).ok()?;
     let end = start.checked_add(len)?;
     let values = source_data.get(start..end)?;
@@ -2627,9 +2504,9 @@ fn execute_reduce_axes_policy<T>(
 where
     T: ErasedReduceScalar,
 {
-    let source_data = typed_slice::<T>(src.data());
+    let source_data = src.data_as::<T>()?;
     let dest_offset_base = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     #[cfg(feature = "parallel")]
     {
         let nthreads = crate::threading::parallel_threads_for_len(layout.dest_total);
@@ -2665,9 +2542,9 @@ fn execute_reduce_axes_serial<T>(
 where
     T: ErasedReduceScalar,
 {
-    let source_data = typed_slice::<T>(src.data());
+    let source_data = src.data_as::<T>()?;
     let dest_offset_base = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     execute_reduce_axes_serial_data(
         op,
         dest_offset_base,
@@ -2824,7 +2701,8 @@ where
 }
 
 trait ErasedReduceScalar:
-    Copy
+    KernelStorageElement
+    + Copy
     + One
     + Zero
     + crate::MaybeSendSync
@@ -2962,41 +2840,41 @@ fn execute_fused<T>(
     inputs: &[ErasedRawStridedRef<'_>],
 ) -> Result<()>
 where
-    T: FusedScalar,
+    T: FusedScalar + KernelStorageElement,
 {
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let dest_view =
         unsafe { StridedViewMut::new_unchecked(dest_data, dest_dims, dest_strides, dest_offset) };
 
     match inputs {
         [a] => {
-            let input_views = [erased_view::<T>(a)];
+            let input_views = [erased_view::<T>(a)?];
             let mut dests = [dest_view];
             execute_fused_views(ctx, &mut dests, &input_views, plan)
         }
         [a, b] => {
-            let input_views = [erased_view::<T>(a), erased_view::<T>(b)];
+            let input_views = [erased_view::<T>(a)?, erased_view::<T>(b)?];
             let mut dests = [dest_view];
             execute_fused_views(ctx, &mut dests, &input_views, plan)
         }
         [a, b, c] => {
             let input_views = [
-                erased_view::<T>(a),
-                erased_view::<T>(b),
-                erased_view::<T>(c),
+                erased_view::<T>(a)?,
+                erased_view::<T>(b)?,
+                erased_view::<T>(c)?,
             ];
             let mut dests = [dest_view];
             execute_fused_views(ctx, &mut dests, &input_views, plan)
         }
         [a, b, c, d] => {
             let input_views = [
-                erased_view::<T>(a),
-                erased_view::<T>(b),
-                erased_view::<T>(c),
-                erased_view::<T>(d),
+                erased_view::<T>(a)?,
+                erased_view::<T>(b)?,
+                erased_view::<T>(c)?,
+                erased_view::<T>(d)?,
             ];
             let mut dests = [dest_view];
             execute_fused_views(ctx, &mut dests, &input_views, plan)
@@ -3016,16 +2894,16 @@ fn execute_fused_uninit<T>(
     validated: crate::map_view::ValidatedDestinationLayout,
 ) -> Result<()>
 where
-    T: FusedScalar,
+    T: FusedScalar + KernelStorageElement,
 {
     let dims = dest.dims();
     let strides = dest.strides();
     let offset = dest.offset();
-    let dest_data = typed_uninit_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_uninit_mut::<T>()?;
     let mut dest_view = unsafe { StridedViewMut::new_unchecked(dest_data, dims, strides, offset) };
     match inputs {
         [a] => {
-            let input_views = [erased_view::<T>(a)];
+            let input_views = [erased_view::<T>(a)?];
             crate::fused::fused_elementwise_into_uninit(
                 &mut dest_view,
                 &input_views,
@@ -3035,7 +2913,7 @@ where
             )
         }
         [a, b] => {
-            let input_views = [erased_view::<T>(a), erased_view::<T>(b)];
+            let input_views = [erased_view::<T>(a)?, erased_view::<T>(b)?];
             crate::fused::fused_elementwise_into_uninit(
                 &mut dest_view,
                 &input_views,
@@ -3046,9 +2924,9 @@ where
         }
         [a, b, c] => {
             let input_views = [
-                erased_view::<T>(a),
-                erased_view::<T>(b),
-                erased_view::<T>(c),
+                erased_view::<T>(a)?,
+                erased_view::<T>(b)?,
+                erased_view::<T>(c)?,
             ];
             crate::fused::fused_elementwise_into_uninit(
                 &mut dest_view,
@@ -3060,10 +2938,10 @@ where
         }
         [a, b, c, d] => {
             let input_views = [
-                erased_view::<T>(a),
-                erased_view::<T>(b),
-                erased_view::<T>(c),
-                erased_view::<T>(d),
+                erased_view::<T>(a)?,
+                erased_view::<T>(b)?,
+                erased_view::<T>(c)?,
+                erased_view::<T>(d)?,
             ];
             crate::fused::fused_elementwise_into_uninit(
                 &mut dest_view,
@@ -3088,7 +2966,7 @@ fn execute_fused_uninit_ptrs<T>(
     validated: crate::map_view::ValidatedDestinationLayout,
 ) -> Result<()>
 where
-    T: FusedScalar,
+    T: FusedScalar + KernelStorageElement,
 {
     match inputs {
         [a] => {
@@ -3131,7 +3009,7 @@ fn dispatch_gather_index<T>(
     start_indices: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     match index_dtype {
         KernelDType::I32 => execute_gather::<T, i32>(plan, dest, operand, start_indices),
@@ -3149,15 +3027,15 @@ fn execute_gather<T, I>(
     start_indices: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
-    I: GatherIndex,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
+    I: GatherIndex + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
-    let index_data = typed_slice::<I>(start_indices.data());
+    let operand_data = operand.data_as::<T>()?;
+    let index_data = start_indices.data_as::<I>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -3187,7 +3065,7 @@ fn dispatch_dynamic_slice_index<T>(
     starts: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     match index_dtype {
         KernelDType::I32 => execute_dynamic_slice::<T, i32>(plan, dest, operand, starts),
@@ -3205,15 +3083,15 @@ fn execute_dynamic_slice<T, I>(
     starts: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
-    I: GatherIndex,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
+    I: GatherIndex + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
-    let start_data = typed_slice::<I>(starts.data());
+    let operand_data = operand.data_as::<T>()?;
+    let start_data = starts.data_as::<I>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -3239,7 +3117,7 @@ fn dispatch_dynamic_update_slice_index<T>(
     starts: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
 {
     match index_dtype {
         KernelDType::I32 => {
@@ -3262,16 +3140,16 @@ fn execute_dynamic_update_slice<T, I>(
     starts: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + crate::MaybeSendSync,
-    I: GatherIndex,
+    T: Copy + crate::MaybeSendSync + KernelStorageElement,
+    I: GatherIndex + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
-    let update_data = typed_slice::<T>(update.data());
-    let start_data = typed_slice::<I>(starts.data());
+    let operand_data = operand.data_as::<T>()?;
+    let update_data = update.data_as::<T>()?;
+    let start_data = starts.data_as::<I>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -3305,7 +3183,7 @@ fn dispatch_scatter_index<T>(
     updates: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + Add<Output = T> + crate::MaybeSendSync,
+    T: Copy + Add<Output = T> + crate::MaybeSendSync + KernelStorageElement,
 {
     match index_dtype {
         KernelDType::I32 => {
@@ -3328,16 +3206,16 @@ fn execute_scatter<T, I>(
     updates: &ErasedRawStridedRef<'_>,
 ) -> Result<()>
 where
-    T: Copy + Add<Output = T> + crate::MaybeSendSync,
-    I: GatherIndex,
+    T: Copy + Add<Output = T> + crate::MaybeSendSync + KernelStorageElement,
+    I: GatherIndex + KernelStorageElement,
 {
-    let operand_data = typed_slice::<T>(operand.data());
-    let index_data = typed_slice::<I>(scatter_indices.data());
-    let update_data = typed_slice::<T>(updates.data());
+    let operand_data = operand.data_as::<T>()?;
+    let index_data = scatter_indices.data_as::<I>()?;
+    let update_data = updates.data_as::<T>()?;
     let dest_dims = dest.dims();
     let dest_strides = dest.strides();
     let dest_offset = dest.offset();
-    let dest_data = typed_slice_mut::<T>(dest.data_mut());
+    let dest_data = dest.data_as_mut::<T>()?;
     let operand_ref = unsafe {
         RawStridedRef::new_unchecked(
             operand_data,
@@ -3374,7 +3252,7 @@ fn execute_fused_views<T>(
     plan: &FusedPlan,
 ) -> Result<()>
 where
-    T: FusedScalar,
+    T: FusedScalar + KernelStorageElement,
 {
     if ctx.is_serial() {
         crate::fused::fused_elementwise_into_serial(dests, inputs, plan)
@@ -3383,47 +3261,11 @@ where
     }
 }
 
-fn erased_view<'a, T>(src: &ErasedRawStridedRef<'a>) -> StridedView<'a, T> {
-    let data = typed_slice::<T>(src.data());
-    unsafe { StridedView::new_unchecked(data, src.dims(), src.strides(), src.offset()) }
-}
-
-fn typed_slice<T>(bytes: &[u8]) -> &[T] {
-    if bytes.is_empty() {
-        return &[];
-    }
-    unsafe {
-        core::slice::from_raw_parts(
-            bytes.as_ptr().cast::<T>(),
-            bytes.len() / core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn typed_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            if bytes.is_empty() {
-                core::ptr::NonNull::<T>::dangling().as_ptr()
-            } else {
-                bytes.as_mut_ptr().cast::<T>()
-            },
-            bytes.len() / core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn typed_uninit_slice_mut<T>(bytes: &mut [MaybeUninit<u8>]) -> &mut [MaybeUninit<T>] {
-    if bytes.is_empty() {
-        return unsafe {
-            core::slice::from_raw_parts_mut(
-                core::ptr::NonNull::<MaybeUninit<T>>::dangling().as_ptr(),
-                0,
-            )
-        };
-    }
-    let len = bytes.len() / core::mem::size_of::<T>();
-    unsafe { core::slice::from_raw_parts_mut(bytes.as_mut_ptr().cast::<MaybeUninit<T>>(), len) }
+fn erased_view<'a, T: KernelStorageElement>(
+    src: &'a ErasedRawStridedRef<'a>,
+) -> Result<StridedView<'a, T>> {
+    let data = src.data_as::<T>()?;
+    Ok(unsafe { StridedView::new_unchecked(data, src.dims(), src.strides(), src.offset()) })
 }
 
 fn read_unaligned_scalar<T>(bytes: &[u8]) -> T

--- a/strided-kernel/src/lib.rs
+++ b/strided-kernel/src/lib.rs
@@ -88,8 +88,8 @@ pub use strided_view::view;
 pub use strided_view::{
     col_major_strides, row_major_strides, Adjoint, ComposableElementOp, Compose, Conj, ElementOp,
     ElementOpApply, ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef,
-    ErasedRawStridedUninitMut, Identity, KernelDType, RawStridedMut, RawStridedRef, Result,
-    StridedArray, StridedError, StridedView, StridedViewMut, Transpose,
+    ErasedRawStridedUninitMut, Identity, KernelDType, KernelStorageElement, RawStridedMut,
+    RawStridedRef, Result, StridedArray, StridedError, StridedView, StridedViewMut, Transpose,
 };
 
 // ============================================================================

--- a/strided-kernel/tests/copy_plan_alloc.rs
+++ b/strided-kernel/tests/copy_plan_alloc.rs
@@ -23,6 +23,15 @@ struct CountingAllocator;
 
 static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
 
+fn as_bytes<T>(data: &[T]) -> &[u8] {
+    unsafe {
+        core::slice::from_raw_parts(
+            data.as_ptr().cast::<u8>(),
+            data.len() * core::mem::size_of::<T>(),
+        )
+    }
+}
+
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         ALLOCATIONS.fetch_add(1, Ordering::SeqCst);
@@ -53,10 +62,8 @@ fn assert_fused_uninit_allocation_parity(ctx: &ExecContext, fused_plan: FusedPla
     let strides = [1isize];
     let lhs = vec![1.25f64; dims[0]];
     let rhs = vec![2.0f64; dims[0]];
-    let lhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-    let rhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+    let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
     let inputs = [lhs_ref.clone(), rhs_ref.clone()];
     let input_ptrs = [
         ErasedRawStridedPtr::from_ref(&lhs_ref),
@@ -64,14 +71,8 @@ fn assert_fused_uninit_allocation_parity(ctx: &ExecContext, fused_plan: FusedPla
     ];
     let plan = ErasedFusedPlan::compile(KernelDType::F64, fused_plan).unwrap();
     let mut initialized = vec![0.0f64; dims[0]];
-    let mut initialized_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut initialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut initialized_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut initialized, &dims, &strides, 0).unwrap();
     plan.execute(ctx, &mut initialized_dest, &inputs).unwrap();
     let initialized_allocations = count_allocations(|| {
         for _ in 0..8 {
@@ -79,14 +80,9 @@ fn assert_fused_uninit_allocation_parity(ctx: &ExecContext, fused_plan: FusedPla
         }
     });
     let mut uninitialized = vec![MaybeUninit::<f64>::uninit(); dims[0]];
-    let mut uninitialized_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninitialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut uninitialized_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninitialized, &dims, &strides, 0)
+            .unwrap();
     plan.execute_uninit(ctx, &mut uninitialized_dest, &input_ptrs)
         .unwrap();
     let uninitialized_allocations = count_allocations(|| {
@@ -99,33 +95,6 @@ fn assert_fused_uninit_allocation_parity(ctx: &ExecContext, fused_plan: FusedPla
         uninitialized_allocations <= initialized_allocations,
         "uninitialized={uninitialized_allocations}, initialized={initialized_allocations}"
     );
-}
-
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_uninit_bytes_mut<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
-            core::mem::size_of_val(data),
-        )
-    }
 }
 
 // One test function: the counter is process-global, so concurrently running
@@ -194,16 +163,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
 
     let plan =
         ErasedCopyPlan::compile(KernelDType::F64, &dims, &dst_strides, &src_strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &src_strides, 0).unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &dst_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&src, &dims, &src_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &dst_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -219,14 +180,10 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     let strides = [1isize];
     let lhs: Vec<f64> = (0..256).map(|value| value as f64).collect();
     let rhs: Vec<f64> = (0..256).map(|value| (value + 1) as f64).collect();
-    let lhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-    let rhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+    let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
     let mut dst = vec![0.0f64; 256];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     erased_zip_into(
         KernelDType::F64,
@@ -314,31 +271,16 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     let output_strides = [2isize, 3];
     let lhs = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0];
     let rhs = [6.0f64, 5.0, 4.0, 3.0, 2.0, 1.0];
-    let lhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &input_strides, 0)
-            .unwrap();
-    let rhs_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &input_strides, 0)
-            .unwrap();
+    let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &input_strides, 0).unwrap();
+    let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &input_strides, 0).unwrap();
     let mut dst = [0.0f64; 8];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &output_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &output_strides, 0).unwrap();
     let reference_strides = [2isize, 7];
     let mut reference_dst = [0.0f64; 12];
-    let mut reference_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut reference_dst),
-        &dims,
-        &reference_strides,
-        0,
-    )
-    .unwrap();
+    let mut reference_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut reference_dst, &dims, &reference_strides, 0)
+            .unwrap();
     erased_map_into(
         KernelDType::F64,
         ErasedMapOp::Negate,
@@ -434,17 +376,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &axes,
     )
     .unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &src_dims, &src_strides, 0)
-            .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&src, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -493,22 +427,15 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &sum_squares_strides,
     )
     .unwrap();
-    let sum_squares_source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&sum_squares_src),
+    let sum_squares_source = ErasedRawStridedRef::from_slice(
+        &sum_squares_src,
         &sum_squares_dims,
         &sum_squares_strides,
         0,
     )
     .unwrap();
-    let mut sum_squares_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut sum_squares_dst),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut sum_squares_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut sum_squares_dst, &[], &[], 0).unwrap();
 
     sum_squares_plan
         .execute(
@@ -552,25 +479,11 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &slice_dims,
     )
     .unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &src_dims, &src_strides, 0)
-            .unwrap();
-    let starts_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&starts),
-        &start_dims,
-        &start_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &slice_dims,
-        &slice_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&src, &src_dims, &src_strides, 0).unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::from_slice(&starts, &start_dims, &start_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &slice_dims, &slice_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source, &starts_ref)
         .unwrap();
@@ -603,30 +516,12 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &src_strides,
     )
     .unwrap();
-    let starts_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&starts),
-        &start_dims,
-        &start_strides,
-        0,
-    )
-    .unwrap();
-    let update_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&update),
-        &update_dims,
-        &update_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::from_slice(&starts, &start_dims, &start_strides, 0).unwrap();
+    let update_ref =
+        ErasedRawStridedRef::from_slice(&update, &update_dims, &update_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -681,30 +576,12 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         },
     )
     .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&indices),
-        &index_dims,
-        &index_strides,
-        0,
-    )
-    .unwrap();
-    let update_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&updates),
-        &update_dims,
-        &update_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let index_ref =
+        ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+    let update_ref =
+        ErasedRawStridedRef::from_slice(&updates, &update_dims, &update_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -743,14 +620,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &slice_steps,
     )
     .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -762,14 +633,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     });
     assert_eq!(allocations, 0, "erased slice execute must not allocate");
     let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
-    let mut uninit_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninit_dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut uninit_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninit_dst, &src_dims, &src_strides, 0)
+            .unwrap();
     let source_ptr = ErasedRawStridedPtr::from_ref(&source);
     let allocations = count_allocations(|| {
         for _ in 0..16 {
@@ -792,14 +658,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &axes,
     )
     .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -811,14 +671,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     });
     assert_eq!(allocations, 0, "erased reverse execute must not allocate");
     let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
-    let mut uninit_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninit_dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut uninit_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninit_dst, &src_dims, &src_strides, 0)
+            .unwrap();
     let allocations = count_allocations(|| {
         for _ in 0..16 {
             plan.execute_uninit(&ExecContext::serial(), &mut uninit_dest, &source_ptr)
@@ -845,14 +700,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         &interior,
     )
     .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source, as_bytes(&fill))
         .unwrap();
@@ -864,14 +713,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     });
     assert_eq!(allocations, 0, "erased pad execute must not allocate");
     let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
-    let mut uninit_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninit_dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut uninit_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninit_dst, &src_dims, &src_strides, 0)
+            .unwrap();
     let allocations = count_allocations(|| {
         for _ in 0..16 {
             plan.execute_uninit(
@@ -907,31 +751,12 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         0,
     )
     .unwrap();
-    let left_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&left),
-        &left_dims,
-        &left_strides,
-        0,
-    )
-    .unwrap();
-    let right_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&right),
-        &right_dims,
-        &right_strides,
-        0,
-    )
-    .unwrap();
+    let left_ref = ErasedRawStridedRef::from_slice(&left, &left_dims, &left_strides, 0).unwrap();
+    let right_ref =
+        ErasedRawStridedRef::from_slice(&right, &right_dims, &right_strides, 0).unwrap();
     let inputs = [left_ref, right_ref];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut dst, &src_dims, &src_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -950,14 +775,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
         ErasedRawStridedPtr::from_ref(&inputs[1]),
     ];
     let mut uninit_dst = vec![MaybeUninit::<f64>::uninit(); 256];
-    let mut uninit_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninit_dst),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
+    let mut uninit_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninit_dst, &src_dims, &src_strides, 0)
+            .unwrap();
     let allocations = count_allocations(|| {
         for _ in 0..16 {
             plan.execute_uninit(&ExecContext::serial(), &mut uninit_dest, &input_ptrs)
@@ -974,8 +794,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     let lhs = [1.0f64; 32];
     let rhs = [2.0f64; 32];
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap(),
     ];
     let input_ptrs = inputs
         .each_ref()
@@ -995,14 +815,8 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     let ctx = ExecContext::serial();
 
     let mut initialized = vec![0.0f64; 32];
-    let mut initialized_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut initialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut initialized_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut initialized, &dims, &strides, 0).unwrap();
     plan.execute(&ctx, &mut initialized_dest, &inputs).unwrap();
     let initialized_allocations = count_allocations(|| {
         for _ in 0..8 {
@@ -1011,14 +825,9 @@ fn execute_is_allocation_free_up_to_rank_limit() {
     });
 
     let mut uninitialized = vec![MaybeUninit::<f64>::uninit(); 32];
-    let mut uninitialized_dest = ErasedRawStridedUninitMut::new(
-        KernelDType::F64,
-        as_uninit_bytes_mut(&mut uninitialized),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut uninitialized_dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut uninitialized, &dims, &strides, 0)
+            .unwrap();
     plan.execute_uninit(&ctx, &mut uninitialized_dest, &input_ptrs)
         .unwrap();
     let uninitialized_allocations = count_allocations(|| {

--- a/strided-kernel/tests/erased_copy_plan.rs
+++ b/strided-kernel/tests/erased_copy_plan.rs
@@ -1,28 +1,11 @@
 use core::fmt::Debug;
+use core::ptr::NonNull;
 
 use num_complex::{Complex32, Complex64};
 use strided_kernel::{
     ErasedCopyPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext, KernelDType,
-    StridedError,
+    KernelStorageElement, StridedError,
 };
-
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
 
 #[test]
 fn erased_copy_plan_executes_f64_transposed_layout() {
@@ -35,17 +18,9 @@ fn erased_copy_plan_executes_f64_transposed_layout() {
     let plan =
         ErasedCopyPlan::compile(KernelDType::F64, &dims, &dst_strides, &src_strides).unwrap();
     {
-        let source =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &src_strides, 0)
-                .unwrap();
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut dst),
-            &dims,
-            &dst_strides,
-            0,
-        )
-        .unwrap();
+        let source = ErasedRawStridedRef::from_slice(&src, &dims, &src_strides, 0).unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &dst_strides, 0).unwrap();
 
         plan.execute(&ExecContext::serial(), &mut dest, &source)
             .unwrap();
@@ -62,11 +37,8 @@ fn erased_copy_plan_rejects_dtype_mismatch() {
     let mut dst = [0.0f32; 2];
 
     let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&src, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &source)
@@ -76,7 +48,7 @@ fn erased_copy_plan_rejects_dtype_mismatch() {
 
 fn assert_supported_copy<T>(dtype: KernelDType, input: &[T])
 where
-    T: Copy + Debug + Default + PartialEq,
+    T: Copy + Debug + Default + PartialEq + KernelStorageElement,
 {
     let dims = [input.len()];
     let strides = [1isize];
@@ -84,9 +56,9 @@ where
 
     let plan = ErasedCopyPlan::compile(dtype, &dims, &strides, &strides).unwrap();
     {
-        let source = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let source = ErasedRawStridedRef::from_slice(input, &dims, &strides, 0).unwrap();
         let mut dest =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut output), &dims, &strides, 0).unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, 0).unwrap();
         plan.execute(&ExecContext::serial(), &mut dest, &source)
             .unwrap();
     }
@@ -115,42 +87,19 @@ fn erased_copy_plan_executes_supported_scalar_set() {
 fn erased_raw_descriptors_reject_invalid_byte_layouts() {
     let dims = [1usize];
     let strides = [1isize];
-    let bytes = [0u8; 9];
-
-    let err = ErasedRawStridedRef::new(KernelDType::F64, &bytes, &dims, &strides, 0).unwrap_err();
+    let mut aligned = [0u64; 2];
+    let err = unsafe {
+        ErasedRawStridedRef::from_raw_parts(
+            KernelDType::F64,
+            NonNull::new(aligned.as_mut_ptr().cast()).unwrap(),
+            9,
+            &dims,
+            &strides,
+            0,
+        )
+    }
+    .unwrap_err();
     assert!(matches!(err, StridedError::ByteLengthMismatch { .. }));
-
-    let aligned = [0.0f64; 2];
-    let aligned_bytes = as_bytes(&aligned);
-    let misaligned = &aligned_bytes[1..1 + core::mem::size_of::<f64>()];
-    let err =
-        ErasedRawStridedRef::new(KernelDType::F64, misaligned, &dims, &strides, 0).unwrap_err();
-    assert!(matches!(err, StridedError::DataAlignmentMismatch { .. }));
-
-    let invalid_bool = [2u8];
-    let err =
-        ErasedRawStridedRef::new(KernelDType::Bool, &invalid_bool, &dims, &strides, 0).unwrap_err();
-    assert!(matches!(err, StridedError::InvalidBoolByte { value: 2 }));
-}
-
-#[test]
-fn erased_copy_plan_revalidates_bool_output_bytes_before_replay() {
-    let dims = [1usize];
-    let strides = [1isize];
-    let source_bytes = [1u8];
-    let mut dest_bytes = [0u8];
-
-    let plan = ErasedCopyPlan::compile(KernelDType::Bool, &dims, &strides, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::Bool, &source_bytes, &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::Bool, &mut dest_bytes, &dims, &strides, 0).unwrap();
-
-    dest.data_mut()[0] = 2;
-    let err = plan
-        .execute(&ExecContext::serial(), &mut dest, &source)
-        .unwrap_err();
-    assert!(matches!(err, StridedError::InvalidBoolByte { value: 2 }));
 }
 
 #[test]
@@ -163,42 +112,23 @@ fn erased_copy_plan_accepts_explicit_execution_contexts() {
     let mut ambient_dst = [0.0f64; 2];
 
     let plan = ErasedCopyPlan::compile(KernelDType::F64, &dims, &strides, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&src), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&src, &dims, &strides, 0).unwrap();
 
     {
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut serial_dst),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut serial_dst, &dims, &strides, 0).unwrap();
         plan.execute(&ExecContext::serial(), &mut dest, &source)
             .unwrap();
     }
     {
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut bounded_dst),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut bounded_dst, &dims, &strides, 0).unwrap();
         let ctx = ExecContext::max_threads(1).unwrap();
         plan.execute(&ctx, &mut dest, &source).unwrap();
     }
     {
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut ambient_dst),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut ambient_dst, &dims, &strides, 0).unwrap();
         plan.execute(&ExecContext::ambient(), &mut dest, &source)
             .unwrap();
     }

--- a/strided-kernel/tests/erased_fused_plan.rs
+++ b/strided-kernel/tests/erased_fused_plan.rs
@@ -4,24 +4,6 @@ use strided_kernel::{
     FusedPlan, KernelDType, StridedError,
 };
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 fn binary_plan(op: FusedOp) -> FusedPlan {
     FusedPlan {
         input_count: 2,
@@ -55,17 +37,10 @@ fn erased_fused_plan_executes_f64_binary_add_transposed_layout() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &src_strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &src_strides, 0).unwrap(),
     ];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &dst_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &dst_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -95,13 +70,11 @@ fn erased_fused_plan_executes_f32_ternary_clamp_with_ambient_context() {
     )
     .unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&x), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&min), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&max), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&x, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&min, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&max, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::ambient(), &mut dest, &inputs)
         .unwrap();
@@ -117,12 +90,8 @@ fn erased_fused_plan_executes_c32_unary_conjugate() {
     let mut dst = [Complex32::new(0.0, 0.0); 2];
 
     let plan = ErasedFusedPlan::compile(KernelDType::C32, unary_plan(FusedOp::Conj)).unwrap();
-    let inputs = [
-        ErasedRawStridedRef::new(KernelDType::C32, as_bytes(&input), &dims, &strides, 0).unwrap(),
-    ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::C32, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let inputs = [ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap()];
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -140,12 +109,10 @@ fn erased_fused_plan_executes_c64_binary_multiply() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::C64, binary_plan(FusedOp::Multiply)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&a), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&b), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::max_threads(1).unwrap(), &mut dest, &inputs)
         .unwrap();
@@ -186,14 +153,12 @@ fn erased_fused_plan_executes_f64_four_input_dag() {
     )
     .unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&c), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&d), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&c, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&d, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -250,14 +215,12 @@ fn erased_fused_plan_executes_i32_safe_integer_dag() {
     )
     .unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&x), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&y), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&lo), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&hi), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&x, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&y, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&lo, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&hi, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -276,17 +239,10 @@ fn erased_fused_plan_executes_i64_binary_add_transposed_layout() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::I64, binary_plan(FusedOp::Add)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&a), &dims, &src_strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&b), &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &src_strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &src_strides, 0).unwrap(),
     ];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::I64,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &dst_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &dst_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -302,19 +258,8 @@ fn erased_fused_plan_executes_bool_identity_conj() {
     let mut dst = [false; 3];
 
     let plan = ErasedFusedPlan::compile(KernelDType::Bool, unary_plan(FusedOp::Conj)).unwrap();
-    let inputs =
-        [
-            ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&input), &dims, &strides, 0)
-                .unwrap(),
-        ];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::Bool,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let inputs = [ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap()];
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &inputs)
         .unwrap();
@@ -332,12 +277,10 @@ fn erased_fused_plan_rejects_dtype_mismatch_before_writing() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &inputs)
@@ -355,11 +298,8 @@ fn erased_fused_plan_rejects_input_count_mismatch_before_writing() {
     let mut dst = [9.0f64, 10.0];
 
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
-    let inputs =
-        [ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap()];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let inputs = [ErasedRawStridedRef::from_slice(&a, &dims, &strides, 0).unwrap()];
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &inputs)
@@ -379,12 +319,10 @@ fn erased_fused_plan_rejects_input_dtype_mismatch_before_writing() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&b), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &dims, &strides, 0).unwrap(),
     ];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut dst), &dims, &strides, 0)
-            .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &inputs)
@@ -405,17 +343,10 @@ fn erased_fused_plan_rejects_runtime_shape_mismatch_before_writing() {
 
     let plan = ErasedFusedPlan::compile(KernelDType::F64, binary_plan(FusedOp::Add)).unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&a), &input_dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&b), &input_dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&a, &input_dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&b, &input_dims, &strides, 0).unwrap(),
     ];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dest_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dest_dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &inputs)

--- a/strided-kernel/tests/erased_gather_plan.rs
+++ b/strided-kernel/tests/erased_gather_plan.rs
@@ -4,24 +4,6 @@ use strided_kernel::{
     KernelDType, StridedError,
 };
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 #[test]
 fn erased_gather_plan_executes_f64_column_gather_with_i64_indices() {
     let operand_dims = [3usize, 4];
@@ -55,30 +37,12 @@ fn erased_gather_plan_executes_f64_column_gather_with_i64_indices() {
         spec,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&indices),
-        &index_dims,
-        &index_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let index_ref =
+        ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -122,30 +86,12 @@ fn erased_gather_plan_executes_f32_windows_with_i32_indices_and_clamping() {
         spec,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F32,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&indices),
-        &index_dims,
-        &index_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F32,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let index_ref =
+        ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::max_threads(1).unwrap(),
@@ -160,7 +106,7 @@ fn erased_gather_plan_executes_f32_windows_with_i32_indices_and_clamping() {
 
 fn assert_supported_take<T>(dtype: KernelDType, input: &[T])
 where
-    T: Copy + core::fmt::Debug + Default + PartialEq,
+    T: Copy + core::fmt::Debug + Default + PartialEq + strided_kernel::KernelStorageElement,
 {
     let operand_dims = [input.len()];
     let operand_strides = [1isize];
@@ -191,24 +137,11 @@ where
     )
     .unwrap();
     let operand_ref =
-        ErasedRawStridedRef::new(dtype, as_bytes(input), &operand_dims, &operand_strides, 0)
-            .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&indices),
-        &index_dims,
-        &index_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        dtype,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+        ErasedRawStridedRef::from_slice(input, &operand_dims, &operand_strides, 0).unwrap();
+    let index_ref =
+        ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::ambient(),
@@ -266,30 +199,11 @@ fn erased_gather_plan_rejects_dtype_and_layout_mismatch_before_writing() {
         spec,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&operand),
-        &operand_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&indices),
-        &index_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F32,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &strides, 0).unwrap();
+    let index_ref = ErasedRawStridedRef::from_slice(&indices, &index_dims, &strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &strides, 0).unwrap();
 
     let err = plan
         .execute(
@@ -303,17 +217,10 @@ fn erased_gather_plan_rejects_dtype_and_layout_mismatch_before_writing() {
     assert!(matches!(err, StridedError::DTypeMismatch { .. }));
     assert_eq!(output, [9.0]);
 
-    let bad_index_ref =
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&indices), &[1], &[0], 0).unwrap();
+    let bad_index_ref = ErasedRawStridedRef::from_slice(&indices, &[1], &[0], 0).unwrap();
     let mut output = [9.0f64];
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &strides, 0).unwrap();
     let err = plan
         .execute(
             &ExecContext::serial(),

--- a/strided-kernel/tests/erased_indexed_write_plan.rs
+++ b/strided-kernel/tests/erased_indexed_write_plan.rs
@@ -4,24 +4,6 @@ use strided_kernel::{
     ErasedScatterPlan, ExecContext, KernelDType, ScatterSpec, StridedError,
 };
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 #[test]
 fn erased_dynamic_slice_plan_executes_fixed_window_with_clamped_starts() {
     let operand_dims = [4usize, 3];
@@ -49,30 +31,12 @@ fn erased_dynamic_slice_plan_executes_fixed_window_with_clamped_starts() {
         &slice_sizes,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let starts_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&starts),
-        &starts_dims,
-        &starts_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -113,38 +77,14 @@ fn erased_dynamic_update_slice_plan_overwrites_clamped_window_after_copy() {
         &dest_strides,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let starts_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&starts),
-        &starts_dims,
-        &starts_strides,
-        0,
-    )
-    .unwrap();
-    let update_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&update),
-        &update_dims,
-        &update_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
+    let update_ref =
+        ErasedRawStridedRef::from_slice(&update, &update_dims, &update_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -193,38 +133,14 @@ fn erased_scatter_plan_adds_overlapping_updates_in_col_major_order() {
         spec,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let index_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&indices),
-        &index_dims,
-        &index_strides,
-        0,
-    )
-    .unwrap();
-    let update_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&updates),
-        &update_dims,
-        &update_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let index_ref =
+        ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+    let update_ref =
+        ErasedRawStridedRef::from_slice(&updates, &update_dims, &update_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::max_threads(2).unwrap(),
@@ -300,7 +216,9 @@ fn erased_indexed_write_plans_reject_invalid_contracts() {
     ));
 }
 
-fn strided_storage<T: Copy + Default>(values: &[T]) -> Vec<T> {
+fn strided_storage<T: Copy + Default + strided_kernel::KernelStorageElement>(
+    values: &[T],
+) -> Vec<T> {
     let mut storage = vec![T::default(); values.len().saturating_mul(2).saturating_sub(1)];
     for (slot, &value) in storage.iter_mut().step_by(2).zip(values) {
         *slot = value;
@@ -310,19 +228,13 @@ fn strided_storage<T: Copy + Default>(values: &[T]) -> Vec<T> {
 
 fn assert_dynamic_fast_paths_match_generic<T>(dtype: KernelDType, values: &[T], updates: &[T])
 where
-    T: Copy + core::fmt::Debug + Default + PartialEq,
+    T: Copy + core::fmt::Debug + Default + PartialEq + strided_kernel::KernelStorageElement,
 {
     let starts_dims = [1usize];
     let starts_strides = [1isize];
     let starts = [99i64];
-    let starts_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&starts),
-        &starts_dims,
-        &starts_strides,
-        0,
-    )
-    .unwrap();
+    let starts_ref =
+        ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
 
     let slice_dims = [4usize];
     let contiguous_strides = [1isize];
@@ -356,38 +268,22 @@ where
         &slice_dims,
     )
     .unwrap();
-    let contiguous_operand_ref = ErasedRawStridedRef::new(
-        dtype,
-        as_bytes(&contiguous_operand),
-        &operand_dims,
-        &contiguous_strides,
-        0,
-    )
-    .unwrap();
-    let strided_operand_ref = ErasedRawStridedRef::new(
-        dtype,
-        as_bytes(&strided_operand),
-        &operand_dims,
-        &strided_strides,
-        0,
-    )
-    .unwrap();
-    let mut contiguous_slice_ref = ErasedRawStridedMut::new(
-        dtype,
-        as_bytes_mut(&mut contiguous_slice),
+    let contiguous_operand_ref =
+        ErasedRawStridedRef::from_slice(&contiguous_operand, &operand_dims, &contiguous_strides, 0)
+            .unwrap();
+    let strided_operand_ref =
+        ErasedRawStridedRef::from_slice(&strided_operand, &operand_dims, &strided_strides, 0)
+            .unwrap();
+    let mut contiguous_slice_ref = ErasedRawStridedMut::from_slice_mut(
+        &mut contiguous_slice,
         &slice_dims,
         &contiguous_strides,
         0,
     )
     .unwrap();
-    let mut strided_slice_ref = ErasedRawStridedMut::new(
-        dtype,
-        as_bytes_mut(&mut strided_slice),
-        &slice_dims,
-        &strided_strides,
-        0,
-    )
-    .unwrap();
+    let mut strided_slice_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut strided_slice, &slice_dims, &strided_strides, 0)
+            .unwrap();
     contiguous_slice_plan
         .execute(
             &ExecContext::max_threads(4).unwrap(),
@@ -438,38 +334,22 @@ where
         &strided_strides,
     )
     .unwrap();
-    let contiguous_update_ref = ErasedRawStridedRef::new(
-        dtype,
-        as_bytes(&contiguous_update),
-        &update_dims,
-        &contiguous_strides,
-        0,
-    )
-    .unwrap();
-    let strided_update_ref = ErasedRawStridedRef::new(
-        dtype,
-        as_bytes(&strided_update),
-        &update_dims,
-        &strided_strides,
-        0,
-    )
-    .unwrap();
-    let mut contiguous_dest_ref = ErasedRawStridedMut::new(
-        dtype,
-        as_bytes_mut(&mut contiguous_dest),
+    let contiguous_update_ref =
+        ErasedRawStridedRef::from_slice(&contiguous_update, &update_dims, &contiguous_strides, 0)
+            .unwrap();
+    let strided_update_ref =
+        ErasedRawStridedRef::from_slice(&strided_update, &update_dims, &strided_strides, 0)
+            .unwrap();
+    let mut contiguous_dest_ref = ErasedRawStridedMut::from_slice_mut(
+        &mut contiguous_dest,
         &operand_dims,
         &contiguous_strides,
         0,
     )
     .unwrap();
-    let mut strided_dest_ref = ErasedRawStridedMut::new(
-        dtype,
-        as_bytes_mut(&mut strided_dest),
-        &operand_dims,
-        &strided_strides,
-        0,
-    )
-    .unwrap();
+    let mut strided_dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut strided_dest, &operand_dims, &strided_strides, 0)
+            .unwrap();
     contiguous_update_plan
         .execute(
             &ExecContext::max_threads(4).unwrap(),
@@ -574,13 +454,9 @@ fn erased_dynamic_slice_preserves_empty_and_negative_stride_generic_cases() {
     let operand = [0.0f64, 1.0, 2.0, 3.0];
     let starts = [0i64];
     let mut empty = Vec::<f64>::new();
-    let operand_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &[4], &[1], 0).unwrap();
-    let starts_ref =
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&starts), &[1], &[1], 0).unwrap();
-    let mut empty_ref =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut empty), &[0], &[1], 0)
-            .unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &[4], &[1], 0).unwrap();
+    let starts_ref = ErasedRawStridedRef::from_slice(&starts, &[1], &[1], 0).unwrap();
+    let mut empty_ref = ErasedRawStridedMut::from_slice_mut(&mut empty, &[0], &[1], 0).unwrap();
     empty_plan
         .execute(
             &ExecContext::serial(),
@@ -602,12 +478,10 @@ fn erased_dynamic_slice_preserves_empty_and_negative_stride_generic_cases() {
         &[4],
     )
     .unwrap();
-    let reverse_operand =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &[4], &[-1], 3).unwrap();
+    let reverse_operand = ErasedRawStridedRef::from_slice(&operand, &[4], &[-1], 3).unwrap();
     let mut reversed = [0.0f64; 4];
     let mut reversed_ref =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut reversed), &[4], &[1], 0)
-            .unwrap();
+        ErasedRawStridedMut::from_slice_mut(&mut reversed, &[4], &[1], 0).unwrap();
     reverse_plan
         .execute(
             &ExecContext::serial(),

--- a/strided-kernel/tests/erased_one_shot.rs
+++ b/strided-kernel/tests/erased_one_shot.rs
@@ -6,19 +6,6 @@ use strided_kernel::{
     FusedPlan, KernelDType, StridedError,
 };
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe { core::slice::from_raw_parts(data.as_ptr().cast::<u8>(), core::mem::size_of_val(data)) }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            core::mem::size_of_val(data),
-        )
-    }
-}
-
 fn single_op_plan(input_count: usize, op: FusedOp) -> FusedPlan {
     FusedPlan {
         input_count,
@@ -36,7 +23,7 @@ fn assert_unary_matches_plan<T>(
     one_shot_op: ErasedMapOp,
     plan_op: FusedOp,
 ) where
-    T: Copy + Default + PartialEq + core::fmt::Debug,
+    T: Copy + Default + PartialEq + core::fmt::Debug + strided_kernel::KernelStorageElement,
 {
     let dims = [input.len()];
     let strides = [1isize];
@@ -44,10 +31,9 @@ fn assert_unary_matches_plan<T>(
     let mut planned = vec![T::default(); input.len()];
 
     {
-        let input = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let input = ErasedRawStridedRef::from_slice(input, &dims, &strides, 0).unwrap();
         let mut output =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut one_shot), &dims, &strides, 0)
-                .unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut one_shot, &dims, &strides, 0).unwrap();
         erased_map_into(
             dtype,
             one_shot_op,
@@ -59,10 +45,9 @@ fn assert_unary_matches_plan<T>(
     }
 
     {
-        let input = ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap();
+        let input = ErasedRawStridedRef::from_slice(input, &dims, &strides, 0).unwrap();
         let mut output =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut planned), &dims, &strides, 0)
-                .unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut planned, &dims, &strides, 0).unwrap();
         ErasedFusedPlan::compile(dtype, single_op_plan(1, plan_op))
             .unwrap()
             .execute(&ExecContext::serial(), &mut output, &[input])
@@ -79,7 +64,7 @@ fn assert_binary_matches_plan<T>(
     one_shot_op: ErasedZipOp,
     plan_op: FusedOp,
 ) where
-    T: Copy + Default + PartialEq + core::fmt::Debug,
+    T: Copy + Default + PartialEq + core::fmt::Debug + strided_kernel::KernelStorageElement,
 {
     let dims = [lhs.len()];
     let strides = [1isize];
@@ -87,11 +72,10 @@ fn assert_binary_matches_plan<T>(
     let mut planned = vec![T::default(); lhs.len()];
 
     {
-        let lhs = ErasedRawStridedRef::new(dtype, as_bytes(lhs), &dims, &strides, 0).unwrap();
-        let rhs = ErasedRawStridedRef::new(dtype, as_bytes(rhs), &dims, &strides, 0).unwrap();
+        let lhs = ErasedRawStridedRef::from_slice(lhs, &dims, &strides, 0).unwrap();
+        let rhs = ErasedRawStridedRef::from_slice(rhs, &dims, &strides, 0).unwrap();
         let mut output =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut one_shot), &dims, &strides, 0)
-                .unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut one_shot, &dims, &strides, 0).unwrap();
         erased_zip_into(
             dtype,
             one_shot_op,
@@ -104,11 +88,10 @@ fn assert_binary_matches_plan<T>(
     }
 
     {
-        let lhs = ErasedRawStridedRef::new(dtype, as_bytes(lhs), &dims, &strides, 0).unwrap();
-        let rhs = ErasedRawStridedRef::new(dtype, as_bytes(rhs), &dims, &strides, 0).unwrap();
+        let lhs = ErasedRawStridedRef::from_slice(lhs, &dims, &strides, 0).unwrap();
+        let rhs = ErasedRawStridedRef::from_slice(rhs, &dims, &strides, 0).unwrap();
         let mut output =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut planned), &dims, &strides, 0)
-                .unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut planned, &dims, &strides, 0).unwrap();
         ErasedFusedPlan::compile(dtype, single_op_plan(2, plan_op))
             .unwrap()
             .execute(&ExecContext::serial(), &mut output, &[lhs, rhs])
@@ -173,17 +156,9 @@ fn one_shot_covers_required_unary_and_binary_ops() {
 
     let dims = [3usize];
     let strides = [1isize];
-    let input_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let input_ref = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut signed = [0.0f64; 3];
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut signed),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut output = ErasedRawStridedMut::from_slice_mut(&mut signed, &dims, &strides, 0).unwrap();
     erased_map_into(
         KernelDType::F64,
         ErasedMapOp::Sign,
@@ -198,19 +173,11 @@ fn one_shot_covers_required_unary_and_binary_ops() {
         (ErasedZipOp::Subtract, [3.0, -7.0, 5.0]),
         (ErasedZipOp::Remainder, [1.0, -1.0, 1.0]),
     ] {
-        let lhs_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-        let rhs_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+        let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
         let mut actual = [0.0f64; 3];
-        let mut output = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut actual),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut output =
+            ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
         erased_zip_into(
             KernelDType::F64,
             op,
@@ -232,18 +199,9 @@ fn one_shot_handles_borrowed_noncontiguous_metadata() {
     let lhs = [0.0f64, 1.0, 2.0, 10.0, 11.0, 12.0];
     let rhs = [100.0f64, 101.0, 102.0, 110.0, 111.0, 112.0];
     let mut dst = [0.0f64; 6];
-    let lhs =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &src_strides, 0).unwrap();
-    let rhs =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &src_strides, 0).unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &dst_strides,
-        0,
-    )
-    .unwrap();
+    let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &src_strides, 0).unwrap();
+    let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &src_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &dst_strides, 0).unwrap();
 
     erased_zip_into(
         KernelDType::F64,
@@ -264,22 +222,9 @@ fn one_shot_empty_output_is_a_noop_for_degenerate_strides() {
     let strides = [1isize, 0];
     let input: [f64; 0] = [];
     let mut output: [f64; 0] = [];
-    let input = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &dims,
-        &strides,
-        isize::MAX,
-    )
-    .unwrap();
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dims,
-        &strides,
-        isize::MAX,
-    )
-    .unwrap();
+    let input = ErasedRawStridedRef::from_slice(&input, &dims, &strides, isize::MAX).unwrap();
+    let mut output =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, isize::MAX).unwrap();
 
     erased_map_into(
         KernelDType::F64,
@@ -308,18 +253,9 @@ fn one_shot_rejects_unsupported_ops_before_writing() {
     let lhs = [true, false];
     let rhs = [false, true];
     let mut dst = [true, true];
-    let lhs =
-        ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-    let rhs =
-        ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&rhs), &dims, &strides, 0).unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::Bool,
-        as_bytes_mut(&mut dst),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+    let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut dst, &dims, &strides, 0).unwrap();
 
     let error = erased_zip_into(
         KernelDType::Bool,
@@ -348,18 +284,10 @@ fn one_shot_complex_abs_uses_real_output_dtype() {
             let dims = [2usize];
             let strides = [1isize];
             let input = [<$input_ty>::new(3.0, 4.0), <$input_ty>::new(5.0, 12.0)];
-            let input =
-                ErasedRawStridedRef::new($input_dtype, as_bytes(&input), &dims, &strides, 0)
-                    .unwrap();
+            let input = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
             let mut actual = [0.0 as $output_ty; 2];
-            let mut output = ErasedRawStridedMut::new(
-                $output_dtype,
-                as_bytes_mut(&mut actual),
-                &dims,
-                &strides,
-                0,
-            )
-            .unwrap();
+            let mut output =
+                ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
             erased_map_into(
                 $input_dtype,
                 ErasedMapOp::Abs,
@@ -388,14 +316,11 @@ fn one_shot_integer_division_is_wrapping_and_zero_is_preflighted() {
                 (ErasedZipOp::Divide, [<$ty>::MIN, 2]),
                 (ErasedZipOp::Remainder, [0, 1]),
             ] {
-                let lhs =
-                    ErasedRawStridedRef::new($dtype, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-                let rhs =
-                    ErasedRawStridedRef::new($dtype, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+                let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+                let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
                 let mut actual = [99 as $ty; 2];
                 let mut output =
-                    ErasedRawStridedMut::new($dtype, as_bytes_mut(&mut actual), &dims, &strides, 0)
-                        .unwrap();
+                    ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
                 erased_zip_into(
                     $dtype,
                     op,
@@ -409,12 +334,11 @@ fn one_shot_integer_division_is_wrapping_and_zero_is_preflighted() {
             }
 
             let rhs = [1 as $ty, 0];
-            let lhs = ErasedRawStridedRef::new($dtype, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-            let rhs = ErasedRawStridedRef::new($dtype, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+            let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+            let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
             let mut actual = [99 as $ty; 2];
             let mut output =
-                ErasedRawStridedMut::new($dtype, as_bytes_mut(&mut actual), &dims, &strides, 0)
-                    .unwrap();
+                ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
             let error = erased_zip_into(
                 $dtype,
                 ErasedZipOp::Divide,
@@ -444,19 +368,11 @@ fn one_shot_preserves_tenferro_numeric_edge_semantics() {
     for op in [ErasedZipOp::Maximum, ErasedZipOp::Minimum] {
         let lhs = [0.0f64, -0.0];
         let rhs = [-0.0f64, 0.0];
-        let lhs_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-        let rhs_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let lhs_ref = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+        let rhs_ref = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
         let mut actual = [1.0f64; 2];
-        let mut output = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut actual),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut output =
+            ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
         erased_zip_into(
             KernelDType::F64,
             op,
@@ -471,17 +387,9 @@ fn one_shot_preserves_tenferro_numeric_edge_semantics() {
     }
 
     let input = [Complex64::new(-0.0, 0.0), Complex64::new(3.0, 4.0)];
-    let input =
-        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let input = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut actual = [Complex64::new(1.0, 1.0); 2];
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::C64,
-        as_bytes_mut(&mut actual),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut output = ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
     erased_map_into(
         KernelDType::C64,
         ErasedMapOp::Sign,
@@ -502,7 +410,7 @@ fn one_shot_rejects_overlap_before_forming_input_reference() {
     let mut storage = [1.0f64, 2.0];
     let ptr = NonNull::new(storage.as_mut_ptr().cast::<u8>()).unwrap();
     let input = unsafe {
-        ErasedRawStridedPtr::new(
+        ErasedRawStridedPtr::from_raw_parts(
             KernelDType::F64,
             ptr,
             core::mem::size_of_val(&storage),
@@ -512,14 +420,7 @@ fn one_shot_rejects_overlap_before_forming_input_reference() {
         )
         .unwrap()
     };
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut storage),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut output = ErasedRawStridedMut::from_slice_mut(&mut storage, &dims, &strides, 0).unwrap();
     let error = erased_map_into(
         KernelDType::F64,
         ErasedMapOp::Negate,
@@ -541,18 +442,10 @@ fn one_shot_accepts_small_injective_layout_without_allocating() {
     let input_strides = [1isize, 3];
     let output_strides = [2isize, 3];
     let input = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let input =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &input_strides, 0)
-            .unwrap();
+    let input = ErasedRawStridedRef::from_slice(&input, &dims, &input_strides, 0).unwrap();
     let mut actual = [0.0f64; 8];
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut actual),
-        &dims,
-        &output_strides,
-        0,
-    )
-    .unwrap();
+    let mut output =
+        ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &output_strides, 0).unwrap();
     erased_map_into(
         KernelDType::F64,
         ErasedMapOp::Negate,
@@ -570,18 +463,10 @@ fn one_shot_rejects_noninjective_destination_before_raw_replay() {
     let input_strides = [1isize];
     let output_strides = [0isize];
     let input = [1.0f64, 2.0, 3.0, 4.0];
-    let input =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &input_strides, 0)
-            .unwrap();
+    let input = ErasedRawStridedRef::from_slice(&input, &dims, &input_strides, 0).unwrap();
     let mut actual = [7.0f64];
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut actual),
-        &dims,
-        &output_strides,
-        0,
-    )
-    .unwrap();
+    let mut output =
+        ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &output_strides, 0).unwrap();
 
     let error = erased_map_into(
         KernelDType::F64,
@@ -603,19 +488,10 @@ fn integer_division_preflight_handles_high_rank_iteratively() {
     let strides = vec![0isize; RANK];
     let lhs = [i32::MIN];
     let rhs = [-1i32];
-    let lhs =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-    let rhs =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+    let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+    let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
     let mut actual = [0i32];
-    let mut output = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut actual),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut output = ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &strides, 0).unwrap();
     erased_zip_into(
         KernelDType::I32,
         ErasedZipOp::Divide,

--- a/strided-kernel/tests/erased_policy_parallel.rs
+++ b/strided-kernel/tests/erased_policy_parallel.rs
@@ -18,15 +18,6 @@ fn as_bytes<T>(data: &[T]) -> &[u8] {
     }
 }
 
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 fn bounded_context() -> ExecContext {
     ExecContext::max_threads(2).unwrap()
 }
@@ -41,19 +32,11 @@ fn large_one_shot_zip_matches_serial() {
         .collect();
 
     let run = |ctx: ExecContext| {
-        let lhs =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &strides, 0).unwrap();
-        let rhs =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &strides, 0).unwrap();
+        let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap();
+        let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap();
         let mut output = vec![0.0f64; LARGE_LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut output),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, 0).unwrap();
         erased_zip_into(
             KernelDType::F64,
             ErasedZipOp::Add,
@@ -76,19 +59,11 @@ fn bounded_one_shot_rejects_noninjective_destination_before_raw_replay() {
     let dest_strides = [0isize];
     let lhs = vec![1.0f64; LARGE_LEN];
     let rhs = vec![2.0f64; LARGE_LEN];
-    let lhs = ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&lhs), &dims, &source_strides, 0)
-        .unwrap();
-    let rhs = ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&rhs), &dims, &source_strides, 0)
-        .unwrap();
+    let lhs = ErasedRawStridedRef::from_slice(&lhs, &dims, &source_strides, 0).unwrap();
+    let rhs = ErasedRawStridedRef::from_slice(&rhs, &dims, &source_strides, 0).unwrap();
     let mut actual = [7.0f64];
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut actual),
-        &dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut actual, &dims, &dest_strides, 0).unwrap();
 
     let error = erased_zip_into(
         KernelDType::F64,
@@ -117,18 +92,10 @@ fn large_erased_copy_matches_serial() {
         ErasedCopyPlan::compile(KernelDType::I64, &dims, &dest_strides, &src_strides).unwrap();
 
     let run = |ctx: ExecContext| {
-        let source_ref =
-            ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&source), &dims, &src_strides, 0)
-                .unwrap();
+        let source_ref = ErasedRawStridedRef::from_slice(&source, &dims, &src_strides, 0).unwrap();
         let mut output = vec![0i64; LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::I64,
-            as_bytes_mut(&mut output),
-            &dims,
-            &dest_strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &dest_strides, 0).unwrap();
         plan.execute(&ctx, &mut dest, &source_ref).unwrap();
         output
     };
@@ -157,23 +124,11 @@ fn large_erased_axis_reduce_matches_serial() {
     .unwrap();
 
     let run = |ctx: ExecContext| {
-        let source_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&source),
-            &src_dims,
-            &src_strides,
-            0,
-        )
-        .unwrap();
+        let source_ref =
+            ErasedRawStridedRef::from_slice(&source, &src_dims, &src_strides, 0).unwrap();
         let mut output = vec![0i32; LARGE_LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::I32,
-            as_bytes_mut(&mut output),
-            &dest_dims,
-            &dest_strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
         plan.execute(&ctx, &mut dest, &source_ref).unwrap();
         output
     };
@@ -210,21 +165,11 @@ fn large_erased_gather_matches_serial() {
     .unwrap();
 
     let run = |ctx: ExecContext| {
-        let operand_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0)
-                .unwrap();
-        let index_ref =
-            ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&indices), &dims, &strides, 0)
-                .unwrap();
+        let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
+        let index_ref = ErasedRawStridedRef::from_slice(&indices, &dims, &strides, 0).unwrap();
         let mut output = vec![0.0f64; LARGE_LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut output),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, 0).unwrap();
         plan.execute(&ctx, &mut dest, &operand_ref, &index_ref)
             .unwrap();
         output
@@ -276,70 +221,30 @@ fn large_erased_dynamic_slice_and_update_match_serial() {
     .unwrap();
 
     let run_slice = |ctx: ExecContext| {
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let starts_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&starts),
-            &starts_dims,
-            &starts_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let starts_ref =
+            ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
         let mut output = vec![0i32; LARGE_LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::I32,
-            as_bytes_mut(&mut output),
-            &window_dims,
-            &window_strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &window_dims, &window_strides, 0)
+                .unwrap();
         slice
             .execute(&ctx, &mut dest, &operand_ref, &starts_ref)
             .unwrap();
         output
     };
     let run_update = |ctx: ExecContext| {
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
-        let update_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&update),
-            &window_dims,
-            &window_strides,
-            0,
-        )
-        .unwrap();
-        let starts_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&starts),
-            &starts_dims,
-            &starts_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+        let update_ref =
+            ErasedRawStridedRef::from_slice(&update, &window_dims, &window_strides, 0).unwrap();
+        let starts_ref =
+            ErasedRawStridedRef::from_slice(&starts, &starts_dims, &starts_strides, 0).unwrap();
         let mut output = vec![0i32; LARGE_LEN + 128];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::I32,
-            as_bytes_mut(&mut output),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &operand_dims, &operand_strides, 0)
+                .unwrap();
         update_slice
             .execute(&ctx, &mut dest, &operand_ref, &update_ref, &starts_ref)
             .unwrap();
@@ -380,23 +285,11 @@ fn large_erased_pad_matches_serial() {
     .unwrap();
 
     let run = |ctx: ExecContext| {
-        let operand_ref = ErasedRawStridedRef::new(
-            KernelDType::I32,
-            as_bytes(&operand),
-            &operand_dims,
-            &operand_strides,
-            0,
-        )
-        .unwrap();
+        let operand_ref =
+            ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
         let mut output = vec![0i32; LARGE_LEN + 128];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::I32,
-            as_bytes_mut(&mut output),
-            &dest_dims,
-            &dest_strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
         plan.execute(&ctx, &mut dest, &operand_ref, as_bytes(&fill))
             .unwrap();
         output
@@ -438,29 +331,13 @@ fn large_erased_scatter_matches_serial_with_overlaps() {
     .unwrap();
 
     let run = |ctx: ExecContext| {
-        let operand_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0)
-                .unwrap();
-        let index_ref = ErasedRawStridedRef::new(
-            KernelDType::I64,
-            as_bytes(&indices),
-            &index_dims,
-            &index_strides,
-            0,
-        )
-        .unwrap();
-        let update_ref =
-            ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&updates), &dims, &strides, 0)
-                .unwrap();
+        let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
+        let index_ref =
+            ErasedRawStridedRef::from_slice(&indices, &index_dims, &index_strides, 0).unwrap();
+        let update_ref = ErasedRawStridedRef::from_slice(&updates, &dims, &strides, 0).unwrap();
         let mut output = vec![0.0f64; LARGE_LEN];
-        let mut dest = ErasedRawStridedMut::new(
-            KernelDType::F64,
-            as_bytes_mut(&mut output),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut dest =
+            ErasedRawStridedMut::from_slice_mut(&mut output, &dims, &strides, 0).unwrap();
         plan.execute(&ctx, &mut dest, &operand_ref, &index_ref, &update_ref)
             .unwrap();
         output

--- a/strided-kernel/tests/erased_reduce_plan.rs
+++ b/strided-kernel/tests/erased_reduce_plan.rs
@@ -4,24 +4,6 @@ use strided_kernel::{
     MaybeSimdOps, ReduceOp, StridedError,
 };
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe {
-        core::slice::from_raw_parts(
-            data.as_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
 #[test]
 fn erased_reduce_plan_executes_f64_sum_transposed_layout() {
     let dims = [2usize, 3];
@@ -31,11 +13,8 @@ fn erased_reduce_plan_executes_f64_sum_transposed_layout() {
 
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &src_strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &src_strides, 0)
-            .unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &src_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -56,10 +35,8 @@ fn erased_reduce_plan_executes_c64_product() {
 
     let plan =
         ErasedReducePlan::compile(KernelDType::C64, ReduceOp::Product, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::max_threads(1).unwrap(), &mut dest, &source)
         .unwrap();
@@ -75,10 +52,8 @@ fn erased_reduce_plan_executes_i32_sum_with_ambient_context() {
     let mut output = [0i32];
 
     let plan = ErasedReducePlan::compile(KernelDType::I32, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::ambient(), &mut dest, &source)
         .unwrap();
@@ -95,12 +70,8 @@ fn erased_reduce_plan_integer_full_reductions_use_wrapping_arithmetic() {
     let mut sum_output = [0i32];
     let sum_plan =
         ErasedReducePlan::compile(KernelDType::I32, ReduceOp::Sum, &dims, &strides).unwrap();
-    let sum_source =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&input_i32), &dims, &strides, 0)
-            .unwrap();
-    let mut sum_dest =
-        ErasedRawStridedMut::new(KernelDType::I32, as_bytes_mut(&mut sum_output), &[], &[], 0)
-            .unwrap();
+    let sum_source = ErasedRawStridedRef::from_slice(&input_i32, &dims, &strides, 0).unwrap();
+    let mut sum_dest = ErasedRawStridedMut::from_slice_mut(&mut sum_output, &[], &[], 0).unwrap();
 
     sum_plan
         .execute(&ExecContext::serial(), &mut sum_dest, &sum_source)
@@ -112,17 +83,9 @@ fn erased_reduce_plan_integer_full_reductions_use_wrapping_arithmetic() {
     let mut product_output = [0i64];
     let product_plan =
         ErasedReducePlan::compile(KernelDType::I64, ReduceOp::Product, &dims, &strides).unwrap();
-    let product_source =
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&input_i64), &dims, &strides, 0)
-            .unwrap();
-    let mut product_dest = ErasedRawStridedMut::new(
-        KernelDType::I64,
-        as_bytes_mut(&mut product_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let product_source = ErasedRawStridedRef::from_slice(&input_i64, &dims, &strides, 0).unwrap();
+    let mut product_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut product_output, &[], &[], 0).unwrap();
 
     product_plan
         .execute(&ExecContext::serial(), &mut product_dest, &product_source)
@@ -137,30 +100,17 @@ fn erased_reduce_plan_serial_full_sum_uses_fixed_multi_accumulator_order() {
     let strides = [1isize];
     let input = [1.0e16f64, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0e16];
     let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
 
     let mut serial_output = [0.0f64];
-    let mut serial_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut serial_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut serial_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut serial_output, &[], &[], 0).unwrap();
     plan.execute(&ExecContext::serial(), &mut serial_dest, &source)
         .unwrap();
 
     let mut one_thread_output = [0.0f64];
-    let mut one_thread_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut one_thread_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut one_thread_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut one_thread_output, &[], &[], 0).unwrap();
     plan.execute(
         &ExecContext::max_threads(1).unwrap(),
         &mut one_thread_dest,
@@ -187,16 +137,13 @@ fn erased_reduce_plan_fixed_bounded_context_is_bitwise_repeatable() {
         })
         .collect::<Vec<f64>>();
     let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let ctx = ExecContext::max_threads(4).unwrap();
     let mut expected = None;
 
     for _ in 0..8 {
         let mut output = [0.0f64];
-        let mut dest =
-            ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0)
-                .unwrap();
+        let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
         plan.execute(&ctx, &mut dest, &source).unwrap();
         let bits = output[0].to_bits();
         assert_eq!(*expected.get_or_insert(bits), bits);
@@ -218,16 +165,13 @@ fn erased_sum_squares_fixed_bounded_context_is_bitwise_repeatable() {
         .collect::<Vec<f64>>();
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let ctx = ExecContext::max_threads(4).unwrap();
     let mut expected = None;
 
     for _ in 0..8 {
         let mut output = [0.0f64];
-        let mut dest =
-            ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0)
-                .unwrap();
+        let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
         plan.execute(&ctx, &mut dest, &source).unwrap();
         let bits = output[0].to_bits();
         assert_eq!(*expected.get_or_insert(bits), bits);
@@ -246,11 +190,9 @@ fn erased_reduce_plan_preserves_noncompact_and_nonfinite_semantics() {
         Complex64::new(4.0, 1.5),
     ];
     let plan = ErasedReducePlan::compile(KernelDType::C64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::C64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut output = [Complex64::new(0.0, 0.0)];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::C64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -267,23 +209,12 @@ fn erased_reduce_plan_preserves_noncompact_and_nonfinite_semantics() {
         &nonfinite_strides,
     )
     .unwrap();
-    let nonfinite_source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&nonfinite_input),
-        &nonfinite_dims,
-        &nonfinite_strides,
-        0,
-    )
-    .unwrap();
+    let nonfinite_source =
+        ErasedRawStridedRef::from_slice(&nonfinite_input, &nonfinite_dims, &nonfinite_strides, 0)
+            .unwrap();
     let mut nonfinite_output = [0.0f64];
-    let mut nonfinite_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut nonfinite_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut nonfinite_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut nonfinite_output, &[], &[], 0).unwrap();
 
     nonfinite_plan
         .execute(
@@ -305,11 +236,9 @@ fn erased_reduce_plan_contiguous_product_covers_vector_body_and_tail() {
         .collect::<Vec<_>>();
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut output = [0.0f64];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -323,11 +252,9 @@ fn erased_reduce_plan_contiguous_fast_path_honors_offset_and_empty_layout() {
     let dims = [3usize];
     let strides = [1isize];
     let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&storage), &dims, &strides, 2).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&storage, &dims, &strides, 2).unwrap();
     let mut output = [0.0f64];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -338,23 +265,11 @@ fn erased_reduce_plan_contiguous_fast_path_honors_offset_and_empty_layout() {
     let empty_plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &empty_dims, &strides)
             .unwrap();
-    let empty_source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes::<f64>(&[]),
-        &empty_dims,
-        &strides,
-        isize::MAX,
-    )
-    .unwrap();
+    let empty_source =
+        ErasedRawStridedRef::from_slice::<f64>(&[], &empty_dims, &strides, isize::MAX).unwrap();
     let mut empty_output = [0.0f64];
-    let mut empty_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut empty_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut empty_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut empty_output, &[], &[], 0).unwrap();
 
     empty_plan
         .execute(&ExecContext::serial(), &mut empty_dest, &empty_source)
@@ -376,11 +291,9 @@ fn erased_reduce_plan_product_documents_reassociated_overflow_classification() {
     let left_fold = input.iter().copied().fold(1.0, |acc, value| acc * value);
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Product, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut output = [0.0f64];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -399,17 +312,8 @@ fn erased_reduce_plan_executes_remaining_supported_dtype_set() {
     let plan = ErasedReducePlan::compile(KernelDType::F32, ReduceOp::Sum, &dims, &strides).unwrap();
     assert_eq!(plan.dtype(), KernelDType::F32);
     assert_eq!(plan.op(), ReduceOp::Sum);
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&input_f32), &dims, &strides, 0)
-            .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F32,
-        as_bytes_mut(&mut output_f32),
-        &[1],
-        &[1],
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input_f32, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output_f32, &[1], &[1], 0).unwrap();
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
     assert_eq!(output_f32, [4.0]);
@@ -418,12 +322,8 @@ fn erased_reduce_plan_executes_remaining_supported_dtype_set() {
     let mut output_i64 = [0i64];
     let plan =
         ErasedReducePlan::compile(KernelDType::I64, ReduceOp::Product, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::I64, as_bytes(&input_i64), &dims, &strides, 0)
-            .unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::I64, as_bytes_mut(&mut output_i64), &[], &[], 0)
-            .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input_i64, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output_i64, &[], &[], 0).unwrap();
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
     assert_eq!(output_i64, [-6]);
@@ -432,12 +332,8 @@ fn erased_reduce_plan_executes_remaining_supported_dtype_set() {
     let mut output_c32 = [Complex32::new(0.0, 0.0)];
     let plan =
         ErasedReducePlan::compile(KernelDType::C32, ReduceOp::Product, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::C32, as_bytes(&input_c32), &dims, &strides, 0)
-            .unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::C32, as_bytes_mut(&mut output_c32), &[], &[], 0)
-            .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input_c32, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output_c32, &[], &[], 0).unwrap();
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
     assert_eq!(output_c32, [input_c32[0] * input_c32[1]]);
@@ -451,19 +347,10 @@ fn erased_reduce_plan_empty_input_returns_operation_identity() {
     let mut sum_output = [9.0f64];
     let mut product_output = [9.0f64];
 
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let mut sum_dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut sum_output), &[], &[], 0)
-            .unwrap();
-    let mut product_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut product_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let mut sum_dest = ErasedRawStridedMut::from_slice_mut(&mut sum_output, &[], &[], 0).unwrap();
+    let mut product_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut product_output, &[], &[], 0).unwrap();
 
     ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides)
         .unwrap()
@@ -497,22 +384,9 @@ fn erased_reduce_plan_executes_single_axis_sum_into_strided_output() {
         &[0],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -539,22 +413,9 @@ fn erased_reduce_plan_integer_axis_reductions_use_wrapping_arithmetic() {
         &[0],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -587,22 +448,9 @@ fn erased_reduce_plan_executes_multi_axis_sum_with_kept_middle_axis() {
         &[0, 2],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::max_threads(2).unwrap(), &mut dest, &source)
         .unwrap();
@@ -629,22 +477,9 @@ fn erased_reduce_plan_executes_all_axes_sum_into_rank0_scalar() {
         &[0, 1],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -671,22 +506,9 @@ fn erased_reduce_plan_axis_reduction_writes_identity_for_empty_reduced_domain() 
         &[1],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -752,10 +574,8 @@ fn erased_reduce_plan_rejects_dtype_mismatch_before_writing() {
     let mut output = [9.0f32];
 
     let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F32, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &source)
@@ -780,16 +600,9 @@ fn erased_reduce_plan_rejects_layout_mismatch_before_writing() {
         &compiled_strides,
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &compiled_dims,
-        &runtime_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let source =
+        ErasedRawStridedRef::from_slice(&input, &compiled_dims, &runtime_strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &source)
@@ -807,11 +620,8 @@ fn erased_reduce_plan_rejects_non_scalar_output_and_unsupported_dtype() {
     let mut output = [9.0f64, 10.0];
 
     let plan = ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[2], &[1], 0)
-            .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[2], &[1], 0).unwrap();
 
     let err = plan
         .execute(&ExecContext::serial(), &mut dest, &source)
@@ -845,28 +655,15 @@ fn erased_reduce_plan_sum_squares_matches_materialized_full_reduction() {
     let mut max_one_output = [0.0f64];
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 4).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 4).unwrap();
 
-    let mut serial_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut serial_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut serial_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut serial_output, &[], &[], 0).unwrap();
     plan.execute(&ExecContext::serial(), &mut serial_dest, &source)
         .unwrap();
 
-    let mut max_one_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut max_one_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut max_one_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut max_one_output, &[], &[], 0).unwrap();
     plan.execute(
         &ExecContext::max_threads(1).unwrap(),
         &mut max_one_dest,
@@ -896,32 +693,18 @@ fn erased_reduce_plan_sum_squares_is_bitwise_materialized_sum() {
         .copied()
         .map(|value| value * value)
         .collect::<Vec<_>>();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
-    let squared_source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&squared), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
+    let squared_source = ErasedRawStridedRef::from_slice(&squared, &dims, &strides, 0).unwrap();
     let sum_squares_plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
     let sum_plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::Sum, &dims, &strides).unwrap();
     let mut fused_output = [0.0f64];
     let mut materialized_output = [0.0f64];
-    let mut fused_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut fused_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
-    let mut materialized_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut materialized_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut fused_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut fused_output, &[], &[], 0).unwrap();
+    let mut materialized_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut materialized_output, &[], &[], 0).unwrap();
 
     sum_squares_plan
         .execute(&ExecContext::serial(), &mut fused_dest, &source)
@@ -957,22 +740,9 @@ fn erased_reduce_plan_sum_squares_matches_materialized_axis_reduction() {
         &[0, 2],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F32,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F32,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 0).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::max_threads(2).unwrap(), &mut dest, &source)
         .unwrap();
@@ -1003,22 +773,9 @@ fn erased_reduce_plan_sum_squares_axis_handles_negative_stride_offset_and_zero_e
         &[0],
     )
     .unwrap();
-    let source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&input),
-        &src_dims,
-        &src_strides,
-        1,
-    )
-    .unwrap();
-    let mut dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut output),
-        &dest_dims,
-        &dest_strides,
-        1,
-    )
-    .unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &src_dims, &src_strides, 1).unwrap();
+    let mut dest =
+        ErasedRawStridedMut::from_slice_mut(&mut output, &dest_dims, &dest_strides, 1).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();
@@ -1038,18 +795,16 @@ fn erased_reduce_plan_sum_squares_axis_handles_negative_stride_offset_and_zero_e
         &[1],
     )
     .unwrap();
-    let empty_source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes::<f64>(&[]),
+    let empty_source = ErasedRawStridedRef::from_slice::<f64>(
+        &[],
         &empty_src_dims,
         &empty_src_strides,
         isize::MAX,
     )
     .unwrap();
     let mut empty_output = [9.0f64, 10.0];
-    let mut empty_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut empty_output),
+    let mut empty_dest = ErasedRawStridedMut::from_slice_mut(
+        &mut empty_output,
         &empty_dest_dims,
         &empty_dest_strides,
         0,
@@ -1073,23 +828,11 @@ fn erased_reduce_plan_sum_squares_handles_empty_rank_zero_and_nonfinite_values()
         &strides,
     )
     .unwrap();
-    let empty_source = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes::<f64>(&[]),
-        &empty_dims,
-        &strides,
-        isize::MAX,
-    )
-    .unwrap();
+    let empty_source =
+        ErasedRawStridedRef::from_slice::<f64>(&[], &empty_dims, &strides, isize::MAX).unwrap();
     let mut empty_output = [9.0f64];
-    let mut empty_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut empty_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut empty_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut empty_output, &[], &[], 0).unwrap();
     empty_plan
         .execute(&ExecContext::serial(), &mut empty_dest, &empty_source)
         .unwrap();
@@ -1098,17 +841,10 @@ fn erased_reduce_plan_sum_squares_handles_empty_rank_zero_and_nonfinite_values()
     let scalar = [-0.0f64];
     let scalar_plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &[], &[]).unwrap();
-    let scalar_source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&scalar), &[], &[], 0).unwrap();
+    let scalar_source = ErasedRawStridedRef::from_slice(&scalar, &[], &[], 0).unwrap();
     let mut scalar_output = [1.0f64];
-    let mut scalar_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut scalar_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut scalar_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut scalar_output, &[], &[], 0).unwrap();
     scalar_plan
         .execute(&ExecContext::serial(), &mut scalar_dest, &scalar_source)
         .unwrap();
@@ -1117,17 +853,10 @@ fn erased_reduce_plan_sum_squares_handles_empty_rank_zero_and_nonfinite_values()
     let nonfinite = [f64::INFINITY, f64::NAN];
     let nonfinite_plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &[2], &[1]).unwrap();
-    let nonfinite_source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&nonfinite), &[2], &[1], 0).unwrap();
+    let nonfinite_source = ErasedRawStridedRef::from_slice(&nonfinite, &[2], &[1], 0).unwrap();
     let mut nonfinite_output = [0.0f64];
-    let mut nonfinite_dest = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut nonfinite_output),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let mut nonfinite_dest =
+        ErasedRawStridedMut::from_slice_mut(&mut nonfinite_output, &[], &[], 0).unwrap();
     nonfinite_plan
         .execute(
             &ExecContext::serial(),
@@ -1145,11 +874,9 @@ fn erased_reduce_plan_sum_squares_rounds_multiplication_before_accumulation() {
     let input = [f64::MAX, f64::MIN_POSITIVE / 2.0];
     let plan =
         ErasedReducePlan::compile(KernelDType::F64, ReduceOp::SumSquares, &dims, &strides).unwrap();
-    let source =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let source = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let mut output = [0.0f64];
-    let mut dest =
-        ErasedRawStridedMut::new(KernelDType::F64, as_bytes_mut(&mut output), &[], &[], 0).unwrap();
+    let mut dest = ErasedRawStridedMut::from_slice_mut(&mut output, &[], &[], 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest, &source)
         .unwrap();

--- a/strided-kernel/tests/erased_static_indexing_plan.rs
+++ b/strided-kernel/tests/erased_static_indexing_plan.rs
@@ -15,24 +15,6 @@ fn as_bytes<T>(data: &[T]) -> &[u8] {
     }
 }
 
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<u8>(),
-            data.len() * core::mem::size_of::<T>(),
-        )
-    }
-}
-
-fn as_uninit_bytes_mut<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
-    unsafe {
-        core::slice::from_raw_parts_mut(
-            data.as_mut_ptr().cast::<MaybeUninit<u8>>(),
-            core::mem::size_of_val(data),
-        )
-    }
-}
-
 fn assume_init_vec<T>(data: Vec<MaybeUninit<T>>) -> Vec<T> {
     let mut data = core::mem::ManuallyDrop::new(data);
     unsafe { Vec::from_raw_parts(data.as_mut_ptr().cast::<T>(), data.len(), data.capacity()) }
@@ -40,7 +22,7 @@ fn assume_init_vec<T>(data: Vec<MaybeUninit<T>>) -> Vec<T> {
 
 fn assert_uninit_slice<T>(dtype: KernelDType, operand: Vec<T>, expected: Vec<T>)
 where
-    T: Copy + core::fmt::Debug + PartialEq,
+    T: Copy + core::fmt::Debug + PartialEq + strided_kernel::KernelStorageElement,
 {
     let dims = [operand.len()];
     let strides = [1isize];
@@ -58,16 +40,14 @@ where
         &slice_strides,
     )
     .unwrap();
-    let operand_ref =
-        ErasedRawStridedRef::new(dtype, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let mut dest = Vec::<MaybeUninit<T>>::with_capacity(operand.len());
     unsafe {
         dest.set_len(operand.len());
     }
     let mut dest_ref =
-        ErasedRawStridedUninitMut::new(dtype, as_uninit_bytes_mut(&mut dest), &dims, &strides, 0)
-            .unwrap();
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut dest, &dims, &strides, 0).unwrap();
 
     plan.execute_uninit(
         &ExecContext::max_threads(2).unwrap(),
@@ -81,7 +61,7 @@ where
 
 fn assert_empty_uninit_slice<T>(dtype: KernelDType)
 where
-    T: Copy,
+    T: Copy + strided_kernel::KernelStorageElement,
 {
     let dims = [0usize];
     let strides = [1isize];
@@ -100,12 +80,11 @@ where
     )
     .unwrap();
     let operand: [T; 0] = [];
-    let operand_ref =
-        ErasedRawStridedRef::new(dtype, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
-    let mut empty_bytes: [MaybeUninit<u8>; 0] = [];
+    let mut empty_bytes: [MaybeUninit<T>; 0] = [];
     let mut dest_ref =
-        ErasedRawStridedUninitMut::new(dtype, &mut empty_bytes, &dims, &strides, 0).unwrap();
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut empty_bytes, &dims, &strides, 0).unwrap();
 
     plan.execute_uninit(&ExecContext::serial(), &mut dest_ref, &operand_ptr)
         .unwrap();
@@ -149,18 +128,11 @@ fn erased_reverse_uninit_handles_rank_above_inline_limit() {
     let operand: Vec<i32> = (0..512).collect();
     let plan =
         ErasedReversePlan::compile(KernelDType::I32, &dims, &strides, &strides, &axes).unwrap();
-    let operand_ref =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&operand), &dims, &strides, 0).unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let mut dest = vec![MaybeUninit::<i32>::uninit(); operand.len()];
-    let mut dest_ref = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes_mut(&mut dest),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest_ref =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut dest, &dims, &strides, 0).unwrap();
 
     plan.execute_uninit(&ExecContext::serial(), &mut dest_ref, &operand_ptr)
         .unwrap();
@@ -192,24 +164,13 @@ fn erased_pad_and_concatenate_uninit_cover_noncontiguous_and_multi_input_outputs
         &interior,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
     let operand_ptr = ErasedRawStridedPtr::from_ref(&operand_ref);
     let mut padded = vec![MaybeUninit::<i32>::uninit(); 7];
-    let mut padded_ref = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes_mut(&mut padded),
-        &padded_dims,
-        &padded_strides,
-        0,
-    )
-    .unwrap();
+    let mut padded_ref =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut padded, &padded_dims, &padded_strides, 0)
+            .unwrap();
     pad.execute_uninit(
         &ExecContext::serial(),
         &mut padded_ref,
@@ -237,35 +198,18 @@ fn erased_pad_and_concatenate_uninit_cover_noncontiguous_and_multi_input_outputs
         0,
     )
     .unwrap();
-    let lhs_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&lhs),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let rhs_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&rhs),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
+    let lhs_ref =
+        ErasedRawStridedRef::from_slice(&lhs, &operand_dims, &operand_strides, 0).unwrap();
+    let rhs_ref =
+        ErasedRawStridedRef::from_slice(&rhs, &operand_dims, &operand_strides, 0).unwrap();
     let inputs = [
         ErasedRawStridedPtr::from_ref(&lhs_ref),
         ErasedRawStridedPtr::from_ref(&rhs_ref),
     ];
     let mut joined = vec![MaybeUninit::<i32>::uninit(); 4];
-    let mut joined_ref = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes_mut(&mut joined),
-        &concat_dims,
-        &concat_strides,
-        0,
-    )
-    .unwrap();
+    let mut joined_ref =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut joined, &concat_dims, &concat_strides, 0)
+            .unwrap();
     concat
         .execute_uninit(&ExecContext::serial(), &mut joined_ref, &inputs)
         .unwrap();
@@ -292,7 +236,7 @@ fn erased_uninit_static_replay_rejects_input_output_overlap_before_writing() {
     .unwrap();
     let mut storage = vec![MaybeUninit::new(7i32), MaybeUninit::new(9i32)];
     let input_ptr = unsafe {
-        ErasedRawStridedPtr::new(
+        ErasedRawStridedPtr::from_raw_parts(
             KernelDType::I32,
             core::ptr::NonNull::new(storage.as_mut_ptr().cast::<u8>()).unwrap(),
             core::mem::size_of_val(storage.as_slice()),
@@ -302,14 +246,8 @@ fn erased_uninit_static_replay_rejects_input_output_overlap_before_writing() {
         )
         .unwrap()
     };
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes_mut(&mut storage),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut storage, &dims, &strides, 0).unwrap();
 
     let error = plan
         .execute_uninit(&ExecContext::serial(), &mut dest, &input_ptr)
@@ -348,35 +286,18 @@ fn erased_concatenate_validates_all_segment_offsets_before_writing() {
     .unwrap();
     let first = [11i32];
     let empty: [i32; 0] = [];
-    let first_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&first),
-        &first_dims,
-        &input_strides,
-        0,
-    )
-    .unwrap();
-    let empty_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&empty),
-        &empty_dims,
-        &input_strides,
-        0,
-    )
-    .unwrap();
+    let first_ref =
+        ErasedRawStridedRef::from_slice(&first, &first_dims, &input_strides, 0).unwrap();
+    let empty_ref =
+        ErasedRawStridedRef::from_slice(&empty, &empty_dims, &input_strides, 0).unwrap();
     let inputs = [
         ErasedRawStridedPtr::from_ref(&first_ref),
         ErasedRawStridedPtr::from_ref(&empty_ref),
     ];
     let mut dest = [MaybeUninit::new(3i32), MaybeUninit::new(7i32)];
-    let mut dest_ref = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        1,
-    )
-    .unwrap();
+    let mut dest_ref =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut dest, &dest_dims, &dest_strides, 1)
+            .unwrap();
 
     let error = plan
         .execute_uninit(&ExecContext::serial(), &mut dest_ref, &inputs)
@@ -416,22 +337,10 @@ fn erased_slice_plan_executes_strided_static_slice() {
         &slice_strides,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::F64,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F64,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest_ref, &operand_ref)
         .unwrap();
@@ -449,16 +358,8 @@ fn erased_reverse_plan_executes_multi_axis_reverse() {
 
     let plan =
         ErasedReversePlan::compile(KernelDType::I32, &dims, &strides, &strides, &axes).unwrap();
-    let operand_ref =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&operand), &dims, &strides, 0).unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut dest),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
+    let mut dest_ref = ErasedRawStridedMut::from_slice_mut(&mut dest, &dims, &strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::max_threads(1).unwrap(),
@@ -494,22 +395,10 @@ fn erased_pad_plan_fills_output_and_copies_cropped_interior_padded_input() {
         &interior,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::serial(),
@@ -524,7 +413,7 @@ fn erased_pad_plan_fills_output_and_copies_cropped_interior_padded_input() {
 
 fn assert_dense_edge_pad<T>(dtype: KernelDType, operand: &[T], fill: T, expected: &[T])
 where
-    T: Copy + core::fmt::Debug + PartialEq,
+    T: Copy + core::fmt::Debug + PartialEq + strided_kernel::KernelStorageElement,
 {
     let operand_dims = [operand.len()];
     let operand_strides = [1isize];
@@ -548,11 +437,9 @@ where
     )
     .unwrap();
     let operand_ref =
-        ErasedRawStridedRef::new(dtype, as_bytes(operand), &operand_dims, &operand_strides, 0)
-            .unwrap();
+        ErasedRawStridedRef::from_slice(operand, &operand_dims, &operand_strides, 0).unwrap();
     let mut dest_ref =
-        ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut dest), &dest_dims, &dest_strides, 0)
-            .unwrap();
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(
         &ExecContext::max_threads(4).unwrap(),
@@ -635,22 +522,10 @@ fn erased_pad_handles_empty_rank_zero_and_noncontiguous_fallbacks() {
         &interior,
     )
     .unwrap();
-    let empty_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&empty),
-        &empty_dims,
-        &empty_strides,
-        0,
-    )
-    .unwrap();
-    let mut padded_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut padded),
-        &padded_dims,
-        &padded_strides,
-        0,
-    )
-    .unwrap();
+    let empty_ref =
+        ErasedRawStridedRef::from_slice(&empty, &empty_dims, &empty_strides, 0).unwrap();
+    let mut padded_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut padded, &padded_dims, &padded_strides, 0).unwrap();
     plan.execute(
         &ExecContext::serial(),
         &mut padded_ref,
@@ -664,16 +539,9 @@ fn erased_pad_handles_empty_rank_zero_and_noncontiguous_fallbacks() {
     let mut scalar_dest = [0i32];
     let scalar_plan =
         ErasedPadPlan::compile(KernelDType::I32, &[], &[], &[], &[], &[], &[], &[]).unwrap();
-    let scalar_ref =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&scalar), &[], &[], 0).unwrap();
-    let mut scalar_dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut scalar_dest),
-        &[],
-        &[],
-        0,
-    )
-    .unwrap();
+    let scalar_ref = ErasedRawStridedRef::from_slice(&scalar, &[], &[], 0).unwrap();
+    let mut scalar_dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut scalar_dest, &[], &[], 0).unwrap();
     scalar_plan
         .execute(
             &ExecContext::serial(),
@@ -701,22 +569,10 @@ fn erased_pad_handles_empty_rank_zero_and_noncontiguous_fallbacks() {
         &interior,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&operand),
-        &dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut strided_dest),
-        &dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &dims, &operand_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut strided_dest, &dims, &dest_strides, 0).unwrap();
     fallback
         .execute(
             &ExecContext::serial(),
@@ -749,16 +605,9 @@ fn erased_pad_contiguous_runs_honor_offsets_and_outer_axis_cropping() {
         &interior,
     )
     .unwrap();
-    let operand_ref =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&operand), &dims, &strides, 1).unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut dest),
-        &padded_dims,
-        &strides,
-        1,
-    )
-    .unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 1).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &padded_dims, &strides, 1).unwrap();
     plan.execute(
         &ExecContext::serial(),
         &mut dest_ref,
@@ -788,22 +637,10 @@ fn erased_pad_contiguous_runs_honor_offsets_and_outer_axis_cropping() {
         &interior,
     )
     .unwrap();
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&operand),
-        &operand_dims,
-        &operand_strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I32,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref =
+        ErasedRawStridedRef::from_slice(&operand, &operand_dims, &operand_strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
     plan.execute(
         &ExecContext::serial(),
         &mut dest_ref,
@@ -839,39 +676,15 @@ fn erased_concatenate_plan_executes_three_input_axis_concatenate() {
         axis,
     )
     .unwrap();
-    let input0_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&input0),
-        &input0_dims,
-        &input_strides,
-        0,
-    )
-    .unwrap();
-    let input1_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&input1),
-        &input1_dims,
-        &input_strides,
-        0,
-    )
-    .unwrap();
-    let input2_ref = ErasedRawStridedRef::new(
-        KernelDType::I64,
-        as_bytes(&input2),
-        &input2_dims,
-        &input_strides,
-        0,
-    )
-    .unwrap();
+    let input0_ref =
+        ErasedRawStridedRef::from_slice(&input0, &input0_dims, &input_strides, 0).unwrap();
+    let input1_ref =
+        ErasedRawStridedRef::from_slice(&input1, &input1_dims, &input_strides, 0).unwrap();
+    let input2_ref =
+        ErasedRawStridedRef::from_slice(&input2, &input2_dims, &input_strides, 0).unwrap();
     let inputs = [input0_ref, input1_ref, input2_ref];
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::I64,
-        as_bytes_mut(&mut dest),
-        &dest_dims,
-        &dest_strides,
-        0,
-    )
-    .unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut dest, &dest_dims, &dest_strides, 0).unwrap();
 
     plan.execute(&ExecContext::serial(), &mut dest_ref, &inputs)
         .unwrap();
@@ -957,16 +770,9 @@ fn erased_static_indexing_plans_reject_mismatches_before_writing() {
         &slice_strides,
     )
     .unwrap();
-    let operand_ref =
-        ErasedRawStridedRef::new(KernelDType::F64, as_bytes(&operand), &dims, &strides, 0).unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::F32,
-        as_bytes_mut(&mut f32_dest),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&operand, &dims, &strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut f32_dest, &dims, &strides, 0).unwrap();
 
     let err = slice
         .execute(&ExecContext::serial(), &mut dest_ref, &operand_ref)
@@ -989,22 +795,9 @@ fn erased_static_indexing_plans_reject_mismatches_before_writing() {
     .unwrap();
     let bool_operand = [true, false];
     let mut bool_dest = [false, false];
-    let operand_ref = ErasedRawStridedRef::new(
-        KernelDType::Bool,
-        as_bytes(&bool_operand),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
-    let mut dest_ref = ErasedRawStridedMut::new(
-        KernelDType::Bool,
-        as_bytes_mut(&mut bool_dest),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let operand_ref = ErasedRawStridedRef::from_slice(&bool_operand, &dims, &strides, 0).unwrap();
+    let mut dest_ref =
+        ErasedRawStridedMut::from_slice_mut(&mut bool_dest, &dims, &strides, 0).unwrap();
 
     let err = pad
         .execute(&ExecContext::serial(), &mut dest_ref, &operand_ref, &[2u8])

--- a/strided-kernel/tests/issue_184_uninit_elementwise.rs
+++ b/strided-kernel/tests/issue_184_uninit_elementwise.rs
@@ -26,6 +26,7 @@ fn assume_init<T>(data: Vec<MaybeUninit<T>>) -> Vec<T> {
 fn assert_mul_dtype<T>(lhs: &[T], rhs: &[T], expected: &[T])
 where
     T: Copy
+        + strided_kernel::KernelStorageElement
         + core::fmt::Debug
         + PartialEq
         + core::ops::Mul<Output = T>
@@ -40,25 +41,10 @@ where
     assert_eq!(assume_init(output), expected);
 }
 
-fn as_bytes<T>(data: &[T]) -> &[u8] {
-    unsafe { core::slice::from_raw_parts(data.as_ptr().cast(), core::mem::size_of_val(data)) }
-}
-
-fn as_uninit_bytes<T>(data: &mut [MaybeUninit<T>]) -> &mut [MaybeUninit<u8>] {
-    unsafe {
-        core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), core::mem::size_of_val(data))
-    }
-}
-
-fn as_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
-    unsafe {
-        core::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), core::mem::size_of_val(data))
-    }
-}
-
 fn assert_mul_broadcast_outer_differential<T>(lhs: &[T], rhs: &[T])
 where
     T: Copy
+        + strided_kernel::KernelStorageElement
         + core::fmt::Debug
         + PartialEq
         + core::ops::Mul<Output = T>
@@ -131,7 +117,11 @@ where
 
 fn assert_compare_differential<T>(lhs: &[T], rhs: &[T])
 where
-    T: Copy + core::fmt::Debug + PartialOrd + strided_kernel::MaybeSendSync,
+    T: Copy
+        + core::fmt::Debug
+        + PartialOrd
+        + strided_kernel::MaybeSendSync
+        + strided_kernel::KernelStorageElement,
 {
     let dims = [lhs.len()];
     let lhs_view = StridedView::<_, Identity>::new(lhs, &dims, &[1], 0).unwrap();
@@ -165,13 +155,13 @@ where
 
 fn assert_fused_differential<T>(dtype: KernelDType, inputs: &[Vec<T>], plan: FusedPlan)
 where
-    T: Copy + core::fmt::Debug + PartialEq,
+    T: Copy + core::fmt::Debug + PartialEq + strided_kernel::KernelStorageElement,
 {
     let dims = [inputs[0].len()];
     let strides = [1isize];
     let refs: Vec<_> = inputs
         .iter()
-        .map(|input| ErasedRawStridedRef::new(dtype, as_bytes(input), &dims, &strides, 0).unwrap())
+        .map(|input| ErasedRawStridedRef::from_slice(input, &dims, &strides, 0).unwrap())
         .collect();
     let ptrs: Vec<_> = refs.iter().map(ErasedRawStridedPtr::from_ref).collect();
     let plan = ErasedFusedPlan::compile(dtype, plan).unwrap();
@@ -179,20 +169,14 @@ where
     for context in [ExecContext::serial(), ExecContext::max_threads(2).unwrap()] {
         let mut initialized = vec![inputs[0][0]; dims[0]];
         let mut initialized_dest =
-            ErasedRawStridedMut::new(dtype, as_bytes_mut(&mut initialized), &dims, &strides, 0)
-                .unwrap();
+            ErasedRawStridedMut::from_slice_mut(&mut initialized, &dims, &strides, 0).unwrap();
         plan.execute(&context, &mut initialized_dest, &refs)
             .unwrap();
 
         let mut uninitialized = vec![MaybeUninit::<T>::uninit(); dims[0]];
-        let mut uninitialized_dest = ErasedRawStridedUninitMut::new(
-            dtype,
-            as_uninit_bytes(&mut uninitialized),
-            &dims,
-            &strides,
-            0,
-        )
-        .unwrap();
+        let mut uninitialized_dest =
+            ErasedRawStridedUninitMut::from_uninit_slice(&mut uninitialized, &dims, &strides, 0)
+                .unwrap();
         plan.execute_uninit(&context, &mut uninitialized_dest, &ptrs)
             .unwrap();
         assert_eq!(assume_init(uninitialized), initialized);
@@ -460,18 +444,10 @@ fn erased_fused_uninitialized_replay_writes_valid_bool_output() {
         },
     )
     .unwrap();
-    let inputs = [
-        ErasedRawStridedRef::new(KernelDType::Bool, as_bytes(&lhs), &dims, &strides, 0).unwrap(),
-    ];
+    let inputs = [ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap()];
     let mut output = vec![MaybeUninit::<bool>::uninit(); 4];
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::Bool,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &strides, 0).unwrap();
     let inputs = inputs.map(|input| ErasedRawStridedPtr::from_ref(&input));
     plan.execute_uninit(&ExecContext::max_threads(1).unwrap(), &mut dest, &inputs)
         .unwrap();
@@ -521,7 +497,7 @@ fn erased_fused_validation_errors_precede_writes_and_overlap_precedes_shared_ref
     let mut output = vec![MaybeUninit::new(99i32); 4];
     let ptr = NonNull::new(output.as_mut_ptr().cast::<u8>()).unwrap();
     let overlapping = unsafe {
-        ErasedRawStridedPtr::new(
+        ErasedRawStridedPtr::from_raw_parts(
             KernelDType::I32,
             ptr,
             core::mem::size_of_val(output.as_slice()),
@@ -531,14 +507,8 @@ fn erased_fused_validation_errors_precede_writes_and_overlap_precedes_shared_ref
         )
         .unwrap()
     };
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &strides, 0).unwrap();
     assert!(matches!(
         plan.execute_uninit(&ExecContext::serial(), &mut dest, &[overlapping]),
         Err(StridedError::OverlappingInputOutput { input: 0 })
@@ -549,17 +519,10 @@ fn erased_fused_validation_errors_precede_writes_and_overlap_precedes_shared_ref
 
     let wrong_dtype = [1.0f32; 4];
     let wrong_dtype_ref =
-        ErasedRawStridedRef::new(KernelDType::F32, as_bytes(&wrong_dtype), &dims, &strides, 0)
-            .unwrap();
+        ErasedRawStridedRef::from_slice(&wrong_dtype, &dims, &strides, 0).unwrap();
     let mut output = vec![MaybeUninit::new(99i32); 4];
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &strides, 0).unwrap();
     assert!(matches!(
         plan.execute_uninit(
             &ExecContext::serial(),
@@ -574,23 +537,11 @@ fn erased_fused_validation_errors_precede_writes_and_overlap_precedes_shared_ref
 
     let short_dims = [2usize];
     let short_input = [1i32; 2];
-    let short_ref = ErasedRawStridedRef::new(
-        KernelDType::I32,
-        as_bytes(&short_input),
-        &short_dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let short_ref =
+        ErasedRawStridedRef::from_slice(&short_input, &short_dims, &strides, 0).unwrap();
     let mut output = vec![MaybeUninit::new(99i32); 4];
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &strides, 0).unwrap();
     assert!(matches!(
         plan.execute_uninit(
             &ExecContext::serial(),
@@ -604,18 +555,11 @@ fn erased_fused_validation_errors_precede_writes_and_overlap_precedes_shared_ref
         .all(|value| unsafe { value.assume_init() == 99 }));
 
     let input = [1i32; 4];
-    let input_ref =
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&input), &dims, &strides, 0).unwrap();
+    let input_ref = ErasedRawStridedRef::from_slice(&input, &dims, &strides, 0).unwrap();
     let input_ptr = ErasedRawStridedPtr::from_ref(&input_ref);
     let mut output = vec![MaybeUninit::new(99i32); 4];
-    let mut noninjective = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &[0],
-        0,
-    )
-    .unwrap();
+    let mut noninjective =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &[0], 0).unwrap();
     assert!(matches!(
         plan.execute_uninit(&ExecContext::serial(), &mut noninjective, &[input_ptr]),
         Err(StridedError::NonInjectiveOutputLayout)
@@ -680,18 +624,12 @@ fn erased_fused_uninitialized_parallel_replay_preserves_wrapping_integer_semanti
     )
     .unwrap();
     let inputs = [
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&lhs), &dims, &strides, 0).unwrap(),
-        ErasedRawStridedRef::new(KernelDType::I32, as_bytes(&rhs), &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&lhs, &dims, &strides, 0).unwrap(),
+        ErasedRawStridedRef::from_slice(&rhs, &dims, &strides, 0).unwrap(),
     ];
     let mut output = vec![MaybeUninit::<i32>::uninit(); len];
-    let mut dest = ErasedRawStridedUninitMut::new(
-        KernelDType::I32,
-        as_uninit_bytes(&mut output),
-        &dims,
-        &strides,
-        0,
-    )
-    .unwrap();
+    let mut dest =
+        ErasedRawStridedUninitMut::from_uninit_slice(&mut output, &dims, &strides, 0).unwrap();
     let inputs = inputs.map(|input| ErasedRawStridedPtr::from_ref(&input));
     plan.execute_uninit(&ExecContext::max_threads(2).unwrap(), &mut dest, &inputs)
         .unwrap();

--- a/strided-kernel/tests/issue_190_bool_overlap.rs
+++ b/strided-kernel/tests/issue_190_bool_overlap.rs
@@ -1,0 +1,234 @@
+use std::mem::MaybeUninit;
+use std::{fs, path::Path, ptr::NonNull};
+
+use strided_kernel::{
+    ErasedConcatenatePlan, ErasedRawStridedPtr, ErasedRawStridedUninitMut, ExecContext,
+    KernelDType, StridedError,
+};
+
+#[test]
+fn concatenate_checks_all_overlaps_before_deferred_bool_validation() {
+    let input_dims: [&[usize]; 2] = [&[1], &[1]];
+    let input_strides: [&[isize]; 2] = [&[1], &[1]];
+    let dest_dims = [2usize];
+    let dest_strides = [1isize];
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::Bool,
+        &input_dims,
+        &input_strides,
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    let mut invalid = vec![2u8];
+    let invalid_ptr = unsafe {
+        ErasedRawStridedPtr::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(invalid.as_mut_ptr()).unwrap(),
+            invalid.len(),
+            &[1],
+            &[1],
+            0,
+        )
+    }
+    .unwrap();
+
+    let mut destination = vec![2u8; 2];
+    let overlapping_ptr = unsafe {
+        ErasedRawStridedPtr::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(destination.as_mut_ptr()).unwrap(),
+            1,
+            &[1],
+            &[1],
+            0,
+        )
+    }
+    .unwrap();
+    let mut output = unsafe {
+        ErasedRawStridedUninitMut::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(destination.as_mut_ptr()).unwrap(),
+            destination.len(),
+            &dest_dims,
+            &dest_strides,
+            0,
+        )
+    }
+    .unwrap();
+
+    let result = plan.execute_uninit(
+        &ExecContext::serial(),
+        &mut output,
+        &[invalid_ptr, overlapping_ptr],
+    );
+    // The first input is invalid, but the second input overlaps the output.
+    // This exact error proves every overlap is checked before deferred Bool
+    // validation of any input.
+    assert!(matches!(
+        result,
+        Err(StridedError::OverlappingInputOutput { input: 1 })
+    ));
+}
+
+#[test]
+fn bool_mutation_after_raw_pointer_handoff_is_validated_before_writes() {
+    let dims = [&[1usize][..]];
+    let strides = [&[1isize][..]];
+    let dest_dims = [1usize];
+    let dest_strides = [1isize];
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::Bool,
+        &dims,
+        &strides,
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    let mut input = [1u8];
+    let input_ptr = input.as_mut_ptr();
+    let handed_off = unsafe {
+        ErasedRawStridedPtr::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(input_ptr).unwrap(),
+            input.len(),
+            &dims[0],
+            &strides[0],
+            0,
+        )
+    }
+    .unwrap();
+    // The raw contract permits sequential mutation through the original
+    // pointer before execution; no access through `handed_off` occurs here.
+    unsafe { *input_ptr = 2 };
+
+    let mut destination = [MaybeUninit::new(7u8)];
+    let mut output = unsafe {
+        ErasedRawStridedUninitMut::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(destination.as_mut_ptr().cast()).unwrap(),
+            destination.len(),
+            &dest_dims,
+            &dest_strides,
+            0,
+        )
+    }
+    .unwrap();
+    let result = plan.execute_uninit(&ExecContext::serial(), &mut output, &[handed_off]);
+    assert!(matches!(result, Err(StridedError::InvalidBoolByte { .. })));
+    assert_eq!(unsafe { destination[0].assume_init() }, 7);
+}
+
+#[test]
+fn bool_uninitialized_replay_does_not_read_strided_holes() {
+    let input_dims = [&[2usize][..]];
+    let input_strides = [&[1isize][..]];
+    let dest_dims = [2usize];
+    let dest_strides = [2isize];
+    let plan = ErasedConcatenatePlan::compile(
+        KernelDType::Bool,
+        &input_dims,
+        &input_strides,
+        &dest_dims,
+        &dest_strides,
+        0,
+    )
+    .unwrap();
+
+    let input = [1u8, 0u8];
+    let input_ptr = unsafe {
+        ErasedRawStridedPtr::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(input.as_ptr() as *mut u8).unwrap(),
+            input.len(),
+            &input_dims[0],
+            &input_strides[0],
+            0,
+        )
+    }
+    .unwrap();
+    let mut destination = [
+        MaybeUninit::<u8>::uninit(),
+        MaybeUninit::<u8>::uninit(),
+        MaybeUninit::<u8>::uninit(),
+    ];
+    let mut output = unsafe {
+        ErasedRawStridedUninitMut::from_raw_parts(
+            KernelDType::Bool,
+            NonNull::new(destination.as_mut_ptr().cast()).unwrap(),
+            destination.len(),
+            &dest_dims,
+            &dest_strides,
+            0,
+        )
+    }
+    .unwrap();
+
+    plan.execute_uninit(&ExecContext::serial(), &mut output, &[input_ptr])
+        .unwrap();
+    // Only offsets 0 and 2 are reachable. The hole at offset 1 remains
+    // MaybeUninit and is deliberately never read or assumed initialized.
+    assert_eq!(unsafe { destination[0].assume_init() }, 1);
+    assert_eq!(unsafe { destination[2].assume_init() }, 0);
+}
+
+#[test]
+fn production_source_contract_has_no_legacy_erased_storage_apis() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let production = [
+        root.join("strided-view/src"),
+        root.join("strided-kernel/src"),
+        root.join("strided-einsum2/src"),
+        root.join("strided-opteinsum/src"),
+        root.join("mdarray-opteinsum/src"),
+        root.join("ndarray-opteinsum/src"),
+        root.join("strided-rs/src"),
+    ];
+    let forbidden = [
+        "ErasedRawStridedRef::new",
+        "ErasedRawStridedMut::new",
+        "ErasedRawStridedUninitMut::new",
+        "ErasedRawStridedPtr::new",
+        "typed_slice",
+        "data_unchecked",
+    ];
+    for directory in production {
+        let mut files = vec![directory];
+        while let Some(path) = files.pop() {
+            if path.is_dir() {
+                files.extend(
+                    fs::read_dir(path)
+                        .unwrap()
+                        .map(|entry| entry.unwrap().path()),
+                );
+                continue;
+            }
+            if path.extension().is_none_or(|ext| ext != "rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&path).unwrap();
+            for pattern in forbidden {
+                assert!(!source.contains(pattern), "{pattern} remains in {path:?}");
+            }
+            if path.ends_with("strided-view/src/raw.rs") {
+                continue;
+            }
+            if path.ends_with("strided-kernel/src/erased.rs") {
+                assert!(!source.contains("std::slice::from_raw_parts"));
+                assert!(!source.contains("std::slice::from_raw_parts_mut"));
+                assert!(!source.contains("core::slice::from_raw_parts"));
+                assert!(!source.contains("core::slice::from_raw_parts_mut"));
+            }
+            assert!(
+                !source.contains("ErasedRawStridedRef::from_raw_parts")
+                    && !source.contains("ErasedRawStridedMut::from_raw_parts")
+                    && !source.contains("ErasedRawStridedUninitMut::from_raw_parts"),
+                "erased raw construction escaped the designated raw boundary: {path:?}"
+            );
+        }
+    }
+}

--- a/strided-view/src/lib.rs
+++ b/strided-view/src/lib.rs
@@ -35,7 +35,7 @@ pub use element_op::{
 // ============================================================================
 pub use raw::{
     ErasedRawStridedMut, ErasedRawStridedPtr, ErasedRawStridedRef, ErasedRawStridedUninitMut,
-    KernelDType, RawStridedMut, RawStridedRef,
+    KernelDType, KernelStorageElement, RawStridedMut, RawStridedRef,
 };
 pub use view::{col_major_strides, row_major_strides, StridedArray, StridedView, StridedViewMut};
 

--- a/strided-view/src/raw.rs
+++ b/strided-view/src/raw.rs
@@ -12,6 +12,34 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use num_complex::{Complex32, Complex64};
 
+mod private {
+    pub trait Sealed {}
+}
+
+/// A scalar type that can safely witness storage for an erased kernel view.
+pub trait KernelStorageElement: private::Sealed + Copy + 'static {
+    const DTYPE: KernelDType;
+}
+
+macro_rules! kernel_storage_element {
+    ($($ty:ty => $dtype:ident),* $(,)?) => {$ (
+        impl private::Sealed for $ty {}
+        impl KernelStorageElement for $ty {
+            const DTYPE: KernelDType = KernelDType::$dtype;
+        }
+    )* };
+}
+
+kernel_storage_element! {
+    f32 => F32,
+    f64 => F64,
+    i32 => I32,
+    i64 => I64,
+    bool => Bool,
+    Complex32 => C32,
+    Complex64 => C64,
+}
+
 use crate::{Result, StridedError, StridedView, StridedViewMut};
 
 /// Dtypes supported by dtype-erased kernel entry points.
@@ -143,19 +171,27 @@ pub struct ErasedRawStridedPtr<'a> {
     dims: &'a [usize],
     strides: &'a [isize],
     offset: isize,
-    marker: PhantomData<&'a [u8]>,
+    marker: PhantomData<&'a [MaybeUninit<u8>]>,
 }
 
 impl<'a> ErasedRawStridedPtr<'a> {
-    /// Create a pointer-backed descriptor.
+    /// Create a pointer-backed descriptor from erased storage.
     ///
     /// # Safety
     ///
-    /// `data..data + byte_len` must remain readable and allocated for `'a`.
-    /// Its bytes must contain valid values for `dtype`. The allocation may
-    /// overlap a destination passed to a one-shot entry point; overlap is
-    /// checked before the pointer is dereferenced.
-    pub unsafe fn new(
+    /// `data` must point into an allocation whose alignment is suitable for
+    /// `dtype`, independently of the observed address. The allocation must
+    /// provide `byte_len` initialized, readable bytes with valid provenance
+    /// for `'a`, and remain alive for `'a`. For `bool`, the bytes may contain
+    /// invalid values temporarily. They must not be read or used to form a
+    /// typed reference until a caller has rejected overlap and
+    /// [`Self::try_as_ref_after_no_overlap`] has validated the complete extent.
+    /// The allocation may overlap a destination.
+    /// The original owner may perform synchronized sequential mutation through
+    /// the same-provenance raw pointer before conversion. No concurrent
+    /// mutation or conflicting access is permitted during overlap checking,
+    /// conversion, or consumer access.
+    pub unsafe fn from_raw_parts(
         dtype: KernelDType,
         data: NonNull<u8>,
         byte_len: usize,
@@ -189,19 +225,52 @@ impl<'a> ErasedRawStridedPtr<'a> {
         }
     }
 
+    /// Convert this pointer to an initialized descriptor after overlap checks.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have proved that no mutable allocation overlaps this
+    /// pointer's complete byte extent.
+    /// The allocation contract from [`Self::from_raw_parts`] must still hold.
+    /// No mutation or other conflicting access may occur during this conversion
+    /// or for the duration of the returned descriptor's consumer access.
+    /// Bool bytes are validated here, immediately before typed access.
+    pub unsafe fn try_as_ref_after_no_overlap(&self) -> Result<ErasedRawStridedRef<'_>> {
+        let bytes = core::slice::from_raw_parts(self.data.as_ptr(), self.byte_len);
+        validate_erased_buffer(self.dtype, bytes)?;
+        ErasedRawStridedRef::from_raw_parts(
+            self.dtype,
+            self.data,
+            self.byte_len,
+            self.dims,
+            self.strides,
+            self.offset,
+        )
+    }
+
     #[inline]
     pub fn dtype(&self) -> KernelDType {
         self.dtype
     }
 
-    #[inline]
-    pub fn data_ptr(&self) -> *const u8 {
-        self.data.as_ptr()
+    /// Check overlap with initialized mutable storage without reading it.
+    pub fn overlaps_mut(&self, dest: &ErasedRawStridedMut<'_>) -> Result<bool> {
+        ranges_overlap(
+            self.data.as_ptr() as usize,
+            self.byte_len,
+            dest.data.as_ptr() as usize,
+            dest.data.len(),
+        )
     }
 
-    #[inline]
-    pub fn byte_len(&self) -> usize {
-        self.byte_len
+    /// Check overlap with uninitialized mutable storage without reading it.
+    pub fn overlaps_uninit_mut(&self, dest: &ErasedRawStridedUninitMut<'_>) -> Result<bool> {
+        ranges_overlap(
+            self.data.as_ptr() as usize,
+            self.byte_len,
+            dest.data.as_ptr() as usize,
+            dest.data.len(),
+        )
     }
 
     #[inline]
@@ -217,16 +286,6 @@ impl<'a> ErasedRawStridedPtr<'a> {
     #[inline]
     pub fn offset(&self) -> isize {
         self.offset
-    }
-
-    /// Materialize the shared byte slice after the caller has ruled out a
-    /// concurrent mutable alias.
-    ///
-    /// # Safety
-    ///
-    /// No live mutable reference may overlap the returned slice.
-    pub unsafe fn data_unchecked(&self) -> &'a [u8] {
-        core::slice::from_raw_parts(self.data.as_ptr(), self.byte_len)
     }
 }
 
@@ -243,34 +302,78 @@ pub struct ErasedRawStridedRef<'a> {
 }
 
 impl<'a> ErasedRawStridedRef<'a> {
-    /// Create a byte-backed erased input descriptor after validating dtype byte
-    /// length, alignment, rank/stride agreement, and reachable element bounds.
-    pub fn new(
-        dtype: KernelDType,
-        data: &'a [u8],
+    /// Create an erased input descriptor from typed, initialized storage.
+    pub fn from_slice<T: KernelStorageElement>(
+        data: &'a [T],
         dims: &'a [usize],
         strides: &'a [isize],
         offset: isize,
     ) -> Result<Self> {
-        let element_count = validate_erased_buffer(dtype, data)?;
+        let dtype = T::DTYPE;
+        let byte_len = data
+            .len()
+            .checked_mul(core::mem::size_of::<T>())
+            .ok_or(StridedError::OffsetOverflow)?;
+        let bytes = unsafe { core::slice::from_raw_parts(data.as_ptr().cast::<u8>(), byte_len) };
+        let element_count = validate_erased_buffer(dtype, bytes)?;
         validate_bounds(element_count, dims, strides, offset)?;
         Ok(Self {
             dtype,
-            data,
+            data: bytes,
             dims,
             strides,
             offset,
         })
     }
 
-    #[inline]
-    pub fn dtype(&self) -> KernelDType {
-        self.dtype
+    /// Construct from erased storage.
+    ///
+    /// # Safety
+    /// `data` must be the start of an allocation aligned for `dtype`; the
+    /// allocation must contain `byte_len` initialized, readable bytes for
+    /// `'a`, and every byte extent must represent valid values for `dtype`.
+    /// The allocation and metadata must outlive `'a`; no mutable alias may
+    /// exist while this descriptor is used. Alignment is an allocation
+    /// property and must not be inferred from the observed address alone.
+    pub unsafe fn from_raw_parts(
+        dtype: KernelDType,
+        data: NonNull<u8>,
+        byte_len: usize,
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let count = validate_erased_buffer_layout(dtype, data, byte_len)?;
+        let bytes = core::slice::from_raw_parts(data.as_ptr(), byte_len);
+        validate_bounds(count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data: bytes,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Borrow the initialized storage as its concrete scalar type.
+    pub fn data_as<T: KernelStorageElement>(&self) -> Result<&[T]> {
+        if self.dtype != T::DTYPE {
+            return Err(StridedError::DTypeMismatch {
+                expected: T::DTYPE.label(),
+                actual: self.dtype.label(),
+            });
+        }
+        Ok(unsafe {
+            core::slice::from_raw_parts(
+                self.data.as_ptr().cast::<T>(),
+                self.data.len() / core::mem::size_of::<T>(),
+            )
+        })
     }
 
     #[inline]
-    pub fn data(&self) -> &'a [u8] {
-        self.data
+    pub fn dtype(&self) -> KernelDType {
+        self.dtype
     }
 
     #[inline]
@@ -286,15 +389,6 @@ impl<'a> ErasedRawStridedRef<'a> {
     #[inline]
     pub fn offset(&self) -> isize {
         self.offset
-    }
-
-    /// Re-check the current byte buffer against the descriptor dtype.
-    ///
-    /// This is normally redundant after construction, but callers that can
-    /// mutate a sibling output descriptor's bytes may need a cheap way to
-    /// re-establish dtype byte validity before typed replay.
-    pub fn validate_data(&self) -> Result<()> {
-        validate_erased_buffer(self.dtype, self.data).map(|_| ())
     }
 }
 
@@ -308,20 +402,23 @@ pub struct ErasedRawStridedMut<'a> {
     dims: &'a [usize],
     strides: &'a [isize],
     offset: isize,
-    needs_data_revalidation: bool,
 }
 
 impl<'a> ErasedRawStridedMut<'a> {
-    /// Create a byte-backed erased output descriptor after validating dtype
-    /// byte length, alignment, rank/stride agreement, and reachable element
-    /// bounds.
-    pub fn new(
-        dtype: KernelDType,
-        data: &'a mut [u8],
+    /// Create an erased output descriptor from typed, initialized storage.
+    pub fn from_slice_mut<T: KernelStorageElement>(
+        data: &'a mut [T],
         dims: &'a [usize],
         strides: &'a [isize],
         offset: isize,
     ) -> Result<Self> {
+        let dtype = T::DTYPE;
+        let byte_len = data
+            .len()
+            .checked_mul(core::mem::size_of::<T>())
+            .ok_or(StridedError::OffsetOverflow)?;
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u8>(), byte_len) };
         let element_count = validate_erased_buffer(dtype, data)?;
         validate_bounds(element_count, dims, strides, offset)?;
         Ok(Self {
@@ -330,26 +427,75 @@ impl<'a> ErasedRawStridedMut<'a> {
             dims,
             strides,
             offset,
-            needs_data_revalidation: false,
+        })
+    }
+
+    /// Construct from erased storage.
+    ///
+    /// # Safety
+    /// `data..data + byte_len` must be an aligned, writable allocation valid
+    /// for `'a`, with valid initialized values for `dtype` throughout the
+    /// complete byte extent; its provenance, extent, lifetime, and exclusive
+    /// aliasing must be upheld by the caller.
+    /// The alignment requirement is on the allocation, not merely the observed
+    /// address. The caller must retain exclusive access: no mutable alias or
+    /// concurrent mutation may exist while this descriptor is used.
+    pub unsafe fn from_raw_parts(
+        dtype: KernelDType,
+        data: NonNull<u8>,
+        byte_len: usize,
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let count = validate_erased_buffer_layout(dtype, data, byte_len)?;
+        let data = core::slice::from_raw_parts_mut(data.as_ptr(), byte_len);
+        validate_erased_buffer(dtype, data)?;
+        validate_bounds(count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Borrow initialized storage as its concrete scalar type.
+    pub fn data_as<T: KernelStorageElement>(&self) -> Result<&[T]> {
+        if self.dtype != T::DTYPE {
+            return Err(StridedError::DTypeMismatch {
+                expected: T::DTYPE.label(),
+                actual: self.dtype.label(),
+            });
+        }
+        Ok(unsafe {
+            core::slice::from_raw_parts(
+                self.data.as_ptr().cast::<T>(),
+                self.data.len() / core::mem::size_of::<T>(),
+            )
+        })
+    }
+
+    /// Borrow initialized storage mutably as its concrete scalar type.
+    pub fn data_as_mut<T: KernelStorageElement>(&mut self) -> Result<&mut [T]> {
+        if self.dtype != T::DTYPE {
+            return Err(StridedError::DTypeMismatch {
+                expected: T::DTYPE.label(),
+                actual: self.dtype.label(),
+            });
+        }
+        Ok(unsafe {
+            core::slice::from_raw_parts_mut(
+                self.data.as_mut_ptr().cast::<T>(),
+                self.data.len() / core::mem::size_of::<T>(),
+            )
         })
     }
 
     #[inline]
     pub fn dtype(&self) -> KernelDType {
         self.dtype
-    }
-
-    #[inline]
-    pub fn data(&self) -> &[u8] {
-        self.data
-    }
-
-    #[inline]
-    pub fn data_mut(&mut self) -> &mut [u8] {
-        if self.dtype.requires_valid_byte_values() {
-            self.needs_data_revalidation = true;
-        }
-        self.data
     }
 
     #[inline]
@@ -365,36 +511,6 @@ impl<'a> ErasedRawStridedMut<'a> {
     #[inline]
     pub fn offset(&self) -> isize {
         self.offset
-    }
-
-    /// Re-check the current byte buffer against the descriptor dtype.
-    ///
-    /// This guards safe replay when callers mutate bytes through
-    /// [`ErasedRawStridedMut::data_mut`] after construction.
-    pub fn validate_data(&self) -> Result<()> {
-        validate_erased_buffer(self.dtype, self.data).map(|_| ())
-    }
-
-    /// Re-check dtype byte validity only when mutable bytes escaped since the
-    /// last validation.
-    pub fn validate_data_if_needed(&mut self) -> Result<()> {
-        if self.needs_data_revalidation {
-            self.validate_data()?;
-            self.needs_data_revalidation = false;
-        }
-        Ok(())
-    }
-
-    /// Mark the current byte buffer as satisfying this descriptor's dtype
-    /// value invariants.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure every byte sequence in `data` is valid for
-    /// `dtype`. This matters for `bool`, where Rust requires stored values to
-    /// be exactly `0` or `1` before a typed `bool` slice is formed.
-    pub unsafe fn assume_data_valid(&mut self) {
-        self.needs_data_revalidation = false;
     }
 }
 
@@ -414,18 +530,24 @@ pub struct ErasedRawStridedUninitMut<'a> {
 }
 
 impl<'a> ErasedRawStridedUninitMut<'a> {
-    /// Create an uninitialized erased output descriptor after validating byte
-    /// length, alignment, rank/stride agreement, and reachable bounds.
-    pub fn new(
-        dtype: KernelDType,
-        data: &'a mut [MaybeUninit<u8>],
+    /// Create an uninitialized erased output descriptor from typed storage.
+    pub fn from_uninit_slice<T: KernelStorageElement>(
+        data: &'a mut [MaybeUninit<T>],
         dims: &'a [usize],
         strides: &'a [isize],
         offset: isize,
     ) -> Result<Self> {
+        let dtype = T::DTYPE;
+        let byte_len = data
+            .len()
+            .checked_mul(core::mem::size_of::<T>())
+            .ok_or(StridedError::OffsetOverflow)?;
+        let data = unsafe {
+            core::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<MaybeUninit<u8>>(), byte_len)
+        };
         let data_ptr =
             NonNull::new(data.as_mut_ptr().cast::<u8>()).unwrap_or_else(NonNull::dangling);
-        let element_count = validate_erased_buffer_layout(dtype, data_ptr, data.len())?;
+        let element_count = validate_erased_buffer_layout(dtype, data_ptr, byte_len)?;
         validate_bounds(element_count, dims, strides, offset)?;
         Ok(Self {
             dtype,
@@ -436,24 +558,56 @@ impl<'a> ErasedRawStridedUninitMut<'a> {
         })
     }
 
+    /// Construct from erased uninitialized storage.
+    ///
+    /// # Safety
+    /// `data..data + byte_len` must be an aligned, writable allocation valid
+    /// for `'a`, with provenance and extent sufficient for all reachable
+    /// elements. The caller must ensure every reachable element is completely
+    /// overwritten before it is read or exposed as initialized storage. The
+    /// allocation's alignment is an allocation property independent of the
+    /// observed address, and the descriptor must have exclusive access with no
+    /// mutable alias or concurrent mutation during use.
+    pub unsafe fn from_raw_parts(
+        dtype: KernelDType,
+        data: NonNull<u8>,
+        byte_len: usize,
+        dims: &'a [usize],
+        strides: &'a [isize],
+        offset: isize,
+    ) -> Result<Self> {
+        let count = validate_erased_buffer_layout(dtype, data, byte_len)?;
+        let data =
+            core::slice::from_raw_parts_mut(data.as_ptr().cast::<MaybeUninit<u8>>(), byte_len);
+        validate_bounds(count, dims, strides, offset)?;
+        Ok(Self {
+            dtype,
+            data,
+            dims,
+            strides,
+            offset,
+        })
+    }
+
+    /// Borrow the uninitialized storage as its concrete scalar type.
+    pub fn data_as_uninit_mut<T: KernelStorageElement>(&mut self) -> Result<&mut [MaybeUninit<T>]> {
+        if self.dtype != T::DTYPE {
+            return Err(StridedError::DTypeMismatch {
+                expected: T::DTYPE.label(),
+                actual: self.dtype.label(),
+            });
+        }
+        Ok(unsafe {
+            core::slice::from_raw_parts_mut(
+                self.data.as_mut_ptr().cast::<MaybeUninit<T>>(),
+                self.data.len() / core::mem::size_of::<T>(),
+            )
+        })
+    }
+
     #[inline]
     pub fn dtype(&self) -> KernelDType {
         self.dtype
-    }
-
-    #[inline]
-    pub fn data_ptr(&self) -> *const u8 {
-        self.data.as_ptr().cast::<u8>()
-    }
-
-    #[inline]
-    pub fn byte_len(&self) -> usize {
-        self.data.len()
-    }
-
-    #[inline]
-    pub fn data_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        self.data
     }
 
     #[inline]
@@ -470,6 +624,16 @@ impl<'a> ErasedRawStridedUninitMut<'a> {
     pub fn offset(&self) -> isize {
         self.offset
     }
+}
+
+fn ranges_overlap(a_start: usize, a_len: usize, b_start: usize, b_len: usize) -> Result<bool> {
+    let a_end = a_start
+        .checked_add(a_len)
+        .ok_or(StridedError::OffsetOverflow)?;
+    let b_end = b_start
+        .checked_add(b_len)
+        .ok_or(StridedError::OffsetOverflow)?;
+    Ok(a_start < b_end && b_start < a_end)
 }
 
 /// Borrowed raw strided input layout.
@@ -675,38 +839,81 @@ mod tests {
     use super::*;
 
     #[test]
+    fn typed_erased_storage_covers_all_kernel_dtypes() {
+        macro_rules! check {
+            ($ty:ty, $value:expr) => {{
+                let mut initialized = [$value, $value];
+                let dims = [2usize];
+                let strides = [1isize];
+                let reference =
+                    ErasedRawStridedRef::from_slice(&initialized, &dims, &strides, 0).unwrap();
+                assert_eq!(reference.data_as::<$ty>().unwrap().len(), 2);
+                let mut mutable =
+                    ErasedRawStridedMut::from_slice_mut(&mut initialized, &dims, &strides, 0)
+                        .unwrap();
+                assert_eq!(mutable.data_as::<$ty>().unwrap().len(), 2);
+                assert_eq!(mutable.data_as_mut::<$ty>().unwrap().len(), 2);
+                let mut uninitialized = [MaybeUninit::<$ty>::uninit(); 2];
+                let mut destination = ErasedRawStridedUninitMut::from_uninit_slice(
+                    &mut uninitialized,
+                    &dims,
+                    &strides,
+                    0,
+                )
+                .unwrap();
+                assert_eq!(destination.data_as_uninit_mut::<$ty>().unwrap().len(), 2);
+            }};
+        }
+
+        check!(f32, 1.0f32);
+        check!(f64, 1.0f64);
+        check!(i32, 1i32);
+        check!(i64, 1i64);
+        check!(bool, true);
+        check!(Complex32, Complex32::new(1.0, 0.0));
+        check!(Complex64, Complex64::new(1.0, 0.0));
+    }
+
+    #[test]
     fn rejects_usize_max_dimension_before_isize_truncation() {
-        let data = [0u8; 1];
+        let data = [false; 1];
         let dims = [usize::MAX];
         let strides = [-1isize];
         assert!(matches!(
             RawStridedRef::new(&data, &dims, &strides, 0),
             Err(crate::StridedError::OffsetOverflow)
         ));
-        let mut data = [0u8; 1];
+        let mut data = [false; 1];
         assert!(matches!(
             RawStridedMut::new(&mut data, &dims, &strides, 0),
             Err(crate::StridedError::OffsetOverflow)
         ));
         assert!(matches!(
-            ErasedRawStridedRef::new(KernelDType::Bool, &data, &dims, &strides, 0),
+            ErasedRawStridedRef::from_slice(&data, &dims, &strides, 0),
             Err(crate::StridedError::OffsetOverflow)
         ));
-        let mut data = [0u8; 1];
+        let mut data = [false; 1];
         assert!(matches!(
-            ErasedRawStridedMut::new(KernelDType::Bool, &mut data, &dims, &strides, 0),
+            ErasedRawStridedMut::from_slice_mut(&mut data, &dims, &strides, 0),
             Err(crate::StridedError::OffsetOverflow)
         ));
         let ptr = NonNull::new(data.as_mut_ptr()).unwrap();
         assert!(matches!(
             unsafe {
-                ErasedRawStridedPtr::new(KernelDType::Bool, ptr, data.len(), &dims, &strides, 0)
+                ErasedRawStridedPtr::from_raw_parts(
+                    KernelDType::Bool,
+                    ptr.cast(),
+                    data.len(),
+                    &dims,
+                    &strides,
+                    0,
+                )
             },
             Err(crate::StridedError::OffsetOverflow)
         ));
-        let mut data = vec![MaybeUninit::<u8>::uninit(); 1];
+        let mut data = vec![MaybeUninit::<bool>::uninit(); 1];
         assert!(matches!(
-            ErasedRawStridedUninitMut::new(KernelDType::Bool, &mut data, &dims, &strides, 0),
+            ErasedRawStridedUninitMut::from_uninit_slice(&mut data, &dims, &strides, 0),
             Err(crate::StridedError::OffsetOverflow)
         ));
     }


### PR DESCRIPTION
## Summary
- seal erased descriptor storage to the seven `KernelDType` scalar types
- replace broad byte access with typed slice constructors/accessors and explicit unsafe raw-parts boundaries
- validate overlap before deferred Bool conversion and cover mutation-after-handoff/uninitialized-hole cases
- migrate erased tests and benches to the typed API

## Verification
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo check --workspace --all-targets`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`
- strict-provenance Miri for all seven storage dtypes and the three Bool/overlap regressions
- coverage check: 53/53 files passed
- Sol low/high final review: no findings

Closes #190