### PR TITLE
chore: prepare strided-rs v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,8 @@ environment or in a repo-root `.env` (`pip install -r scripts/requirements-dev.t
 
 The system prompt lives in `ai/prompts/repository-rules-review.md`. Two
 deterministic checks run before the LLM and independently of it: secret-shaped
-text in added lines blocks the upload entirely, and the **Retired Crate Freeze**
-rejects source changes in the crates retired by
-[#199](https://github.com/tensor4all/strided-rs/issues/199).
+text in added lines blocks the upload entirely, and the **Deprecated Tree
+Freeze** rejects source changes under `deprecated/`.
 
 Maintainer escape hatches, both requiring the `maintain`/`admin` role and
 reapplication after the latest push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,22 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Satoshi Terasaki", "Hiroshi Shinaoka"]
 repository = "https://github.com/tensor4all/strided-rs"
 
 [workspace.dependencies]
-strided-rs = { version = "0.3.0", path = "strided-rs" }
-strided-traits = { version = "0.3.0", path = "strided-traits" }
-strided-view = { version = "0.3.0", path = "strided-view" }
-strided-perm = { version = "0.3.0", path = "strided-perm" }
-strided-kernel = { version = "0.3.0", path = "strided-kernel" }
-strided-einsum2 = { version = "0.3.0", path = "strided-einsum2", default-features = false }
-strided-opteinsum = { version = "0.3.0", path = "strided-opteinsum", default-features = false }
-mdarray-opteinsum = { version = "0.3.0", path = "mdarray-opteinsum", default-features = false }
-ndarray-opteinsum = { version = "0.3.0", path = "ndarray-opteinsum", default-features = false }
+strided-rs = { version = "0.4.0", path = "strided-rs" }
+strided-traits = { version = "0.4.0", path = "strided-traits" }
+strided-view = { version = "0.4.0", path = "strided-view" }
+strided-perm = { version = "0.4.0", path = "strided-perm" }
+strided-kernel = { version = "0.4.0", path = "strided-kernel" }
+strided-einsum2 = { version = "0.4.0", path = "strided-einsum2", default-features = false }
+strided-opteinsum = { version = "0.4.0", path = "strided-opteinsum", default-features = false }
+mdarray-opteinsum = { version = "0.4.0", path = "mdarray-opteinsum", default-features = false }
+ndarray-opteinsum = { version = "0.4.0", path = "ndarray-opteinsum", default-features = false }
 
 approx = "0.5"
 cblas-inject = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is inspired by Julia's [Strided.jl](https://github.com/Jutho/Strided.jl),
 The recommended user-facing crate is [`strided-rs`](strided-rs/README.md).
 Use individual crates such as `strided-perm`, `strided-view`, or
 `strided-kernel` directly when you need a smaller dependency surface or a
-lower-level API.
+lower-level API. All nine workspace crates listed below are maintained.
 
 ## Workspace Layout
 
@@ -33,20 +33,11 @@ lower-level API.
 
 ## Installation
 
-These crates are being prepared for crates.io publication, but this repository
-does not publish them automatically. Until a release is published, use workspace
-path dependencies:
+Add the facade crate from crates.io:
 
 ```toml
 [dependencies]
-strided-rs = { path = "../strided-rs/strided-rs" }
-```
-
-After publication, use:
-
-```toml
-[dependencies]
-strided-rs = "0.1"
+strided-rs = "0.4"
 ```
 
 ## Documentation

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -3,15 +3,19 @@
 These rules are adapted from `tenferro-rs/REPOSITORY_RULES.md` for the current
 strided-rs workspace. Apply them in addition to the shared tensor4all rules.
 
-## Retired Crate Freeze
+## Einsum Maintenance Ownership
 
-- `strided-einsum2`, `strided-opteinsum`, `mdarray-opteinsum`,
-  `ndarray-opteinsum`, and everything under `deprecated/` are retired per
-  [#199](https://github.com/tensor4all/strided-rs/issues/199). Contraction is
-  owned by tenferro (`tenferro-einsum` plans, `tenferro-cpu` executes).
-- Do not land new features, refactors, or performance work in the retired
-  crates. Only fixes that protect the current tenferro pin belong here, and
-  only when the tenferro-side absorption cannot deliver them first.
+- `strided-einsum2` is the minimum binary CPU einsum implementation.
+- `strided-opteinsum` is its maintained N-ary frontend.
+- `mdarray-opteinsum` and `ndarray-opteinsum` remain maintained adapters.
+
+## Deprecated Tree Freeze
+
+- Everything under `deprecated/` remains retired per
+  [#199](https://github.com/tensor4all/strided-rs/issues/199).
+- Do not land new features, refactors, or performance work there. Only fixes
+  that protect the current tenferro pin belong there, and only when the
+  tenferro-side absorption cannot deliver them first.
 - Deprecation notices are exempt: README banners, crate-level and item-level
   doc comments, `#[deprecated]` attributes, and `Cargo.toml` metadata may
   change freely.

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -39,7 +39,23 @@ Replace `0.4.0` below for later releases.
 
 ```bash
 git push origin main
-git tag -a v0.4.0 -m "strided-rs v0.4.0"
+release_sha=$(git rev-parse HEAD)
+test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$release_sha"
+
+# Wait for the required CI workflow triggered by this exact pushed commit.
+run_id=
+for attempt in {1..30}; do
+  run_id=$(gh run list --workflow ci.yml --branch main --event push \
+    --commit "$release_sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+  test -z "$run_id" || break
+  sleep 10
+done
+test -n "$run_id"
+gh run watch "$run_id" --exit-status
+test "$(gh run view "$run_id" --json headSha --jq .headSha)" = "$release_sha"
+test "$(gh run view "$run_id" --json conclusion --jq .conclusion)" = success
+
+git tag -a v0.4.0 "$release_sha" -m "strided-rs v0.4.0"
 git push origin v0.4.0
 git switch --detach v0.4.0
 test -z "$(git status --porcelain)"

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -38,6 +38,8 @@ Push the validated `main` commit before creating and pushing the release tag.
 Replace `0.4.0` below for later releases.
 
 ```bash
+set -euo pipefail
+
 git push origin main
 release_sha=$(git rev-parse HEAD)
 test "$(git ls-remote origin refs/heads/main | cut -f1)" = "$release_sha"

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -19,7 +19,7 @@ cargo fmt --all -- --check
 cargo test --workspace
 ```
 
-Confirm all nine package archives contain their license and provenance files:
+Confirm all nine package file lists contain their license and provenance files:
 
 ```bash
 set -euo pipefail
@@ -84,20 +84,46 @@ git switch --detach v0.4.0
 test -z "$(git status --porcelain)"
 ```
 
-Create each package archive from the tag and verify Cargo recorded the tagged
-commit in `.cargo_vcs_info.json`:
+The detached tag checkout is the publication source. Do not create all nine
+archives at once: Cargo cannot package a crate whose v0.4 workspace
+prerequisites are not yet available from crates.io.
+
+## 3. Package, inspect, and publish in dependency order
+
+Process one crate completely before starting the next, in this exact order:
+
+1. `strided-traits`
+2. `strided-view`
+3. `strided-perm`
+4. `strided-kernel`
+5. `strided-einsum2`
+6. `strided-opteinsum`
+7. `mdarray-opteinsum`
+8. `ndarray-opteinsum`
+9. `strided-rs`
+
+The adapters occupy the same dependency layer and may be processed in either
+order. For every crate, create and inspect its archive, run the publish dry
+run, publish it, and wait for crates.io to serve the exact version before
+proceeding. Thus every prerequisite is registry-visible before Cargo packages
+a dependent crate, and the first archive is fully inspected before the first
+irreversible publish.
 
 ```bash
 set -euo pipefail
 
 version=0.4.0
 expected=$(git rev-parse HEAD)
+test "$(git describe --exact-match --tags HEAD)" = "v$version"
+
 for crate in \
   strided-traits strided-view strided-perm strided-kernel \
   strided-einsum2 strided-opteinsum mdarray-opteinsum \
   ndarray-opteinsum strided-rs
 do
+  test -z "$(git status --porcelain)"
   cargo package -p "$crate" --no-verify
+
   archive="target/package/${crate}-${version}.crate"
   prefix="${crate}-${version}"
   vcs_info=$(tar -xOf "$archive" "$prefix/.cargo_vcs_info.json")
@@ -105,6 +131,7 @@ do
   dirty=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(str(json.load(sys.stdin)["git"].get("dirty", False)).lower())')
   test "$actual" = "$expected"
   test "$dirty" = false
+
   for required in LICENSE-APACHE LICENSE-MIT NOTICE; do
     tar -xOf "$archive" "$prefix/$required" | cmp - "$crate/$required"
   done
@@ -121,44 +148,26 @@ do
       fi
       ;;
   esac
+
+  cargo publish -p "$crate" --dry-run
+  cargo publish -p "$crate"
+
+  visible=false
+  for attempt in {1..30}; do
+    if cargo info "$crate@$version"; then
+      visible=true
+      break
+    fi
+    sleep 10
+  done
+  test "$visible" = true
 done
+
+test -z "$(git status --porcelain)"
 ```
 
-Do not publish if an archive names another commit or reports a dirty worktree.
-
-## 3. Publish in dependency order
-
-Publish one layer at a time in this order:
-
-1. `strided-traits`
-2. `strided-view`
-3. `strided-perm`
-4. `strided-kernel`
-5. `strided-einsum2`
-6. `strided-opteinsum`
-7. `mdarray-opteinsum` and `ndarray-opteinsum` (either order)
-8. `strided-rs`
-
-For each crate, publish from the unchanged tag checkout:
-
-```bash
-set -euo pipefail
-
-crate=strided-traits # Replace for each package in the order above.
-cargo publish -p "$crate"
-```
-
-After each publish, wait until crates.io serves that exact version before
-publishing a dependent crate:
-
-```bash
-set -euo pipefail
-
-crate=strided-traits # Replace with the package just published.
-cargo info "$crate@0.4.0"
-```
-
-Registry indexing is asynchronous; retry `cargo info` rather than changing a
-manifest, repackaging with different metadata, or publishing dependents early.
-After the facade is visible, leave the detached checkout unchanged and verify
-`git status --porcelain` is empty.
+The visibility wait is bounded to 30 attempts and retries because registry
+indexing is asynchronous. If it expires, stop and resume only after confirming
+the just-published version is visible; do not edit a manifest, repackage with
+different metadata, or publish a dependent early. After the facade is visible,
+leave the detached checkout unchanged.

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -103,10 +103,11 @@ Process one crate completely before starting the next, in this exact order:
 9. `strided-rs`
 
 The adapters occupy the same dependency layer and may be processed in either
-order. For every crate, create and inspect its archive, run the publish dry
-run, publish it, and wait for crates.io to serve the exact version before
-proceeding. Thus every prerequisite is registry-visible before Cargo packages
-a dependent crate, and the first archive is fully inspected before the first
+order. For every crate, first query crates.io for the exact version. An absent
+version is packaged, inspected, dry-run, published, and awaited. An existing
+version is skipped only after its registry archive passes the same provenance
+checks. Thus every prerequisite is registry-visible before Cargo packages a
+dependent crate, and the first new archive is fully inspected before the first
 irreversible publish.
 
 ```bash
@@ -116,16 +117,13 @@ version=0.4.0
 expected=$(git rev-parse HEAD)
 test "$(git describe --exact-match --tags HEAD)" = "v$version"
 
-for crate in \
-  strided-traits strided-view strided-perm strided-kernel \
-  strided-einsum2 strided-opteinsum mdarray-opteinsum \
-  ndarray-opteinsum strided-rs
-do
-  test -z "$(git status --porcelain)"
-  cargo package -p "$crate" --no-verify
+download_dir=$(mktemp -d)
+trap 'rm -rf "$download_dir"' EXIT
 
-  archive="target/package/${crate}-${version}.crate"
-  prefix="${crate}-${version}"
+verify_archive() {
+  local crate=$1 archive=$2 prefix="${1}-${version}"
+  local vcs_info actual dirty archive_files
+
   vcs_info=$(tar -xOf "$archive" "$prefix/.cargo_vcs_info.json")
   actual=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(json.load(sys.stdin)["git"]["sha1"])')
   dirty=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(str(json.load(sys.stdin)["git"].get("dirty", False)).lower())')
@@ -148,6 +146,42 @@ do
       fi
       ;;
   esac
+}
+
+for crate in \
+  strided-traits strided-view strided-perm strided-kernel \
+  strided-einsum2 strided-opteinsum mdarray-opteinsum \
+  ndarray-opteinsum strided-rs
+do
+  test -z "$(git status --porcelain)"
+
+  registry_archive="$download_dir/${crate}-${version}.crate"
+  if ! http_status=$(curl --location --silent --show-error \
+    --user-agent "strided-rs-release/$version" \
+    --output "$registry_archive" --write-out '%{http_code}' \
+    "https://crates.io/api/v1/crates/$crate/$version/download"); then
+    echo "failed to query crates.io for $crate@$version" >&2
+    exit 1
+  fi
+
+  case "$http_status" in
+    200)
+      verify_archive "$crate" "$registry_archive"
+      echo "$crate@$version already exists and matches tag; skipping"
+      continue
+      ;;
+    404)
+      rm -f "$registry_archive"
+      ;;
+    *)
+      echo "unexpected HTTP status $http_status for $crate@$version" >&2
+      exit 1
+      ;;
+  esac
+
+  cargo package -p "$crate" --no-verify
+  archive="target/package/${crate}-${version}.crate"
+  verify_archive "$crate" "$archive"
 
   cargo publish -p "$crate" --dry-run
   cargo publish -p "$crate"
@@ -167,7 +201,9 @@ test -z "$(git status --porcelain)"
 ```
 
 The visibility wait is bounded to 30 attempts and retries because registry
-indexing is asynchronous. If it expires, stop and resume only after confirming
-the just-published version is visible; do not edit a manifest, repackage with
-different metadata, or publish a dependent early. After the facade is visible,
-leave the detached checkout unchanged.
+indexing is asynchronous. If it expires, rerun the same unchanged block: this
+is safe only because every existing version is downloaded and
+provenance-verified against the tag before it is skipped. Any network failure,
+HTTP result other than 200 or 404, or archive mismatch aborts the release. Do
+not edit a manifest, repackage with different metadata, or publish a dependent
+early. After the facade is visible, leave the detached checkout unchanged.

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -1,0 +1,100 @@
+# Publishing a strided-rs release
+
+Publish only a commit that has already landed on `main`. The release tag must
+identify that exact commit, and every crate must be published from a clean
+checkout of the tag.
+
+## 1. Prepare and validate `main`
+
+Complete all version and dependency changes in a reviewed commit before the
+release. Do not edit manifests while publishing: crates.io must receive the
+same manifests recorded by the tag.
+
+```bash
+git switch main
+git pull --ff-only origin main
+cargo fmt --all -- --check
+cargo test --workspace
+```
+
+Confirm all nine package archives contain their license and provenance files:
+
+```bash
+for crate in \
+  strided-traits strided-view strided-perm strided-kernel \
+  strided-einsum2 strided-opteinsum mdarray-opteinsum \
+  ndarray-opteinsum strided-rs
+do
+  cargo package -p "$crate" --list
+done
+```
+
+Every list must contain `LICENSE-APACHE`, `LICENSE-MIT`, and `NOTICE`.
+`strided-perm` must also contain `THIRD-PARTY-LICENSES`.
+
+## 2. Tag before publishing
+
+Push the validated `main` commit before creating and pushing the release tag.
+Replace `0.4.0` below for later releases.
+
+```bash
+git push origin main
+git tag -a v0.4.0 -m "strided-rs v0.4.0"
+git push origin v0.4.0
+git switch --detach v0.4.0
+test -z "$(git status --porcelain)"
+```
+
+Create each package archive from the tag and verify Cargo recorded the tagged
+commit in `.cargo_vcs_info.json`:
+
+```bash
+version=0.4.0
+expected=$(git rev-parse HEAD)
+for crate in \
+  strided-traits strided-view strided-perm strided-kernel \
+  strided-einsum2 strided-opteinsum mdarray-opteinsum \
+  ndarray-opteinsum strided-rs
+do
+  cargo package -p "$crate" --no-verify
+  archive="target/package/${crate}-${version}.crate"
+  vcs_info=$(tar -xOf "$archive" "${crate}-${version}/.cargo_vcs_info.json")
+  actual=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(json.load(sys.stdin)["git"]["sha1"])')
+  dirty=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(str(json.load(sys.stdin)["git"].get("dirty", False)).lower())')
+  test "$actual" = "$expected"
+  test "$dirty" = false
+done
+```
+
+Do not publish if an archive names another commit or reports a dirty worktree.
+
+## 3. Publish in dependency order
+
+Publish one layer at a time in this order:
+
+1. `strided-traits`
+2. `strided-view`
+3. `strided-perm`
+4. `strided-kernel`
+5. `strided-einsum2`
+6. `strided-opteinsum`
+7. `mdarray-opteinsum` and `ndarray-opteinsum` (either order)
+8. `strided-rs`
+
+For each crate, publish from the unchanged tag checkout:
+
+```bash
+cargo publish -p <crate>
+```
+
+After each publish, wait until crates.io serves that exact version before
+publishing a dependent crate:
+
+```bash
+cargo info <crate>@0.4.0
+```
+
+Registry indexing is asynchronous; retry `cargo info` rather than changing a
+manifest, repackaging with different metadata, or publishing dependents early.
+After the facade is visible, leave the detached checkout unchanged and verify
+`git status --porcelain` is empty.

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -11,6 +11,8 @@ release. Do not edit manifests while publishing: crates.io must receive the
 same manifests recorded by the tag.
 
 ```bash
+set -euo pipefail
+
 git switch main
 git pull --ff-only origin main
 cargo fmt --all -- --check
@@ -20,17 +22,36 @@ cargo test --workspace
 Confirm all nine package archives contain their license and provenance files:
 
 ```bash
+set -euo pipefail
+
 for crate in \
   strided-traits strided-view strided-perm strided-kernel \
   strided-einsum2 strided-opteinsum mdarray-opteinsum \
   ndarray-opteinsum strided-rs
 do
-  cargo package -p "$crate" --list
+  package_files=$(cargo package -p "$crate" --list)
+  printf '%s\n' "$package_files"
+  for required in LICENSE-APACHE LICENSE-MIT NOTICE; do
+    grep -Fxq "$required" <<<"$package_files"
+  done
+  case "$crate" in
+    strided-traits|strided-view|strided-perm|strided-kernel)
+      grep -Fxq THIRD-PARTY-LICENSES <<<"$package_files"
+      ;;
+    *)
+      if grep -Fxq THIRD-PARTY-LICENSES <<<"$package_files"; then
+        echo "unexpected THIRD-PARTY-LICENSES in $crate" >&2
+        exit 1
+      fi
+      ;;
+  esac
 done
 ```
 
-Every list must contain `LICENSE-APACHE`, `LICENSE-MIT`, and `NOTICE`.
-`strided-perm` must also contain `THIRD-PARTY-LICENSES`.
+Every package must contain `LICENSE-APACHE`, `LICENSE-MIT`, and its
+package-specific `NOTICE`. Only `strided-traits`, `strided-view`,
+`strided-kernel`, and `strided-perm` contain ported or license-derived code, so
+only those archives contain `THIRD-PARTY-LICENSES`.
 
 ## 2. Tag before publishing
 
@@ -67,6 +88,8 @@ Create each package archive from the tag and verify Cargo recorded the tagged
 commit in `.cargo_vcs_info.json`:
 
 ```bash
+set -euo pipefail
+
 version=0.4.0
 expected=$(git rev-parse HEAD)
 for crate in \
@@ -76,11 +99,28 @@ for crate in \
 do
   cargo package -p "$crate" --no-verify
   archive="target/package/${crate}-${version}.crate"
-  vcs_info=$(tar -xOf "$archive" "${crate}-${version}/.cargo_vcs_info.json")
+  prefix="${crate}-${version}"
+  vcs_info=$(tar -xOf "$archive" "$prefix/.cargo_vcs_info.json")
   actual=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(json.load(sys.stdin)["git"]["sha1"])')
   dirty=$(printf '%s' "$vcs_info" | python3 -c 'import json, sys; print(str(json.load(sys.stdin)["git"].get("dirty", False)).lower())')
   test "$actual" = "$expected"
   test "$dirty" = false
+  for required in LICENSE-APACHE LICENSE-MIT NOTICE; do
+    tar -xOf "$archive" "$prefix/$required" | cmp - "$crate/$required"
+  done
+  case "$crate" in
+    strided-traits|strided-view|strided-perm|strided-kernel)
+      tar -xOf "$archive" "$prefix/THIRD-PARTY-LICENSES" |
+        cmp - "$crate/THIRD-PARTY-LICENSES"
+      ;;
+    *)
+      archive_files=$(tar -tf "$archive")
+      if grep -q '/THIRD-PARTY-LICENSES$' <<<"$archive_files"; then
+        echo "unexpected THIRD-PARTY-LICENSES in $crate" >&2
+        exit 1
+      fi
+      ;;
+  esac
 done
 ```
 
@@ -102,14 +142,20 @@ Publish one layer at a time in this order:
 For each crate, publish from the unchanged tag checkout:
 
 ```bash
-cargo publish -p <crate>
+set -euo pipefail
+
+crate=strided-traits # Replace for each package in the order above.
+cargo publish -p "$crate"
 ```
 
 After each publish, wait until crates.io serves that exact version before
 publishing a dependent crate:
 
 ```bash
-cargo info <crate>@0.4.0
+set -euo pipefail
+
+crate=strided-traits # Replace with the package just published.
+cargo info "$crate@0.4.0"
 ```
 
 Registry indexing is asynchronous; retry `cargo info` rather than changing a

--- a/ai/prompts/repository-rules-review.md
+++ b/ai/prompts/repository-rules-review.md
@@ -8,10 +8,12 @@ strided-rs provides dynamic-rank strided views and cache-optimized CPU kernels:
 kernel layers are ports of Julia's Strided.jl / StridedViews.jl; the
 permutation engine follows HPTT.
 
-`strided-einsum2`, `strided-opteinsum`, `mdarray-opteinsum`,
-`ndarray-opteinsum`, and `deprecated/` are retired. Contraction is owned by
-tenferro. A deterministic check already reports source changes there, so do not
-duplicate that finding; review those diffs only for the rules that still apply.
+`strided-einsum2` is the minimum binary CPU einsum implementation, and
+`strided-opteinsum` is its maintained N-ary frontend. `mdarray-opteinsum` and
+`ndarray-opteinsum` remain maintained adapters. Everything under `deprecated/`
+remains retired. A deterministic check already reports source changes under
+`deprecated/`, so do not duplicate that finding; review those diffs only for
+the rules that still apply.
 
 ## Authority
 

--- a/docs/PROVENANCE_AND_CITATION_POLICY.md
+++ b/docs/PROVENANCE_AND_CITATION_POLICY.md
@@ -66,6 +66,10 @@ list is best-effort; corrections and additions are welcome.
 | Blocked tensor transposition (dimension fusion, macro/micro kernels, recursive loop nest) | `strided-perm` | P. Springer, T. Su, P. Bientinesi, "HPTT: A High-Performance Tensor Transposition C++ Library", [ARRAY 2017](https://doi.org/10.1145/3091966.3091968), [arXiv:1704.04374](https://arxiv.org/abs/1704.04374) |
 | Cache-blocked strided map/reduce (dimension fusion, stride-ordered loops, L1 blocking) | `strided-kernel` | Strided.jl has no accompanying paper; cite the [Strided.jl repository](https://github.com/Jutho/Strided.jl) |
 
-License-bearing attributions are declared in `NOTICE` (Strided.jl /
-StridedViews.jl, MIT) and `THIRD-PARTY-LICENSES` (HPTT, BSD-3-Clause); the
-`strided-perm` crate is licensed as `(MIT OR Apache-2.0) AND BSD-3-Clause`.
+Every published crate declares its component-specific lineage in its packaged
+`NOTICE`. Crates containing ported or license-derived code also package the
+applicable complete upstream license text in `THIRD-PARTY-LICENSES`:
+`strided-traits` and `strided-kernel` carry Strided.jl's MIT notice,
+`strided-view` carries StridedViews.jl's MIT notice, and `strided-perm` carries
+HPTT's BSD-3-Clause notice. The `strided-perm` crate is licensed as
+`(MIT OR Apache-2.0) AND BSD-3-Clause`.

--- a/mdarray-opteinsum/Cargo.toml
+++ b/mdarray-opteinsum/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "N-ary einsum frontend for mdarray arrays, powered by strided-opteinsum."
+keywords = ["tensor", "einsum", "mdarray", "contraction"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 mdarray.workspace = true

--- a/mdarray-opteinsum/LICENSE-APACHE
+++ b/mdarray-opteinsum/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mdarray-opteinsum/LICENSE-MIT
+++ b/mdarray-opteinsum/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mdarray-opteinsum/NOTICE
+++ b/mdarray-opteinsum/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/mdarray-opteinsum/NOTICE
+++ b/mdarray-opteinsum/NOTICE
@@ -1,15 +1,9 @@
-strided-rs
+mdarray-opteinsum
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate provides an einsum adapter compatible with the `mdarray` array
+library:
+https://crates.io/crates/mdarray
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+No mdarray code is ported into this adapter.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.

--- a/ndarray-opteinsum/Cargo.toml
+++ b/ndarray-opteinsum/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "N-ary einsum frontend for ndarray arrays, powered by strided-opteinsum."
+keywords = ["tensor", "einsum", "ndarray", "contraction"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 ndarray.workspace = true

--- a/ndarray-opteinsum/LICENSE-APACHE
+++ b/ndarray-opteinsum/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/ndarray-opteinsum/LICENSE-MIT
+++ b/ndarray-opteinsum/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ndarray-opteinsum/NOTICE
+++ b/ndarray-opteinsum/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/ndarray-opteinsum/NOTICE
+++ b/ndarray-opteinsum/NOTICE
@@ -1,15 +1,9 @@
-strided-rs
+ndarray-opteinsum
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate provides an einsum adapter compatible with the `ndarray` array
+library:
+https://crates.io/crates/ndarray
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+No ndarray code is ported into this adapter.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -3,9 +3,8 @@
 
 Ported from ``tenferro-rs/scripts/repository-rules-review.py`` and adapted to
 the strided-rs workspace: crates live at the repository root, the rule sections
-differ, and the deterministic boundary check enforces the retired-crate freeze
-from https://github.com/tensor4all/strided-rs/issues/199 instead of tenferro's
-AD boundary.
+differ, and the deterministic boundary check protects the retired
+`deprecated/` tree instead of tenferro's AD boundary.
 
 Local API key loading uses the ``python-dotenv`` library. Install dev helpers with:
 
@@ -44,19 +43,8 @@ HUNK_HEADER = re.compile(
     r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$"
 )
 
-# Crates retired by #199. Contraction moves to tenferro; strided-rs narrows to
-# the affine strided primitive layer.
-RETIRED_CRATES: tuple[str, ...] = (
-    "strided-einsum2",
-    "strided-opteinsum",
-    "mdarray-opteinsum",
-    "ndarray-opteinsum",
-)
-RETIRED_PATH_PREFIXES: tuple[str, ...] = (
-    *(f"{crate}/" for crate in RETIRED_CRATES),
-    "deprecated/",
-)
-# Deprecation notices may still land in the frozen crates: doc comments,
+DEPRECATED_PATH_PREFIX = "deprecated/"
+# Deprecation notices may still land in the frozen tree: doc comments,
 # attributes such as `#[deprecated]`, and blank lines. The block-comment
 # continuation alternatives require a trailing space, slash, or end of line so
 # that a dereference such as `*dst = value;` is not mistaken for a comment.
@@ -150,19 +138,14 @@ ALWAYS_SECTIONS = frozenset(
     }
 )
 
-# Sections a human reviewer owns; never routed to the LLM. Empty today because
-# every strided-rs rule section is delta-reviewable. Kept so that adding a
-# human-only section stays a one-line change, and so the rule-coverage test can
-# tell "human-owned" apart from "accidentally unrouted".
-HUMAN_ONLY_SECTIONS: frozenset[str] = frozenset()
+# Sections a human reviewer owns; never routed to the LLM. Maintenance
+# ownership is repository context rather than a delta-reviewable restriction.
+HUMAN_ONLY_SECTIONS: frozenset[str] = frozenset({"Einsum Maintenance Ownership"})
 
 SECTION_TRIGGERS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
     (
-        re.compile(
-            r"^(?:strided-einsum2|strided-opteinsum|mdarray-opteinsum"
-            r"|ndarray-opteinsum|deprecated)/"
-        ),
-        frozenset({"Retired Crate Freeze"}),
+        re.compile(r"^deprecated/"),
+        frozenset({"Deprecated Tree Freeze"}),
     ),
     (
         re.compile(r"^strided-view/|/view|/erased|/copy_plan|/metadata"),
@@ -1187,21 +1170,17 @@ def format_report(
     return "\n".join(lines)
 
 
-def is_retired_path(path: str) -> bool:
-    return path.startswith(RETIRED_PATH_PREFIXES)
-
-
-def retired_freeze_violations(
+def deprecated_tree_freeze_violations(
     added: dict[str, list[tuple[int, str]]],
 ) -> list[str]:
-    """Report added source lines inside the crates frozen by #199.
+    """Report added source lines inside the tree retired by #199.
 
     Non-Rust files (README banners, `Cargo.toml` metadata) are exempt, as are
-    doc comments and attributes, so the Phase 0 deprecation notices can land.
+    doc comments and attributes, so deprecation notices can land.
     """
     violations: list[str] = []
     for path in sorted(added):
-        if not is_retired_path(path) or not path.endswith(".rs"):
+        if not path.startswith(DEPRECATED_PATH_PREFIX) or not path.endswith(".rs"):
             continue
         for line_no, text in added[path]:
             if FREEZE_EXEMPT_LINE.match(text):
@@ -1219,24 +1198,20 @@ def deterministic_checks(
     if added is None:
         return findings
 
-    violations = retired_freeze_violations(added)
+    violations = deprecated_tree_freeze_violations(added)
     if violations:
-        touched = sorted(
-            {path.split("/", 1)[0] for path in added if is_retired_path(path)}
-        )
         findings.append(
             Finding(
-                id="retired-crate-freeze",
+                id="deprecated-tree-freeze",
                 severity="block",
-                rule_section="Retired Crate Freeze",
-                file=touched[0] if touched else "",
+                rule_section="Deprecated Tree Freeze",
+                file="deprecated",
                 line=None,
-                summary="Source change in a crate retired by #199",
+                summary="Source change under deprecated/",
                 detail=(
-                    "These crates are frozen; contraction moves to tenferro. "
-                    "Deprecation notices (docs, attributes, Cargo metadata) are "
-                    "exempt. Use the maintainer waiver label for a fix that "
-                    "protects the current tenferro pin.\n"
+                    "This tree is frozen. Deprecation notices (docs, attributes, "
+                    "Cargo metadata) are exempt. Use the maintainer waiver label "
+                    "for a fix that protects the current tenferro pin.\n"
                     + "\n".join(violations)
                 ),
             )

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -257,7 +257,7 @@ def test_select_rule_sections_does_not_freeze_maintained_einsum_crates() -> None
     mod = load_module()
     for crate in MAINTAINED_EINSUM_CRATES:
         sections = mod.select_rule_sections([f"{crate}/src/lib.rs"])
-        assert "Retired Crate Freeze" not in sections, crate
+        assert "Deprecated Tree Freeze" not in sections, crate
     assert "Deprecated Tree Freeze" in mod.select_rule_sections(
         ["deprecated/benches/strided_bench.rs"]
     )

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -53,6 +53,12 @@ AWS = "AKIA" + "ABCDEFGHIJKLMNOP"
 SK = "sk-" + "0123456789abcdef0123456789abcdef"
 VALUE = "abcdefghij" + "klmnopqrst"
 BEARER = "Authorization: Bearer " + VALUE
+MAINTAINED_EINSUM_CRATES = (
+    "strided-einsum2",
+    "strided-opteinsum",
+    "mdarray-opteinsum",
+    "ndarray-opteinsum",
+)
 
 
 # --- diff parsing ------------------------------------------------------------
@@ -247,12 +253,12 @@ def test_select_rule_sections_routes_bench_paths() -> None:
     assert "Performance And Benchmark Discipline" in sections
 
 
-def test_select_rule_sections_routes_retired_crates_to_freeze() -> None:
+def test_select_rule_sections_does_not_freeze_maintained_einsum_crates() -> None:
     mod = load_module()
-    for crate in mod.RETIRED_CRATES:
+    for crate in MAINTAINED_EINSUM_CRATES:
         sections = mod.select_rule_sections([f"{crate}/src/lib.rs"])
-        assert "Retired Crate Freeze" in sections, crate
-    assert "Retired Crate Freeze" in mod.select_rule_sections(
+        assert "Retired Crate Freeze" not in sections, crate
+    assert "Deprecated Tree Freeze" in mod.select_rule_sections(
         ["deprecated/benches/strided_bench.rs"]
     )
 
@@ -284,42 +290,52 @@ def test_build_rules_payload_returns_requested_section_bodies() -> None:
     assert "Public Surface Discipline" not in payload
 
 
-# --- retired-crate freeze ----------------------------------------------------
+# --- maintained einsum crates -----------------------------------------------
 
 
-def test_retired_freeze_blocks_source_change() -> None:
+def test_maintained_einsum_crates_are_not_deterministically_frozen() -> None:
     mod = load_module()
-    diff = make_diff("strided-einsum2/src/util.rs", ["fn faster() -> usize { 1 }"])
-    findings = mod.deterministic_checks(
-        ["strided-einsum2/src/util.rs"], added=mod.added_lines_with_text(diff)
-    )
+    for crate in MAINTAINED_EINSUM_CRATES:
+        path = f"{crate}/src/lib.rs"
+        diff = make_diff(path, ["fn maintained() -> usize { 1 }"])
+        assert mod.deterministic_checks(
+            [path], added=mod.added_lines_with_text(diff)
+        ) == [], crate
+
+
+def test_deprecated_tree_freeze_blocks_source_change() -> None:
+    mod = load_module()
+    path = "deprecated/strided/src/lib.rs"
+    diff = make_diff(path, ["fn new_feature() -> usize { 1 }"])
+    findings = mod.deterministic_checks([path], added=mod.added_lines_with_text(diff))
     assert len(findings) == 1
     assert findings[0].severity == "block"
-    assert findings[0].id == "retired-crate-freeze"
-    assert "strided-einsum2/src/util.rs:2" in findings[0].detail
+    assert findings[0].id == "deprecated-tree-freeze"
+    assert f"{path}:2" in findings[0].detail
 
 
-def test_retired_freeze_allows_deprecation_notices() -> None:
+def test_deprecated_tree_freeze_allows_deprecation_notices() -> None:
     mod = load_module()
+    path = "deprecated/strided/src/lib.rs"
     diff = make_diff(
-        "strided-opteinsum/src/lib.rs",
+        path,
         [
-            "//! Deprecated: use tenferro-einsum instead.",
+            "//! Deprecated: use strided-view instead.",
             "/// Migration pointer.",
-            '#[deprecated(note = "see strided-rs#199")]',
+            '#[deprecated(note = "use strided-view")]',
             "",
         ],
     )
-    findings = mod.deterministic_checks(
-        ["strided-opteinsum/src/lib.rs"], added=mod.added_lines_with_text(diff)
-    )
-    assert findings == []
+    assert mod.deterministic_checks(
+        [path], added=mod.added_lines_with_text(diff)
+    ) == []
 
 
-def test_retired_freeze_exempts_block_comments_but_not_dereference() -> None:
+def test_deprecated_tree_freeze_exempts_block_comments_but_not_dereference() -> None:
     mod = load_module()
+    path = "deprecated/strided/src/uninit.rs"
     diff = make_diff(
-        "strided-einsum2/src/uninit.rs",
+        path,
         [
             "/** Deprecated. */",
             " * continuation",
@@ -327,47 +343,24 @@ def test_retired_freeze_exempts_block_comments_but_not_dereference() -> None:
             "*dst = value;",
         ],
     )
-    findings = mod.deterministic_checks(
-        ["strided-einsum2/src/uninit.rs"], added=mod.added_lines_with_text(diff)
-    )
+    findings = mod.deterministic_checks([path], added=mod.added_lines_with_text(diff))
     assert len(findings) == 1
-    detail = findings[0].detail
-    assert "*dst = value;" in detail
-    assert "continuation" not in detail
+    assert "*dst = value;" in findings[0].detail
+    assert "continuation" not in findings[0].detail
 
 
-def test_retired_freeze_allows_readme_and_manifest() -> None:
+def test_deprecated_tree_freeze_allows_readme_and_manifest() -> None:
     mod = load_module()
     diff = "\n".join(
         [
-            make_diff("mdarray-opteinsum/README.md", ["> **Deprecated.**"]),
-            make_diff("mdarray-opteinsum/Cargo.toml", ['description = "deprecated"']),
+            make_diff("deprecated/strided/README.md", ["> **Deprecated.**"]),
+            make_diff("deprecated/strided/Cargo.toml", ['description = "deprecated"']),
         ]
     )
-    findings = mod.deterministic_checks(
-        ["mdarray-opteinsum/README.md", "mdarray-opteinsum/Cargo.toml"],
+    assert mod.deterministic_checks(
+        ["deprecated/strided/README.md", "deprecated/strided/Cargo.toml"],
         added=mod.added_lines_with_text(diff),
-    )
-    assert findings == []
-
-
-def test_retired_freeze_ignores_retained_crates() -> None:
-    mod = load_module()
-    diff = make_diff("strided-kernel/src/threading.rs", ["fn faster() -> usize { 1 }"])
-    findings = mod.deterministic_checks(
-        ["strided-kernel/src/threading.rs"], added=mod.added_lines_with_text(diff)
-    )
-    assert findings == []
-
-
-def test_retired_path_prefixes_cover_all_retired_crates() -> None:
-    mod = load_module()
-    for crate in mod.RETIRED_CRATES:
-        assert mod.is_retired_path(f"{crate}/src/lib.rs"), crate
-    assert mod.is_retired_path("deprecated/benches/strided_bench.rs")
-    assert not mod.is_retired_path("strided-view/src/view.rs")
-    # Prefix matching must not catch a retained crate whose name shares a stem.
-    assert not mod.is_retired_path("strided-einsum2-notes.md")
+    ) == []
 
 
 # --- model response handling -------------------------------------------------
@@ -1081,12 +1074,15 @@ def test_prompt_file_exists_and_requires_json_only() -> None:
     assert "untrusted data" in text
 
 
-def test_rules_file_documents_the_retirement() -> None:
+def test_rules_file_documents_einsum_maintenance_ownership() -> None:
     mod = load_module()
-    freeze = mod.parse_repository_rules_sections()["Retired Crate Freeze"]
-    for crate in mod.RETIRED_CRATES:
-        assert crate in freeze, crate
-    assert "199" in freeze
+    ownership = mod.parse_repository_rules_sections()["Einsum Maintenance Ownership"]
+    for crate in MAINTAINED_EINSUM_CRATES:
+        assert crate in ownership, crate
+    assert "minimum binary CPU einsum implementation" in ownership
+    assert "maintained N-ary frontend" in ownership
+    deprecated = mod.parse_repository_rules_sections()["Deprecated Tree Freeze"]
+    assert "deprecated/" in deprecated
 
 
 def main() -> int:

--- a/strided-einsum2/Cargo.toml
+++ b/strided-einsum2/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Binary einsum (pairwise tensor contraction) on strided views."
+keywords = ["tensor", "einsum", "contraction", "linear-algebra"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 strided-traits.workspace = true

--- a/strided-einsum2/LICENSE-APACHE
+++ b/strided-einsum2/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-einsum2/LICENSE-MIT
+++ b/strided-einsum2/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-einsum2/NOTICE
+++ b/strided-einsum2/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-einsum2/NOTICE
+++ b/strided-einsum2/NOTICE
@@ -1,15 +1,5 @@
-strided-rs
+strided-einsum2
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This binary einsum implementation is original to strided-rs.
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
-
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.

--- a/strided-einsum2/README.md
+++ b/strided-einsum2/README.md
@@ -3,9 +3,6 @@
 
 The `strided-einsum2` crate provides `einsum2_into` for binary tensor contractions.
 
-Most Rust benchmark runners were moved to `strided-opteinsum/benches/`.
-Latest broad benchmark results are documented in `strided-opteinsum/README.md`.
-
 The `dot_general` batched matmul diagnostic compares the tenferro-benchmark
 `bij,bjk->bik` cases against PyTorch `bmm` with memory-matched row-major and
 col-major layouts. Allocation and setup are outside the timed loop: Rust
@@ -18,8 +15,7 @@ Set `STRIDED_EINSUM2_DOT_GENERAL_BENCH_DIAGNOSTICS=1` to emit extra Rust-side
 diagnostic rows (`raw-cblas-dgemm`, `raw-trait-dgemm`, and on macOS
 `raw-fortran-dgemm`) for separating BLAS call overhead from PyTorch `bmm`.
 On macOS without MKL, PyTorch CPU `bmm` falls back to per-batch `addmm` rather
-than MKL batched GEMM; current 1T Accelerate runs do not show a stable TN-layout
-loss once measured with enough repetitions.
+than MKL batched GEMM.
 
 ```bash
 STRIDED_EINSUM2_DOT_GENERAL_BENCH_PROFILE=full \
@@ -27,25 +23,8 @@ STRIDED_EINSUM2_DOT_GENERAL_BENCH_DTYPES=f64,c64,c128 \
 bash strided-einsum2/benches/run_dot_general_pytorch_compare.sh 1 4
 ```
 
-Latest local allocation-free Accelerate run (`runs=30`, `warmups=5`):
-
-| benchmark | dtype | threads | strided-einsum2-accelerate-prepared ms | pytorch-bmm ms | ratio |
-|---|---:|---:|---:|---:|---:|
-| `bin_batched_matmul_b32_m64_n64_k64` | f64 | 1 | 0.046375 | 0.077375 | 0.60x |
-| `bin_batched_matmul_b32_m64_n64_k64` | f64 | 4 | 0.046417 | 0.078521 | 0.59x |
-| `bin_batched_matmul_b32_m64_n64_k64` | c64 | 1 | 0.343666 | 0.332021 | 1.04x |
-| `bin_batched_matmul_b32_m64_n64_k64` | c64 | 4 | 0.342417 | 0.332604 | 1.03x |
-| `bin_batched_matmul_b32_m64_n64_k64` | c128 | 1 | 0.748334 | 0.760542 | 0.98x |
-| `bin_batched_matmul_b32_m64_n64_k64` | c128 | 4 | 0.755875 | 0.758333 | 1.00x |
-| `bin_batched_matmul_b32_m128_n128_k128` | f64 | 1 | 0.301042 | 0.376313 | 0.80x |
-| `bin_batched_matmul_b32_m128_n128_k128` | f64 | 4 | 0.307916 | 0.378687 | 0.81x |
-| `bin_batched_matmul_b32_m128_n128_k128` | c64 | 1 | 1.224958 | 1.251854 | 0.98x |
-| `bin_batched_matmul_b32_m128_n128_k128` | c64 | 4 | 1.238375 | 1.243312 | 1.00x |
-| `bin_batched_matmul_b32_m128_n128_k128` | c128 | 1 | 2.981833 | 2.979667 | 1.00x |
-| `bin_batched_matmul_b32_m128_n128_k128` | c128 | 4 | 2.999375 | 2.977917 | 1.01x |
-
-The faer-prepared path is useful for isolating non-BLAS behavior, but macOS
-regression checks should use the Accelerate path above.
+Published benchmark programs and current measured results live in
+[`strided-rs-benchmark-suite`](https://github.com/tensor4all/strided-rs-benchmark-suite).
 
 **Julia reference scripts** (e.g. `julia_matmul.jl`, `julia_dot.jl`) use OMEinsum. Run single-threaded for comparison (from repo root):
 

--- a/strided-kernel/Cargo.toml
+++ b/strided-kernel/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Cache-optimized kernels for strided multidimensional array operations in Rust (ported from Julia Strided.jl/StridedViews.jl)."
+keywords = ["tensor", "strided", "kernels", "numerical"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 strided-view.workspace = true

--- a/strided-kernel/LICENSE-APACHE
+++ b/strided-kernel/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-kernel/LICENSE-MIT
+++ b/strided-kernel/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-kernel/NOTICE
+++ b/strided-kernel/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-kernel/NOTICE
+++ b/strided-kernel/NOTICE
@@ -1,15 +1,13 @@
-strided-rs
+strided-kernel
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate ports cache-optimized map, reduce, broadcast, and threading
+algorithms from Julia's Strided.jl, including fusion, ordering, blocking, and
+`_mapreduce_threaded!`:
+https://github.com/Jutho/Strided.jl
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+Strided.jl is licensed under the MIT License. Its complete upstream license
+notice is reproduced in `THIRD-PARTY-LICENSES`.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing portions ported from Strided.jl, you must also comply with
+the upstream MIT license notice requirements.

--- a/strided-kernel/README.md
+++ b/strided-kernel/README.md
@@ -107,7 +107,7 @@ The library automatically optimizes iteration order for cache efficiency:
 
 ```toml
 [dependencies]
-strided-kernel = { path = "../strided-kernel", features = ["parallel"] }
+strided-kernel = { version = "0.4", features = ["parallel"] }
 ```
 
 The default `ExecutionPolicy::AmbientRayon` behavior uses the current installed
@@ -183,38 +183,8 @@ uv --version
 STRIDED_KERNEL_MUL_BENCH_PROFILE=full bash strided-kernel/benches/run_mul_pytorch_compare.sh 1 4
 ```
 
-### Single-Threaded Results
-
-Environment: Apple Silicon M2, single-threaded.
-
-| Case | Julia Strided (ms) | Rust strided (ms) | Rust naive (ms) |
-|---|---:|---:|---:|
-| symmetrize_4000 | 17.75 | 20.56 | 41.38 |
-| scale_transpose_1000 | 0.53 | 0.79 | 0.42 |
-| mwe_stridedview_scale_transpose_1000 | 0.51 | 0.81 | 0.40 |
-| complex_elementwise_1000 | 7.75 | 12.91 | 12.27 |
-| permute_32_4d | 0.90 | 1.23 | 2.03 |
-| multiple_permute_sum_32_4d | 2.26 | 3.11 | 2.21 |
-
-Notes:
-- Julia results from `strided-kernel/benches/julia_compare.jl` (mean time). Rust results from `strided-kernel/benches/rust_compare.rs` (mean time).
-- All benchmarks use column-major layout for parity with Julia.
-- The Rust naive baseline uses raw pointer arithmetic with `unsafe` and precomputed strides (no bounds checks, no library overhead).
-- `scale_transpose` and `multiple_permute_sum`: the naive baseline is faster because the ordering/blocking pipeline overhead is not recovered on these relatively small, simple access patterns. Julia Strided shows the same trend.
-
-### Multi-Threaded Scaling (Rust, `parallel` feature)
-
-Environment: Apple Silicon M2 (4 performance + 4 efficiency cores). Mean time.
-
-| Case | 1T (ms) | 2T (ms) | 4T (ms) | Speedup (4T) |
-|---|---:|---:|---:|---:|
-| symmetrize_4000 | 20.88 | 17.78 | 11.33 | 1.8x |
-| scale_transpose_1000 | 0.76 | 0.48 | 0.37 | 2.1x |
-| mwe_scale_transpose_1000 | 0.69 | 0.53 | 0.41 | 1.7x |
-| complex_elementwise_1000 | 12.85 | 6.61 | 3.52 | 3.7x |
-| permute_32_4d | 1.09 | 0.64 | 0.48 | 2.3x |
-| multiple_permute_sum_32_4d | 3.03 | 1.86 | 1.36 | 2.2x |
-| sum_1m | 0.89 | 0.49 | 0.39 | 2.3x |
+Published benchmark programs and current measured results live in
+[`strided-rs-benchmark-suite`](https://github.com/tensor4all/strided-rs-benchmark-suite).
 
 ### Algorithm Comparison: Julia Strided.jl vs Rust strided-rs
 
@@ -242,105 +212,3 @@ The key architectural differences are:
 > fusion pass then catches contiguity regardless of memory layout. See
 > [docs/strided\_jl\_threading\_bug.md](../docs/strided_jl_threading_bug.md) for a
 > minimal reproduction and root cause analysis.
-
-### Scaling Benchmarks (Strided.jl benchtests.jl suite)
-
-These benchmarks measure performance across exponentially-scaled array sizes, showing the
-crossover point where the ordering/blocking pipeline overhead pays off.
-
-Run with: `bash strided-kernel/benches/run_scaling.sh` (default: 1 2 4 threads)
-
-Environment: Apple Silicon M2 (4P + 4E cores). Median timing, adaptive iteration count.
-
-#### 1D Sum
-
-| size | Rust naive (μs) | Rust strided 1T | 2T | 4T | Julia base (μs) | Julia Strided 1T | 2T | 4T |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 4 | 0.04 | 0.04 | 0.00 | 0.00 | 0.00 | 0.04 | 0.04 | 0.04 |
-| 12 | 0.04 | 0.04 | 0.00 | 0.00 | 0.00 | 0.04 | 0.04 | 0.04 |
-| 32 | 0.04 | 0.04 | 0.00 | 0.04 | 0.00 | 0.04 | 0.04 | 0.04 |
-| 91 | 0.08 | 0.04 | 0.04 | 0.04 | 0.00 | 0.08 | 0.08 | 0.08 |
-| 256 | 0.25 | 0.08 | 0.04 | 0.04 | 0.04 | 0.17 | 0.17 | 0.17 |
-| 725 | 0.92 | 0.17 | 0.08 | 0.08 | 0.08 | 0.33 | 0.33 | 0.38 |
-| 2048 | 2.25 | 0.29 | 0.25 | 0.25 | 0.21 | 0.92 | 0.96 | 0.96 |
-| 5793 | 5.29 | 0.63 | 0.67 | 0.67 | 0.50 | 2.58 | 2.54 | 2.63 |
-| 16384 | 13.96 | 1.83 | 1.83 | 1.83 | 1.54 | 7.08 | 7.25 | 7.29 |
-| 46341 | 39.58 | 40.67 | 35.67 | 37.75 | 4.42 | 19.96 | 26.67 | 16.67 |
-| 131072 | 112.13 | 113.04 | 75.29 | 76.63 | 12.58 | 57.75 | 46.67 | 24.21 |
-| 370728 | 317.33 | 318.29 | 185.50 | 188.13 | 35.25 | 163.13 | 101.73 | 61.54 |
-| 1048576 | 939.67 | 935.33 | 497.04 | 430.04 | 103.25 | 461.63 | 258.71 | 162.83 |
-
-Notes:
-- For 1D contiguous sum, Rust strided can beat the naive loop at small/medium sizes due to an explicit SIMD reduction kernel.
-- With the Rust `parallel` feature enabled, sizes above the threading threshold route through the threaded kernel path (even at 1T), so 1T can be slightly slower than the naive loop until multi-threading is enabled.
-- Julia's `Base.sum` uses hand-tuned SIMD reduction; Julia's `@strided sum` includes kernel-dispatch overhead compared to `Base.sum`.
-
-#### 4D Permute: (4,3,2,1) — full reversal
-
-| s | s⁴ | Rust naive (μs) | Rust strided 1T | 2T | 4T | Julia copy (μs) | Julia Strided 1T | 2T | 4T |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 4 | 256 | 0.21 | 1.29 | 1.29 | 1.33 | 0.04 | 0.29 | 0.29 | 0.29 |
-| 8 | 4096 | 2.04 | 3.92 | 3.92 | 3.92 | 0.46 | 2.00 | 1.79 | 1.83 |
-| 12 | 20736 | 14.33 | 14.04 | 14.00 | 14.00 | 2.38 | 8.71 | 8.75 | 8.54 |
-| 16 | 65536 | 54.71 | 50.46 | 48.88 | 48.83 | 7.92 | 31.92 | 34.63 | 40.21 |
-| 24 | 331776 | 275.50 | 190.79 | 139.29 | 131.54 | 40.29 | 127.13 | 84.02 | 84.75 |
-| 32 | 1048576 | 1119.75 | 1152.58 | 715.42 | 502.50 | 164.17 | 899.54 | 477.90 | 329.10 |
-| 48 | 5308416 | 16857.92 | 8614.17 | 5567.96 | 3687.67 | 1077.00 | 7558.15 | 4879.65 | 3206.54 |
-| 64 | 16777216 | 85412.17 | 50799.25 | 27581.00 | 23729.00 | 3593.38 | 47799.17 | 25965.08 | 15537.29 |
-
-#### 4D Permute: (2,3,4,1)
-
-| s | s⁴ | Rust naive (μs) | Rust strided 1T | 2T | 4T | Julia copy (μs) | Julia Strided 1T | 2T | 4T |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 4 | 256 | 0.21 | 1.17 | 1.17 | 1.21 | 0.04 | 0.25 | 0.25 | 0.29 |
-| 8 | 4096 | 2.04 | 3.79 | 3.83 | 3.96 | 0.46 | 1.63 | 1.63 | 1.63 |
-| 12 | 20736 | 17.33 | 13.83 | 13.79 | 13.83 | 2.42 | 8.96 | 8.88 | 8.88 |
-| 16 | 65536 | 46.13 | 38.04 | 39.04 | 39.42 | 7.75 | 25.79 | 29.33 | 30.50 |
-| 24 | 331776 | 231.71 | 171.88 | 114.33 | 120.88 | 42.38 | 129.17 | 85.29 | 77.71 |
-| 32 | 1048576 | 762.08 | 784.88 | 498.58 | 356.42 | 154.79 | 671.00 | 407.04 | 226.33 |
-| 48 | 5308416 | 16466.67 | 6234.46 | 4795.38 | 3023.21 | 1089.81 | 6168.71 | 4060.40 | 2800.46 |
-| 64 | 16777216 | 72763.71 | 21973.96 | 15040.88 | 9475.75 | 3552.79 | 18350.92 | 13969.13 | 8989.65 |
-
-#### 4D Permute: (3,4,1,2)
-
-| s | s⁴ | Rust naive (μs) | Rust strided 1T | 2T | 4T | Julia copy (μs) | Julia Strided 1T | 2T | 4T |
-|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| 4 | 256 | 0.21 | 1.21 | 1.17 | 1.17 | 0.04 | 0.29 | 0.29 | 0.29 |
-| 8 | 4096 | 2.08 | 3.88 | 3.88 | 3.88 | 0.46 | 1.50 | 1.46 | 1.46 |
-| 12 | 20736 | 10.04 | 13.79 | 13.79 | 13.79 | 2.42 | 7.42 | 7.50 | 7.46 |
-| 16 | 65536 | 47.75 | 39.00 | 41.96 | 34.92 | 7.67 | 26.58 | 30.75 | 46.00 |
-| 24 | 331776 | 231.58 | 198.50 | 138.83 | 129.25 | 39.71 | 116.58 | 78.67 | 91.96 |
-| 32 | 1048576 | 1118.71 | 888.75 | 569.04 | 413.58 | 161.50 | 1102.48 | 606.48 | 393.83 |
-| 48 | 5308416 | 8661.25 | 6699.79 | 4990.75 | 2955.79 | 1111.21 | 5649.42 | 4040.88 | 2726.33 |
-| 64 | 16777216 | 64188.00 | 28535.00 | 19057.08 | 12836.33 | 3574.73 | 24472.02 | 17239.00 | 11821.58 |
-
-#### Scaling observations
-
-- **Crossover point**: Strided's ordering/blocking overhead is recovered at ~20K elements (s≥12 for 4D permute). Below this, the naive loop is faster.
-- **Large arrays (s≥48)**: Rust strided achieves 0.3-0.6x of naive single-threaded, and further improves with threading.
-- **Rust vs Julia strided (1T, s=64)**:
-  - (4,3,2,1): Rust 50.8ms vs Julia 47.8ms — Rust 1.1x slower
-  - (2,3,4,1): Rust 22.0ms vs Julia 18.4ms — Rust 1.2x slower
-  - (3,4,1,2): Rust 28.5ms vs Julia 24.5ms — Rust 1.2x slower
-- **Multi-threaded (4T, s=64)**: Both achieve ~2-4x speedup over single-threaded strided. Rust and Julia reach comparable absolute performance at large sizes.
-- **Julia copy vs Rust naive**: Julia's `copy!` is ~10-25x faster than Rust's raw pointer loop for large s because Julia uses optimized `memcpy`; Rust's naive loop does element-by-element copy for parity with the permute benchmark.
-
-#### Per-case analysis
-
-**symmetrize\_4000** (Julia 17.7 ms, Rust 20.6 ms) —
-Both use the general mapreduce kernel: dimension fusion → importance ordering → L1 cache blocking. Julia applies `@simd` on the innermost loop. Rust uses stride-specialized inner loops (slice-based when stride=1). Rust is ~1.2x slower.
-
-**scale\_transpose\_1000** (Julia 0.53 ms, Rust 0.79 ms) —
-Both follow the same importance-weighted ordering for a 2-array (dest + transposed src) operation. The naive baseline (0.42 ms) is faster because it writes contiguously without blocking overhead; the strided version pays for the ordering/blocking pipeline on a small array.
-
-**mwe\_stridedview\_scale\_transpose\_1000** (Julia 0.51 ms, Rust 0.81 ms) —
-Same operation as scale\_transpose\_1000 using `map_into` with a transposed view.
-
-**complex\_elementwise\_1000** (Julia 7.8 ms, Rust 12.9 ms) —
-Both arrays are contiguous, so the operation is compute-bound. The gap comes from Julia's `@simd` enabling aggressive auto-vectorization of transcendental functions (`exp`, `sin`), while Rust's LLVM generates more conservative code for the same operations.
-
-**permute\_32\_4d** (Julia 0.90 ms, Rust 1.23 ms) —
-Both nest loops with the highest-importance dimension innermost. The stride=1 specialization allows LLVM to vectorize the contiguous inner dimension effectively, but Rust is still ~1.4x slower here.
-
-**multiple\_permute\_sum\_32\_4d** (Julia 2.3 ms, Rust 3.1 ms) —
-Both compute a combined importance score over all 5 arrays (output + 4 inputs) and iterate in the optimal compromise order, but Rust is still ~1.4x slower.

--- a/strided-kernel/THIRD-PARTY-LICENSES
+++ b/strided-kernel/THIRD-PARTY-LICENSES
@@ -1,0 +1,22 @@
+The Strided.jl package is licensed under the MIT "Expat" License:
+
+> Copyright (c) 2017: Jutho Haegeman.
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+>

--- a/strided-opteinsum/Cargo.toml
+++ b/strided-opteinsum/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 repository.workspace = true
 description = "N-ary einsum frontend with contraction-order optimization for strided tensors."
 readme = "README.md"
+keywords = ["tensor", "einsum", "contraction", "optimization"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 strided-view.workspace = true

--- a/strided-opteinsum/LICENSE-APACHE
+++ b/strided-opteinsum/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-opteinsum/LICENSE-MIT
+++ b/strided-opteinsum/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-opteinsum/NOTICE
+++ b/strided-opteinsum/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-opteinsum/NOTICE
+++ b/strided-opteinsum/NOTICE
@@ -1,15 +1,9 @@
-strided-rs
+strided-opteinsum
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate is inspired by design ideas and reference test-case patterns from
+OMEinsum.jl:
+https://github.com/under-Peter/OMEinsum.jl
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+The implementation is original to strided-rs; no OMEinsum.jl code is ported.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.

--- a/strided-opteinsum/README.md
+++ b/strided-opteinsum/README.md
@@ -37,63 +37,10 @@ Run Julia OMEinsum references (single-threaded):
 OMP_NUM_THREADS=1 JULIA_NUM_THREADS=1 julia --project=strided-einsum2/benches strided-einsum2/benches/julia_matmul.jl
 ```
 
-Benchmark results were re-measured on February 8, 2026.
-Environment: Apple Silicon M2, single-threaded. Mean time (ms).
-
-| Case | Julia OMEinsum (ms) | Rust strided-opteinsum (ms) |
-|---|---:|---:|
-| matmul (1) square 1000×1000 Float64 | 41.433 | 42.311 |
-| matmul (1) square 1000×1000 ComplexF64 | 204.183 | 238.002 |
-| matmul (2) (2000,50)×(50,2000) Float64 | 11.446 | 9.059 |
-| matmul (2) (2000,50)×(50,2000) ComplexF64 | 44.618 | 44.121 |
-| matmul (3) (50,2000)×(2000,50) Float64 | 0.267 | 0.312 |
-| matmul (3) (50,2000)×(2000,50) ComplexF64 | 1.418 | 1.325 |
-| batchmul (1) square b=3 1000³ Float64 | 127.743 | 132.710 |
-| batchmul (1) square b=3 1000³ ComplexF64 | 603.465 | 717.366 |
-| batchmul (2) b=3 (2000,50)×(50,2000) Float64 | 30.294 | 28.087 |
-| batchmul (2) b=3 (2000,50)×(50,2000) ComplexF64 | 129.160 | 138.139 |
-| batchmul (3) b=3 (50,2000)×(2000,50) Float64 | 0.780 | 0.929 |
-| batchmul (3) b=3 (50,2000)×(2000,50) ComplexF64 | 3.280 | 4.173 |
-| dot (1) square 100³ Float64 | 5.382 | 0.295 |
-| dot (1) square 100³ ComplexF64 | 4.805 | 0.639 |
-| dot (2) (2000,50,2000) Float64 | 1073.075 | 60.099 |
-| dot (2) (2000,50,2000) ComplexF64 | 961.889 | 134.398 |
-| dot (3) (50,2000,50) Float64 | 26.836 | 1.418 |
-| dot (3) (50,2000,50) ComplexF64 | 24.051 | 3.688 |
-| trace 1000×1000 Float64 | 0.003 | 0.002 |
-| trace 1000×1000 ComplexF64 | 0.004 | 0.004 |
-| ptrace (100,100,100)→(100) Float64 | 0.019 | 0.009 |
-| ptrace (100,100,100)→(100) ComplexF64 | 0.029 | 0.009 |
-| diag (100,100,100)→(100,100) Float64 | 0.015 | 0.009 |
-| diag (100,100,100)→(100,100) ComplexF64 | 0.021 | 0.011 |
-| perm (30,30,30,30) Float64 | 0.576 | 0.004 |
-| perm (30,30,30,30) ComplexF64 | 0.758 | 0.003 |
-| tcontract (1) square 30³ Float64 | 0.072 | 0.065 |
-| tcontract (1) square 30³ ComplexF64 | 0.220 | 0.236 |
-| tcontract (2) (2000,50,50)×(50,2000,50) Float64 | 399.641 | 455.236 |
-| tcontract (2) (2000,50,50)×(50,2000,50) ComplexF64 | 1987.545 | 2515.189 |
-| tcontract (3) (50,2000,2000)×(2000,50,2000) Float64 | 690.430 | 723.605 |
-| tcontract (3) (50,2000,2000)×(2000,50,2000) ComplexF64 | 5005.792 | 3047.210 |
-| star (50,50) Float64 | 2.552 | 0.513 |
-| star (50,50) ComplexF64 | 6.400 | 1.644 |
-| starandcontract (50,50) Float64 | 0.112 | 0.030 |
-| starandcontract (50,50) ComplexF64 | 0.127 | 0.028 |
-| indexsum (100,100,100)→(100,100) Float64 | 0.162 | 0.183 |
-| indexsum (100,100,100)→(100,100) ComplexF64 | 1.265 | 0.325 |
-| hadamard (100,100,100) Float64 | 0.195 | 0.399 |
-| hadamard (100,100,100) ComplexF64 | 0.695 | 0.819 |
-| outer (1) square 40⁴ Float64 | 1.470 | 0.430 |
-| outer (1) square 40⁴ ComplexF64 | 2.262 | 1.276 |
-| outer (2) (80,20)×(20,80) Float64 | 1.224 | 0.427 |
-| outer (2) (80,20)×(20,80) ComplexF64 | 2.260 | 1.033 |
-| outer (3) (20,80)×(80,20) Float64 | 1.164 | 0.429 |
-| outer (3) (20,80)×(80,20) ComplexF64 | 2.262 | 0.992 |
-| manyinds (12+12→13 indices, dim 2) Float64 | 0.065 | 0.086 |
-| manyinds (12+12→13 indices, dim 2) ComplexF64 | 0.128 | 0.162 |
+Published benchmark programs and current measured results live in
+[`strided-rs-benchmark-suite`](https://github.com/tensor4all/strided-rs-benchmark-suite).
 
 ## Notes
 
 - Current parser accepts ASCII lowercase index labels.
 - Generative output notation such as `->ii` is tracked in GitHub issues.
-
-See also [benchmark suite](https://github.com/tensor4all/strided-rs-benchmark-suite) for strided-rs based on the einsum benchmark

--- a/strided-perm/Cargo.toml
+++ b/strided-perm/Cargo.toml
@@ -6,6 +6,8 @@ license = "(MIT OR Apache-2.0) AND BSD-3-Clause"
 authors.workspace = true
 repository.workspace = true
 description = "Cache-efficient tensor permutation / transpose (HPTT-inspired)."
+keywords = ["tensor", "permutation", "transpose", "multidimensional"]
+categories = ["science", "mathematics", "algorithms"]
 
 [dependencies]
 strided-view.workspace = true

--- a/strided-perm/LICENSE-APACHE
+++ b/strided-perm/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-perm/LICENSE-MIT
+++ b/strided-perm/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-perm/NOTICE
+++ b/strided-perm/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-perm/NOTICE
+++ b/strided-perm/NOTICE
@@ -1,15 +1,11 @@
-strided-rs
+strided-perm
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate derives its tensor permutation algorithm and implementation
+structure from HPTT by Paul Springer, Tong Su, and Paolo Bientinesi:
+https://github.com/springer13/hptt
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+HPTT's SIMD kernels and autotuning are not ported. The complete applicable
+BSD-3-Clause license text and citation are in `THIRD-PARTY-LICENSES`.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed as `(MIT OR Apache-2.0) AND BSD-3-Clause`; see
+`LICENSE-APACHE`, `LICENSE-MIT`, and `THIRD-PARTY-LICENSES`.

--- a/strided-perm/README.md
+++ b/strided-perm/README.md
@@ -30,7 +30,7 @@ Enable the `parallel` feature to use Rayon-backed copy entry points:
 
 ```toml
 [dependencies]
-strided-perm = { version = "0.1", features = ["parallel"] }
+strided-perm = { version = "0.4", features = ["parallel"] }
 ```
 
 ```rust
@@ -51,7 +51,7 @@ The transpose engine in `src/hptt/` reimplements the algorithm of
 Paolo Bientinesi, following the structure of the original C++ implementation
 (P. Springer, T. Su, P. Bientinesi, "HPTT: A High-Performance Tensor
 Transposition C++ Library", ARRAY 2017). HPTT is licensed under BSD-3-Clause
-(Copyright 2018 Paul Springer); see `THIRD-PARTY-LICENSES` at the workspace
-root for the full text.
+(Copyright 2018 Paul Springer); see the packaged `THIRD-PARTY-LICENSES` file
+for the full text.
 
 This crate is therefore licensed as `(MIT OR Apache-2.0) AND BSD-3-Clause`.

--- a/strided-perm/THIRD-PARTY-LICENSES
+++ b/strided-perm/THIRD-PARTY-LICENSES
@@ -1,0 +1,50 @@
+This file lists third-party works whose algorithms or code influenced this
+project. Each entry includes the original license text.
+
+================================================================================
+HPTT — High-Performance Tensor Transpose
+https://github.com/springer13/hptt
+================================================================================
+
+The strided-perm/src/hptt/ module reimplements in Rust the algorithm of the
+HPTT library by Paul Springer, Tong Su, and Paolo Bientinesi, following the
+structure of the original C++ implementation (see the file-level comments in
+strided-perm/src/hptt/ for the correspondence). The strided-perm crate is
+therefore licensed as "(MIT OR Apache-2.0) AND BSD-3-Clause"; the BSD-3-Clause
+license of HPTT is reproduced below.
+
+Reference:
+  Paul Springer, Tong Su, and Paolo Bientinesi.
+  "HPTT: A High-Performance Tensor Transpose C++ Library."
+  In Proceedings of the 4th ACM SIGPLAN International Workshop on
+  Libraries, Languages, and Compilers for Array Programming (ARRAY), 2017.
+
+License (BSD-3-Clause):
+
+  Copyright 2018 Paul Springer
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.

--- a/strided-rs/Cargo.toml
+++ b/strided-rs/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 repository.workspace = true
 description = "User-facing facade crate for the strided-rs workspace."
 readme = "README.md"
+keywords = ["tensor", "strided", "array", "einsum", "numerical"]
+categories = ["science", "mathematics", "data-structures"]
 
 [dependencies]
 strided-traits.workspace = true

--- a/strided-rs/LICENSE-APACHE
+++ b/strided-rs/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-rs/LICENSE-MIT
+++ b/strided-rs/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-rs/NOTICE
+++ b/strided-rs/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-rs/NOTICE
+++ b/strided-rs/NOTICE
@@ -1,15 +1,7 @@
 strided-rs
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This user-facing facade crate and its re-export structure are original to
+strided-rs. Component crates carry their own package-specific provenance and
+applicable third-party license notices.
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
-
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.

--- a/strided-rs/README.md
+++ b/strided-rs/README.md
@@ -8,7 +8,7 @@ users can depend on one package.
 
 ```toml
 [dependencies]
-strided-rs = "0.1"
+strided-rs = "0.4"
 ```
 
 Use individual crates such as `strided-perm`, `strided-view`, or
@@ -51,14 +51,14 @@ features are disabled, enable one backend feature when using einsum APIs or the
 
 ```toml
 [dependencies]
-strided-rs = { version = "0.1", default-features = false, features = ["blas"] }
+strided-rs = { version = "0.4", default-features = false, features = ["blas"] }
 ```
 
 Use a provider feature when the BLAS provider should be fixed explicitly:
 
 ```toml
 [dependencies]
-strided-rs = { version = "0.1", default-features = false, features = ["blas-openblas"] }
+strided-rs = { version = "0.4", default-features = false, features = ["blas-openblas"] }
 ```
 
 ## Namespaced APIs

--- a/strided-traits/Cargo.toml
+++ b/strided-traits/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Shared traits for strided-rs: element operations, scalar bounds, and type-level composition."
+keywords = ["tensor", "strided", "numerical", "traits"]
+categories = ["science", "mathematics"]
 
 [dependencies]
 num-traits.workspace = true

--- a/strided-traits/LICENSE-APACHE
+++ b/strided-traits/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-traits/LICENSE-MIT
+++ b/strided-traits/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-traits/NOTICE
+++ b/strided-traits/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-traits/NOTICE
+++ b/strided-traits/NOTICE
@@ -1,15 +1,12 @@
-strided-rs
+strided-traits
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate ports the type-level `FN`/`FC`/`FT`/`FA` operation counterparts
+from Julia's Strided.jl:
+https://github.com/Jutho/Strided.jl
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+Strided.jl is licensed under the MIT License. Its complete upstream license
+notice is reproduced in `THIRD-PARTY-LICENSES`.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing portions ported from Strided.jl, you must also comply with
+the upstream MIT license notice requirements.

--- a/strided-traits/THIRD-PARTY-LICENSES
+++ b/strided-traits/THIRD-PARTY-LICENSES
@@ -1,0 +1,22 @@
+The Strided.jl package is licensed under the MIT "Expat" License:
+
+> Copyright (c) 2017: Jutho Haegeman.
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+>

--- a/strided-view/Cargo.toml
+++ b/strided-view/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Device-agnostic strided view types and metadata operations (ported from Julia StridedViews.jl)."
+keywords = ["tensor", "strided", "array", "multidimensional"]
+categories = ["science", "mathematics", "data-structures"]
 
 [dependencies]
 strided-traits.workspace = true

--- a/strided-view/LICENSE-APACHE
+++ b/strided-view/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strided-view/LICENSE-MIT
+++ b/strided-view/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Satoshi Terasaki, Hiroshi Shinaoka and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/strided-view/NOTICE
+++ b/strided-view/NOTICE
@@ -1,0 +1,15 @@
+strided-rs
+
+This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+
+Upstream projects:
+- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
+- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+
+Upstream copyright notices:
+- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
+- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
+
+This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing this work, you must also comply with the upstream MIT license
+notice requirements for the portions derived from the upstream projects.

--- a/strided-view/NOTICE
+++ b/strided-view/NOTICE
@@ -1,15 +1,12 @@
-strided-rs
+strided-view
 
-This repository is a Rust port of Julia's Strided.jl and StridedViews.jl.
+This crate ports dynamic-rank strided views and metadata operations from
+Julia's StridedViews.jl:
+https://github.com/Jutho/StridedViews.jl
 
-Upstream projects:
-- Strided.jl: https://github.com/Jutho/Strided.jl (MIT License)
-- StridedViews.jl: https://github.com/Jutho/StridedViews.jl (MIT License)
+StridedViews.jl is licensed under the MIT License. Its complete upstream
+license notice is reproduced in `THIRD-PARTY-LICENSES`.
 
-Upstream copyright notices:
-- Strided.jl: Copyright (c) 2017 Jutho Haegeman.
-- StridedViews.jl: Copyright (c) 2023 Jutho Haegeman and contributors.
-
-This repository is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
-When redistributing this work, you must also comply with the upstream MIT license
-notice requirements for the portions derived from the upstream projects.
+This crate is licensed under the terms in `LICENSE-APACHE` and `LICENSE-MIT`.
+When redistributing portions ported from StridedViews.jl, you must also comply
+with the upstream MIT license notice requirements.

--- a/strided-view/THIRD-PARTY-LICENSES
+++ b/strided-view/THIRD-PARTY-LICENSES
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Jutho Haegeman <jutho.haegeman@ugent.be> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- prepare all nine strided-rs workspace crates for 0.4.0
- retain `strided-einsum2`, `strided-opteinsum`, and both adapters as maintained CPU einsum components
- add targeted crates.io keywords/categories and accurate per-package license/provenance files
- update release docs for tagged, dependency-ordered, resumable crates.io publication

This supersedes the retirement direction in #199 for the four einsum crates.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace` (898 passed, 9 ignored)
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- feature matrix for facade, parallel kernel, and permutation paths
- `cargo llvm-cov --workspace --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (54/54 files)
- `python3 scripts/test-repository-rules-review.py` (79 passed)
- deterministic and DeepSeek repository-rules reviews (zero findings)
- all nine package lists and metadata inspected
- `cargo publish -p strided-traits --dry-run`
- crates.io ownership and 0.4.0 absence verified for all nine crates

Strict Rust 1.97 clippy with `-D warnings` reports pre-existing findings identically on `origin/main`; this PR changes no Rust source. Full workspace clippy was also run with `--cap-lints warn` to inventory the baseline without expanding release scope.

## Release sequencing

After merge and exact-SHA CI success, tag `v0.4.0`; package, inspect, dry-run, publish, and wait for registry visibility one crate at a time in dependency order. No manifest changes occur after tagging.
