### PR TITLE
Fix uninitialized GEMM parallel bounds

### DIFF
--- a/docs/2026-07-31-issue-198-worklog.md
+++ b/docs/2026-07-31-issue-198-worklog.md
@@ -1,0 +1,10 @@
+# Issue #198 worklog
+
+## 2026-07-31
+
+- Reproduced the `strided-einsum2` `faer + parallel` feature combination failure
+  after the merged uninitialized GEMM work (#188/#196).
+- Added the existing `MaybeSendSync` contract to the uninitialized contiguous
+  output wrapper and its preparation entry point. This is a type-bound fix only;
+  it does not change kernel behavior or threading policy.
+- Verification: `cargo fmt --all -- --check`; `cargo test -p strided-einsum2`.

--- a/strided-einsum2/src/contiguous.rs
+++ b/strided-einsum2/src/contiguous.rs
@@ -9,6 +9,7 @@ use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
+use strided_kernel::MaybeSendSync;
 use strided_view::{RawStridedMut, RawStridedRef, StridedArray, StridedView, StridedViewMut};
 
 /// GEMM-ready input operand with contiguous data.
@@ -777,7 +778,7 @@ pub fn prepare_output_raw<T: ScalarBase + 'static>(
 }
 
 #[allow(dead_code)]
-impl<'a, 'b, T: Copy + 'static> UninitContiguousOperand<'a, 'b, T> {
+impl<'a, 'b, T: Copy + MaybeSendSync + 'static> UninitContiguousOperand<'a, 'b, T> {
     #[inline]
     pub(crate) fn ptr(&self) -> *mut MaybeUninit<T> {
         self.ptr
@@ -836,7 +837,7 @@ impl<'a, 'b, T: Copy + 'static> UninitContiguousOperand<'a, 'b, T> {
 /// Prepare an overwrite-only C operand. A non-fusable destination receives a
 /// dense `MaybeUninit` temporary and a compiled uninitialized writeback plan.
 #[allow(dead_code)]
-pub(crate) fn prepare_output_raw_uninit<'a, 'b, T: ScalarBase + 'static>(
+pub(crate) fn prepare_output_raw_uninit<'a, 'b, T: ScalarBase + MaybeSendSync + 'static>(
     destination: &'a mut RawStridedMut<'b, MaybeUninit<T>>,
     n_group1: usize,
     n_group2: usize,


### PR DESCRIPTION
## Summary
- add the existing `MaybeSendSync` bound to uninitialized contiguous GEMM writeback
- keep behavior and provider threading unchanged
- add a worklog and verify the `faer + parallel` feature combination

This fixes a feature-combination compile failure exposed when downstream pins merged #188/#196.

## Verification
- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=4 RUSTFLAGS="-C link-arg=-Wl,--threads=1" cargo check -p strided-einsum2 --features faer,parallel`
- `CARGO_BUILD_JOBS=4 RUSTFLAGS="-C link-arg=-Wl,--threads=1" cargo test -p strided-einsum2`